### PR TITLE
fix typos in flutter_bloc docs and add FlutterError when BlocProvider not found

### DIFF
--- a/packages/flutter_bloc/lib/src/bloc_builder.dart
+++ b/packages/flutter_bloc/lib/src/bloc_builder.dart
@@ -6,12 +6,12 @@ import 'package:bloc/bloc.dart';
 
 /// A function that will be run which takes the [BuildContext] and state
 /// and is responsible for returning a [Widget] which is to be rendered.
-/// This is analagous to the `builder` function in [StreamBuilder].
+/// This is analogous to the `builder` function in [StreamBuilder].
 typedef Widget BlocWidgetBuilder<S>(BuildContext context, S state);
 
 /// A Flutter widget which requires a [Bloc] and a [BlocWidgetBuilder] `builder` function.
 /// [BlocBuilder] handles building the widget in response to new states.
-/// BlocBuilder analagous to [StreamBuilder] but has simplified API
+/// BlocBuilder analogous to [StreamBuilder] but has simplified API
 /// to reduce the amount of boilerplate code needed
 /// as well as bloc-specific performance improvements.
 class BlocBuilder<E, S> extends BlocBuilderBase<E, S> {

--- a/packages/flutter_bloc/lib/src/bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/bloc_provider.dart
@@ -28,6 +28,15 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>> extends StatelessWidget {
   static T of<T extends Bloc<dynamic, dynamic>>(BuildContext context) {
     BlocProvider<T> provider =
         context.ancestorWidgetOfExactType(_typeOf<BlocProvider<T>>());
+    if (provider == null) {
+      throw FlutterError(
+          'BlocProvider.of() called with a context that does not contain a Bloc of type $T.\n'
+          'No ancestor could be found starting from the context that was passed '
+          'to BlocProvider.of<$T>(). This can happen '
+          'if the context you use comes from a widget above the BlocProvider.\n'
+          'The context used was:\n'
+          '  $context');
+    }
     return provider.bloc;
   }
 


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Typos in BlocBuilder fixed (analagous -> analogous)
- `FlutterError` added when a BlocProvider does not exist above current context

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
None