### PR TITLE
bloc v0.9.4

### DIFF
--- a/packages/bloc/CHANGELOG.md
+++ b/packages/bloc/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.4
+
+Calls to `dispatch` after after `dispose` has been called trigger `onError` in the `Bloc` and `BlocDelegate`.
+
 # 0.9.3
 
 Restrict `rxdart` to `">=0.18.1 <0.21.0"` due to breaking changes.

--- a/packages/bloc/pubspec.yaml
+++ b/packages/bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc
 description: A predictable state management library that helps implement the BLoC (Business Logic Component) design pattern.
-version: 0.9.3
+version: 0.9.4
 author: felix.angelov <felangelov@gmail.com>
 homepage: https://felangel.github.io/bloc
 

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -415,7 +415,7 @@ void main() {
         _bloc.dispatch(CounterEvent.decrement);
       });
 
-      test('triggers onError', () {
+      test('triggers onError from mapEventToState', () {
         final exception = Exception('fatal exception');
         Object expectedError;
         StackTrace expectedStacktrace;
@@ -432,6 +432,33 @@ void main() {
           expect(expectedStacktrace, isNotNull);
         });
 
+        _bloc.dispatch(CounterEvent.increment);
+      });
+
+      test('triggers onError from dispatch', () {
+        Object capturedError;
+        StackTrace capturedStacktrace;
+        final CounterBloc _bloc = CounterBloc(
+          null,
+          (Object error, StackTrace stacktrace) {
+            capturedError = error;
+            capturedStacktrace = stacktrace;
+          },
+        );
+
+        expectLater(_bloc.state, emitsInOrder(<int>[0])).then((dynamic _) {
+          expect(
+            capturedError,
+            isStateError,
+          );
+          expect(
+            (capturedError as StateError).message,
+            'Cannot add new events after calling close',
+          );
+          expect(capturedStacktrace, isNull);
+        });
+
+        _bloc.dispose();
         _bloc.dispatch(CounterEvent.increment);
       });
     });

--- a/packages/bloc/test/helpers/counter/counter_bloc.dart
+++ b/packages/bloc/test/helpers/counter/counter_bloc.dart
@@ -1,6 +1,7 @@
 import 'package:bloc/bloc.dart';
 
 typedef OnTransitionCallback = Function(Transition<CounterEvent, int>);
+typedef OnErrorCallback = Function(Object error, StackTrace stacktrace);
 
 enum CounterEvent { increment, decrement }
 
@@ -8,8 +9,9 @@ class CounterBloc extends Bloc<CounterEvent, int> {
   int get initialState => 0;
 
   final OnTransitionCallback onTransitionCallback;
+  final OnErrorCallback onErrorCallback;
 
-  CounterBloc([this.onTransitionCallback]);
+  CounterBloc([this.onTransitionCallback, this.onErrorCallback]);
 
   @override
   Stream<int> mapEventToState(int currentState, CounterEvent event) async* {
@@ -26,6 +28,11 @@ class CounterBloc extends Bloc<CounterEvent, int> {
   @override
   void onTransition(Transition<CounterEvent, int> transition) {
     onTransitionCallback(transition);
+  }
+
+  @override
+  void onError(Object error, StackTrace stacktrace) {
+    onErrorCallback(error, stacktrace);
   }
 
   @override


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Calls to `dispatch` after after `dispose` has been called trigger `onError` in the `Bloc` and `BlocDelegate`.
- version bump to `0.9.4`

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
None