### PR TITLE
Replaced legacy typedef syntax: BlocWidgetBuilder

### DIFF
--- a/packages/flutter_bloc/lib/src/bloc_builder.dart
+++ b/packages/flutter_bloc/lib/src/bloc_builder.dart
@@ -7,7 +7,7 @@ import 'package:bloc/bloc.dart';
 /// A function that will be run which takes the [BuildContext] and state
 /// and is responsible for returning a [Widget] which is to be rendered.
 /// This is analogous to the `builder` function in [StreamBuilder].
-typedef Widget BlocWidgetBuilder<S>(BuildContext context, S state);
+typedef BlocWidgetBuilder<S> = Widget Function(BuildContext context, S state);
 
 /// A Flutter widget which requires a [Bloc] and a [BlocWidgetBuilder] `builder` function.
 /// [BlocBuilder] handles building the widget in response to new states.


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
According to https://www.dartlang.org/guides/language/effective-dart/design#dont-use-the-legacy-typedef-syntax we should not use the legacy typedef syntax

## Related PRs
None

## Todos
None

## Steps to Test or Reproduce
None
## Impact to Remaining Code Base
This PR will affect:

* none, as the new syntax typedef syntax is a superset of the old one.