### PR TITLE
BlocProvider use ancestorInheritedElementForWidgetOfExactType

### DIFF
--- a/packages/flutter_bloc/lib/src/bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/bloc_provider.dart
@@ -5,7 +5,7 @@ import 'package:bloc/bloc.dart';
 /// A Flutter widget which provides a bloc to its children via `BlocProvider.of(context)`.
 /// It is used as a DI widget so that a single instance of a bloc can be provided
 /// to multiple widgets within a subtree.
-class BlocProvider<T extends Bloc<dynamic, dynamic>> extends StatelessWidget {
+class BlocProvider<T extends Bloc<dynamic, dynamic>> extends StatefulWidget {
   /// The Bloc which is to be made available throughout the subtree
   final T bloc;
 
@@ -21,13 +21,15 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>> extends StatelessWidget {
         super(key: key);
 
   @override
-  Widget build(BuildContext context) => child;
+  _BlocProviderState<T> createState() => _BlocProviderState<T>();
 
   /// Method that allows widgets to access the bloc as long as their `BuildContext`
   /// contains a `BlocProvider` instance.
   static T of<T extends Bloc<dynamic, dynamic>>(BuildContext context) {
-    BlocProvider<T> provider =
-        context.ancestorWidgetOfExactType(_typeOf<BlocProvider<T>>());
+    final type = _typeOf<_BlocProviderInherited<T>>();
+    final _BlocProviderInherited<T> provider =
+        context.ancestorInheritedElementForWidgetOfExactType(type)?.widget;
+
     if (provider == null) {
       throw FlutterError(
           'BlocProvider.of() called with a context that does not contain a Bloc of type $T.\n'
@@ -37,8 +39,33 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>> extends StatelessWidget {
           'The context used was:\n'
           '  $context');
     }
-    return provider.bloc;
+    return provider?.bloc;
   }
 
   static Type _typeOf<T>() => T;
+}
+
+class _BlocProviderState<T extends Bloc<dynamic, dynamic>>
+    extends State<BlocProvider<T>> {
+  @override
+  Widget build(BuildContext context) {
+    return _BlocProviderInherited<T>(
+      bloc: widget.bloc,
+      child: widget.child,
+    );
+  }
+}
+
+class _BlocProviderInherited<T extends Bloc<dynamic, dynamic>>
+    extends InheritedWidget {
+  _BlocProviderInherited({
+    Key key,
+    @required Widget child,
+    @required this.bloc,
+  }) : super(key: key, child: child);
+
+  final T bloc;
+
+  @override
+  bool updateShouldNotify(_BlocProviderInherited oldWidget) => false;
 }


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
update `BlocProvider` to use `ancestorInheritedElementForWidgetOfExactType` instead of `ancestorWidgetOfExactType`

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
None