### PR TITLE
bloc v0.9.0 rc

### DIFF
--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/felangel/bloc/master/docs/assets/bloc_logo_full.png" height="60" alt="Bloc" /><small>0.8.4</small>
+<img src="https://raw.githubusercontent.com/felangel/bloc/master/docs/assets/bloc_logo_full.png" height="60" alt="Bloc" /><small>0.9.0</small>
 
 [![Build Status](https://travis-ci.org/felangel/bloc.svg?branch=master)](https://travis-ci.org/felangel/bloc)
 [![codecov](https://codecov.io/gh/felangel/Bloc/branch/master/graph/badge.svg)](https://codecov.io/gh/felangel/bloc)

--- a/docs/coreconcepts.md
+++ b/docs/coreconcepts.md
@@ -230,7 +230,7 @@ Just like we can handle `Transitions` at the bloc level, we can also handle `Exc
 
 > `onError` is a method that can be overriden to handle every local Bloc `Exception`. By default all exceptions will be ignored and `Bloc` functionality will be unaffected. 
  
-?> **Note**: The stack trace argument may be `null` if this state stream received an error without a stack trace.
+?> **Note**: The stacktrace argument may be `null` if the state stream received an error without a `StackTrace`.
 
 ?> **Tip**: `onError` is a great place to add bloc-specific error handling.
 

--- a/packages/bloc/CHANGELOG.md
+++ b/packages/bloc/CHANGELOG.md
@@ -151,3 +151,10 @@ Minor Internal Improvements and Documentation Updates
 # 0.8.4
 
 Blocs handle exceptions thrown in `mapEventToState` and documentation updates.
+
+# 0.9.0
+
+`Bloc` and `BlocDelegate` Error Handling
+
+- Added `onError` to `Bloc` for local error handling.
+- Added `onError` to `BlocDelegate` for global error handling.

--- a/packages/bloc/pubspec.yaml
+++ b/packages/bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc
 description: A predictable state management library that helps implement the BLoC (Business Logic Component) design pattern.
-version: 0.8.4
+version: 0.9.0
 author: felix.angelov <felangelov@gmail.com>
 homepage: https://felangel.github.io/bloc
 

--- a/packages/bloc/test/bloc_delegate_test.dart
+++ b/packages/bloc/test/bloc_delegate_test.dart
@@ -116,7 +116,7 @@ void main() {
 
   group('onError', () {
     test('is called on bloc exception', () {
-      var errorHandled = false;
+      bool errorHandled = false;
 
       final delegate = MockBlocDelegate();
       final CounterExceptionBloc _bloc = CounterExceptionBloc();


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- `onError` added to `Bloc`
- `onError` added to `BlocDelegate`

## Related PRs
#98 
#97 

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
None