### PR TITLE
User can hook into bloc exceptions

### DIFF
--- a/packages/bloc/example/main.dart
+++ b/packages/bloc/example/main.dart
@@ -28,6 +28,11 @@ class SimpleBlocDelegate implements BlocDelegate {
   void onTransition(Transition transition) {
     print(transition);
   }
+
+  @override
+  void onError(Object error, StackTrace stacktrace) {
+    print(error);
+  }
 }
 
 void main() {

--- a/packages/bloc/lib/src/bloc_delegate.dart
+++ b/packages/bloc/lib/src/bloc_delegate.dart
@@ -8,4 +8,7 @@ abstract class BlocDelegate {
   /// `onTransition` is called before a [Bloc]'s state has been updated.
   /// A great spot to add universal logging/analytics.
   void onTransition(Transition transition);
+
+  // Called whenever there's an exception thrown
+  void onError(Object error, StackTrace stacktrace) => null;
 }

--- a/packages/bloc/test/bloc_delegate_test.dart
+++ b/packages/bloc/test/bloc_delegate_test.dart
@@ -1,6 +1,6 @@
-import 'package:test/test.dart';
 import 'package:bloc/bloc.dart';
 import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
 
 import './helpers/helpers.dart';
 
@@ -111,6 +111,24 @@ void main() {
       });
 
       complexBloc.dispatch(ComplexEventB());
+    });
+  });
+
+  group('onError', () {
+    test('listens to errors', () {
+      var errorHandled = false;
+
+      final delegate = MockBlocDelegate();
+      final CounterExceptionBloc _bloc = CounterExceptionBloc();
+      BlocSupervisor().delegate = delegate;
+      when(delegate.onError(any, any))
+          .thenAnswer((dynamic _) => errorHandled = true);
+
+      _bloc.dispatch(CounterEvent.increment);
+
+      expectLater(_bloc.state, emitsInOrder(<int>[0])).then((dynamic _) {
+        expect(errorHandled, isTrue);
+      });
     });
   });
 }

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -1,8 +1,9 @@
-import 'package:test/test.dart';
-import 'package:mockito/mockito.dart';
 import 'package:bloc/bloc.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
 
 import './helpers/helpers.dart';
+import 'helpers/counter/on_error_bloc.dart';
 
 class MockBlocDelegate extends Mock implements BlocDelegate {}
 
@@ -412,6 +413,25 @@ void main() {
 
         _bloc.dispatch(CounterEvent.increment);
         _bloc.dispatch(CounterEvent.decrement);
+      });
+
+      test('can be handled via onError', () {
+        final exception = Exception('fatal exception');
+        Object expectedError;
+        StackTrace expectedStacktrace;
+
+        final OnErrorBloc _bloc =
+            OnErrorBloc(exception, (Object error, StackTrace stacktrace) {
+          expectedError = error;
+          expectedStacktrace = stacktrace;
+        });
+
+        _bloc.dispatch(CounterEvent.increment);
+
+        expectLater(_bloc.state, emitsInOrder(<int>[0])).then((dynamic _) {
+          expect(expectedError, exception);
+          expect(expectedStacktrace, isNotNull);
+        });
       });
     });
   });

--- a/packages/bloc/test/helpers/counter/on_error_bloc.dart
+++ b/packages/bloc/test/helpers/counter/on_error_bloc.dart
@@ -1,0 +1,23 @@
+import 'package:bloc/bloc.dart';
+
+import '../counter/counter_bloc.dart';
+
+class OnErrorBloc extends Bloc<CounterEvent, int> {
+  OnErrorBloc(this.exception, this.testOnError);
+
+  final Function testOnError;
+  final Exception exception;
+
+  @override
+  int get initialState => 0;
+
+  @override
+  void onError(Object error, StackTrace stacktrace) {
+    testOnError(error, stacktrace);
+  }
+
+  @override
+  Stream<int> mapEventToState(int currentState, CounterEvent event) async* {
+    throw exception;
+  }
+}


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
YES, this requires BlocDelegate to register a `onError` handler. Should this be optional?

## Description
This allows a library user to hook into exceptions thrown during even processing.

## Related PRs
https://github.com/felangel/bloc/pull/97


## Todos
- [x] Tests
- [x] Documentation
- [x] Examples
