### PR TITLE
Bloc Ignore Duplicate States

### DIFF
--- a/examples/flutter_infinite_list/pubspec.yaml
+++ b/examples/flutter_infinite_list/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter_bloc:
     path: ../../packages/flutter_bloc
   http: 0.12.0
-  equatable: 0.1.1
+  equatable: 0.1.5
 
 dev_dependencies:
   flutter_test:

--- a/examples/flutter_login/pubspec.yaml
+++ b/examples/flutter_login/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     path: ../../packages/flutter_bloc
   user_repository:
     path: user_repository
-  equatable: 0.1.1
+  equatable: 0.1.5
 
 dev_dependencies:
   flutter_test:

--- a/packages/bloc/CHANGELOG.md
+++ b/packages/bloc/CHANGELOG.md
@@ -131,3 +131,7 @@ Additional Minor Updates to Documentation
 # 0.7.8
 
 Additional Minor Updates to Documentation
+
+# 0.8.0
+
+Blocs ignore duplicate states

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -11,7 +11,7 @@ abstract class Bloc<Event, State> {
   BehaviorSubject<State> _stateSubject;
 
   /// Returns [Stream] of [State]s.
-  /// Consumed by [BlocBuilder].
+  /// Consumed by the presentation layer.
   Stream<State> get state => _stateSubject.stream;
 
   /// Returns the [State] before any [Event]s have been `dispatched`.
@@ -63,6 +63,7 @@ abstract class Bloc<Event, State> {
       return mapEventToState(_stateSubject.value, event);
     }).forEach(
       (State nextState) {
+        if (currentState == nextState) return;
         final transition = Transition(
           currentState: _stateSubject.value,
           event: currentEvent,

--- a/packages/bloc/pubspec.yaml
+++ b/packages/bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc
 description: The goal of this package is to make it easy to implement the BLoC (Business Logic Component) design pattern.
-version: 0.7.8
+version: 0.8.0
 author: felix.angelov <felangelov@gmail.com>
 homepage: https://felangel.github.io/bloc
 

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -65,7 +65,7 @@ void main() {
       });
 
       test('should map multiple events to correct states', () {
-        final List<String> expected = ['', 'data', 'data', 'data'];
+        final List<String> expected = ['', 'data'];
 
         expectLater(simpleBloc.state, emitsInOrder(expected)).then((dynamic _) {
           verify(
@@ -73,24 +73,6 @@ void main() {
               Transition<dynamic, String>(
                 currentState: '',
                 event: 'event1',
-                nextState: 'data',
-              ),
-            ),
-          ).called(1);
-          verify(
-            delegate.onTransition(
-              Transition<dynamic, String>(
-                currentState: 'data',
-                event: 'event2',
-                nextState: 'data',
-              ),
-            ),
-          ).called(1);
-          verify(
-            delegate.onTransition(
-              Transition<dynamic, String>(
-                currentState: 'data',
-                event: 'event3',
                 nextState: 'data',
               ),
             ),
@@ -144,7 +126,7 @@ void main() {
       test('should map single event to correct state', () {
         final List<ComplexState> expected = [
           ComplexStateA(),
-          ComplexStateA(),
+          ComplexStateB(),
         ];
 
         expectLater(complexBloc.state, emitsInOrder(expected))
@@ -153,20 +135,19 @@ void main() {
             delegate.onTransition(
               Transition<ComplexEvent, ComplexState>(
                 currentState: ComplexStateA(),
-                event: ComplexEventA(),
-                nextState: ComplexStateA(),
+                event: ComplexEventB(),
+                nextState: ComplexStateB(),
               ),
             ),
           ).called(1);
-          expect(complexBloc.currentState, ComplexStateA());
+          expect(complexBloc.currentState, ComplexStateB());
         });
 
-        complexBloc.dispatch(ComplexEventA());
+        complexBloc.dispatch(ComplexEventB());
       });
 
       test('should map multiple events to correct states', () {
         final List<ComplexState> expected = [
-          ComplexStateA(),
           ComplexStateA(),
           ComplexStateB(),
           ComplexStateC(),
@@ -176,15 +157,6 @@ void main() {
           complexBloc.state,
           emitsInOrder(expected),
         ).then((dynamic _) {
-          verify(
-            delegate.onTransition(
-              Transition<ComplexEvent, ComplexState>(
-                currentState: ComplexStateA(),
-                event: ComplexEventA(),
-                nextState: ComplexStateA(),
-              ),
-            ),
-          ).called(1);
           verify(
             delegate.onTransition(
               Transition<ComplexEvent, ComplexState>(


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
YES

## Description
Blocs will ignore duplicate states. If a Bloc yields `State state` and `currentState == state`, then no transition will occur and no change will be made to the `Stream<State`.

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
None (No change to Bloc API)