### PR TITLE
update BlocBuilder to always use latest state

### DIFF
--- a/packages/flutter_bloc/lib/src/bloc_builder.dart
+++ b/packages/flutter_bloc/lib/src/bloc_builder.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/widgets.dart';
 
+import 'package:rxdart/rxdart.dart';
 import 'package:bloc/bloc.dart';
 
 /// A function that will be run which takes the [BuildContext] and state
@@ -50,10 +51,12 @@ class _BlocBuilderBaseState<E, S> extends State<BlocBuilderBase<E, S>> {
   StreamSubscription<S> _subscription;
   S _state;
 
+  S get currentState => (widget.bloc.state as BehaviorSubject<S>).value;
+
   @override
   void initState() {
     super.initState();
-    _state = widget.bloc.initialState;
+    _state = currentState;
     _subscribe();
   }
 
@@ -63,7 +66,7 @@ class _BlocBuilderBaseState<E, S> extends State<BlocBuilderBase<E, S>> {
     if (oldWidget.bloc.state != widget.bloc.state) {
       if (_subscription != null) {
         _unsubscribe();
-        _state = widget.bloc.initialState;
+        _state = currentState;
       }
       _subscribe();
     }

--- a/packages/flutter_bloc/test/bloc_builder_test.dart
+++ b/packages/flutter_bloc/test/bloc_builder_test.dart
@@ -307,5 +307,30 @@ void main() {
       expect(_materialApp.theme, ThemeData.light());
       expect(numBuilds, 3);
     });
+
+    testWidgets('shows latest state instead of initial state',
+        (WidgetTester tester) async {
+      final ThemeBloc _themeBloc = ThemeBloc();
+      _themeBloc.dispatch(SetDarkTheme());
+      await tester.pumpAndSettle();
+
+      int numBuilds = 0;
+      await tester.pumpWidget(
+        MyApp(
+          themeBloc: _themeBloc,
+          onBuild: () {
+            numBuilds++;
+          },
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      MaterialApp _materialApp =
+          find.byKey(Key('material_app')).evaluate().first.widget;
+
+      expect(_materialApp.theme, ThemeData.dark());
+      expect(numBuilds, 1);
+    });
   });
 }


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
Fix for #29 
Update `BlocBuilder` to always use latest state rather than initial state on initialization.

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
None