### PR TITLE
BlocProvider performance enhancements (v0.5.1)

### DIFF
--- a/packages/flutter_bloc/CHANGELOG.md
+++ b/packages/flutter_bloc/CHANGELOG.md
@@ -93,3 +93,7 @@ Additional Minor Updates to Documentation
 # 0.5.0
 
 Updated to `bloc: ^0.8.0`
+
+# 0.5.1
+
+`BlocProvider` performance improvements

--- a/packages/flutter_bloc/lib/src/bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/bloc_provider.dart
@@ -5,11 +5,11 @@ import 'package:bloc/bloc.dart';
 /// A Flutter widget which provides a bloc to its children via `BlocProvider.of(context)`.
 /// It is used as a DI widget so that a single instance of a bloc can be provided
 /// to multiple widgets within a subtree.
-class BlocProvider<T extends Bloc<dynamic, dynamic>> extends StatefulWidget {
-  /// The Bloc which is to be made available throughout the subtree
+class BlocProvider<T extends Bloc<dynamic, dynamic>> extends InheritedWidget {
+  /// The [Bloc] which is to be made available throughout the subtree
   final T bloc;
 
-  /// The Widget and its descendants which will have access to the Bloc.
+  /// The [Widget] and its descendants which will have access to the [Bloc].
   final Widget child;
 
   BlocProvider({
@@ -20,14 +20,11 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>> extends StatefulWidget {
         assert(child != null),
         super(key: key);
 
-  @override
-  _BlocProviderState<T> createState() => _BlocProviderState<T>();
-
   /// Method that allows widgets to access the bloc as long as their `BuildContext`
   /// contains a `BlocProvider` instance.
   static T of<T extends Bloc<dynamic, dynamic>>(BuildContext context) {
-    final type = _typeOf<_BlocProviderInherited<T>>();
-    final _BlocProviderInherited<T> provider =
+    final type = _typeOf<BlocProvider<T>>();
+    final BlocProvider<T> provider =
         context.ancestorInheritedElementForWidgetOfExactType(type)?.widget;
 
     if (provider == null) {
@@ -42,30 +39,10 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>> extends StatefulWidget {
     return provider?.bloc;
   }
 
+  /// Necessary to obtain generic [Type]
+  /// https://github.com/dart-lang/sdk/issues/11923
   static Type _typeOf<T>() => T;
-}
-
-class _BlocProviderState<T extends Bloc<dynamic, dynamic>>
-    extends State<BlocProvider<T>> {
-  @override
-  Widget build(BuildContext context) {
-    return _BlocProviderInherited<T>(
-      bloc: widget.bloc,
-      child: widget.child,
-    );
-  }
-}
-
-class _BlocProviderInherited<T extends Bloc<dynamic, dynamic>>
-    extends InheritedWidget {
-  _BlocProviderInherited({
-    Key key,
-    @required Widget child,
-    @required this.bloc,
-  }) : super(key: key, child: child);
-
-  final T bloc;
 
   @override
-  bool updateShouldNotify(_BlocProviderInherited oldWidget) => false;
+  bool updateShouldNotify(BlocProvider oldWidget) => false;
 }

--- a/packages/flutter_bloc/pubspec.yaml
+++ b/packages/flutter_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_bloc
 description: Flutter Widgets that make it easy to implement the BLoC (Business Logic Component) design pattern. Built to be used with the bloc package.
-version: 0.5.0
+version: 0.5.1
 author: felix.angelov <felangelov@gmail.com>
 homepage: https://felangel.github.io/bloc
 

--- a/performance_tests/flutter_bloc/bloc_provider/README.md
+++ b/performance_tests/flutter_bloc/bloc_provider/README.md
@@ -16,12 +16,16 @@ flutter drive --target=test_driver/main.dart --driver=test_driver/driver/bloc_pr
 
 **I + I**: `InheritedWidget` + `inheritFromWidgetOfExactType`
 
-**SF + I**: `StatefulWidget` + `InheritedWidget` + `ancestorInheritedElementForWidgetOfExactType`
+**SF + AI**: `StatefulWidget` + `InheritedWidget` + `ancestorInheritedElementForWidgetOfExactType`
 
-|                  | I + A   | S + A  | I + I  | SF + I |
-|------------------|---------|--------|--------|--------|
-| Avg Frame (ms)   | 1.363   | 1.159  | 1.446  | 1.145  |
-| Worst Frame (ms) | 12.157  | 9.967  | 10.348 | 8.350  |
+**S + AI**: `StatelessWidget` + `InheritedWidget` + `ancestorInheritedElementForWidgetOfExactType`
+
+**I + AI**: `InheritedWidget` + `ancestorInheritedElementForWidgetOfExactType`
+
+|                  | I + A  | S + A | I + I  | SF + AI | S + AI | I + AI |
+| ---------------- | ------ | ----- | ------ | ------- | ------ | ------ |
+| Avg Frame (ms)   | 1.363  | 1.159 | 1.446  | 1.145   | 1.249  | 1.100  |
+| Worst Frame (ms) | 12.157 | 9.967 | 10.348 | 8.350   | 10.811 | 8.969  |
 
 **Average across 10 runs*
 


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Address #56
- `BlocProvider` performance enhancement to use `InheritedWidget` directly without `StatefulWidget` wrapper.

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
None