### PR TITLE
restrict rxdart to < 0.21.0

### DIFF
--- a/packages/angular_bloc/pubspec.yaml
+++ b/packages/angular_bloc/pubspec.yaml
@@ -8,8 +8,7 @@ environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
 
 dependencies:
-  angular: ^5.0.0
-  rxdart: ">=0.18.1 <1.0.0"
+  angular: ^5.0.0  
   bloc: ^0.9.0
 
 dev_dependencies:

--- a/packages/bloc/CHANGELOG.md
+++ b/packages/bloc/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.3
+
+Restrict `rxdart` to `">=0.18.1 <0.21.0"` due to breaking changes.
+
 # 0.9.2
 
 Additional Minor Updates to Documentation

--- a/packages/bloc/pubspec.yaml
+++ b/packages/bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc
 description: A predictable state management library that helps implement the BLoC (Business Logic Component) design pattern.
-version: 0.9.2
+version: 0.9.3
 author: felix.angelov <felangelov@gmail.com>
 homepage: https://felangel.github.io/bloc
 

--- a/packages/bloc/pubspec.yaml
+++ b/packages/bloc/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   meta: ^1.1.6
-  rxdart: ">=0.18.1 <1.0.0"
+  rxdart: ">=0.18.1 <0.21.0"
 
 dev_dependencies:
   test: ">=1.3.0 <2.0.0"

--- a/packages/flutter_bloc/pubspec.yaml
+++ b/packages/flutter_bloc/pubspec.yaml
@@ -7,8 +7,7 @@ homepage: https://felangel.github.io/bloc
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
 
-dependencies:
-  rxdart: ">=0.18.1 <1.0.0"
+dependencies:  
   bloc: "^0.9.0"
   flutter:
     sdk: flutter

--- a/performance_tests/flutter_bloc/bloc_builder/pubspec.yaml
+++ b/performance_tests/flutter_bloc/bloc_builder/pubspec.yaml
@@ -5,8 +5,7 @@ version: 1.0.0+1
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
 
-dependencies:
-  rxdart: ">=0.18.1 <1.0.0"
+dependencies:  
   flutter_bloc:
     path: ../../../packages/flutter_bloc
   flutter:

--- a/performance_tests/flutter_bloc/bloc_provider/pubspec.yaml
+++ b/performance_tests/flutter_bloc/bloc_provider/pubspec.yaml
@@ -5,8 +5,7 @@ version: 1.0.0+1
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
 
-dependencies:
-  rxdart: ">=0.18.1 <1.0.0"
+dependencies:  
   flutter_bloc:
     path: ../../../packages/flutter_bloc
   flutter:


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
Restrict `rxdart` version to `<0.21.0` due to breaking changes. (#104)

## Todos
- [x] Tests
- [x] Documentation
- [x] Examples

## Impact to Remaining Code Base
None