### PR TITLE
bloc v0.11.0

### DIFF
--- a/packages/bloc/CHANGELOG.md
+++ b/packages/bloc/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.11.0
+
+Update `mapEventToState` to remove unnecessary argument for `currentState`
+- `Stream<S> mapEventToState(S currentState, E event)` -> `Stream<S> mapEventToState(E event)`
+- Documentation Updates
+- Example Updates
+
 # 0.10.0
 
 Updated to `rxdart ^0.21.0` and Documentation Updates

--- a/packages/bloc/README.md
+++ b/packages/bloc/README.md
@@ -40,7 +40,7 @@ This design pattern helps to separate _presentation_ from _business logic_. Foll
 
 **initialState** is the state before any events have been processed (before `mapEventToState` has ever been called). `initialState` **must be implemented**.
 
-**mapEventToState** is a method that **must be implemented** when a class extends `Bloc`. The function takes two arguments: state and event. `mapEventToState` is called whenever an event is `dispatched` by the presentation layer. `mapEventToState` must convert that event, along with the current state, into a new state and return the new state in the form of a `Stream` which is consumed by the presentation layer.
+**mapEventToState** is a method that **must be implemented** when a class extends `Bloc`. The function takes the incoming event as an argument. `mapEventToState` is called whenever an event is `dispatched` by the presentation layer. `mapEventToState` must convert that event into a new state and return the new state in the form of a `Stream` which is consumed by the presentation layer.
 
 **dispatch** is a method that takes an `event` and triggers `mapEventToState`. `dispatch` may be called from the presentation layer or from within the Bloc (see examples) and notifies the Bloc of a new `event`.
 
@@ -66,7 +66,7 @@ class CounterBloc extends Bloc<CounterEvent, int> {
   int get initialState => 0;
 
   @override
-  Stream<int> mapEventToState(int currentState, CounterEvent event) async* {
+  Stream<int> mapEventToState(CounterEvent event) async* {
     switch (event) {
       case CounterEvent.decrement:
         yield currentState - 1;

--- a/packages/bloc/example/main.dart
+++ b/packages/bloc/example/main.dart
@@ -9,7 +9,7 @@ class CounterBloc extends Bloc<CounterEvent, int> {
   int get initialState => 0;
 
   @override
-  Stream<int> mapEventToState(int currentState, CounterEvent event) async* {
+  Stream<int> mapEventToState(CounterEvent event) async* {
     switch (event) {
       case CounterEvent.decrement:
         // Simulating Network Latency

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -62,21 +62,18 @@ abstract class Bloc<Event, State> {
   Stream<Event> transform(Stream<Event> events) => events;
 
   /// Must be implemented when a class extends [Bloc].
-  /// Takes the current `state` and incoming `event` as arguments.
+  /// Takes the incoming `event` as the argument.
   /// `mapEventToState` is called whenever an [Event] is `dispatched` by the presentation layer.
-  /// `mapEventToState` must convert that [Event], along with the current [State], into a new [State]
+  /// `mapEventToState` must convert that [Event] into a new [State]
   /// and return the new [State] in the form of a [Stream] which is consumed by the presentation layer.
-  Stream<State> mapEventToState(State currentState, Event event);
+  Stream<State> mapEventToState(Event event);
 
   void _bindStateSubject() {
     Event currentEvent;
 
     transform(_eventSubject).asyncExpand((Event event) {
       currentEvent = event;
-      return mapEventToState(
-        currentState,
-        event,
-      ).handleError(_handleError);
+      return mapEventToState(currentEvent).handleError(_handleError);
     }).forEach(
       (State nextState) {
         if (currentState == nextState) return;

--- a/packages/bloc/pubspec.yaml
+++ b/packages/bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc
 description: A predictable state management library that helps implement the BLoC (Business Logic Component) design pattern.
-version: 0.10.0
+version: 0.11.0
 author: felix.angelov <felangelov@gmail.com>
 homepage: https://felangel.github.io/bloc
 

--- a/packages/bloc/test/bloc_delegate_test.dart
+++ b/packages/bloc/test/bloc_delegate_test.dart
@@ -8,6 +8,10 @@ class MockBlocDelegate extends Mock implements BlocDelegate {}
 
 void main() {
   group('onTransition', () {
+    test('returns null on base delegate', () {
+      BlocDelegate().onTransition(null);
+    });
+
     test('is called when delegate is provided', () {
       final delegate = MockBlocDelegate();
       final complexBloc = ComplexBloc();
@@ -115,6 +119,10 @@ void main() {
   });
 
   group('onError', () {
+    test('returns null on base delegate', () {
+      BlocDelegate().onError(null, null);
+    });
+
     test('is called on bloc exception', () {
       bool errorHandled = false;
 

--- a/packages/bloc/test/helpers/async/async_bloc.dart
+++ b/packages/bloc/test/helpers/async/async_bloc.dart
@@ -9,10 +9,7 @@ class AsyncBloc extends Bloc<AsyncEvent, AsyncState> {
   AsyncState get initialState => AsyncState.initial();
 
   @override
-  Stream<AsyncState> mapEventToState(
-    AsyncState currentState,
-    AsyncEvent event,
-  ) async* {
+  Stream<AsyncState> mapEventToState(AsyncEvent event) async* {
     yield currentState.copyWith(isLoading: true);
     await Future<void>.delayed(Duration(milliseconds: 500));
     yield currentState.copyWith(isLoading: false, isSuccess: true);

--- a/packages/bloc/test/helpers/complex/complex_bloc.dart
+++ b/packages/bloc/test/helpers/complex/complex_bloc.dart
@@ -14,10 +14,7 @@ class ComplexBloc extends Bloc<ComplexEvent, ComplexState> {
   }
 
   @override
-  Stream<ComplexState> mapEventToState(
-    ComplexState currentState,
-    ComplexEvent event,
-  ) {
+  Stream<ComplexState> mapEventToState(ComplexEvent event) {
     if (event is ComplexEventA) {
       return Observable.just(ComplexStateA());
     }

--- a/packages/bloc/test/helpers/counter/counter_bloc.dart
+++ b/packages/bloc/test/helpers/counter/counter_bloc.dart
@@ -16,7 +16,7 @@ class CounterBloc extends Bloc<CounterEvent, int> {
   CounterBloc([this.onTransitionCallback, this.onErrorCallback]);
 
   @override
-  Stream<int> mapEventToState(int currentState, CounterEvent event) async* {
+  Stream<int> mapEventToState(CounterEvent event) async* {
     switch (event) {
       case CounterEvent.decrement:
         yield currentState - 1;

--- a/packages/bloc/test/helpers/counter/counter_exception_bloc.dart
+++ b/packages/bloc/test/helpers/counter/counter_exception_bloc.dart
@@ -9,7 +9,7 @@ class CounterExceptionBloc extends Bloc<CounterEvent, int> {
   int get initialState => 0;
 
   @override
-  Stream<int> mapEventToState(int currentState, CounterEvent event) async* {
+  Stream<int> mapEventToState(CounterEvent event) async* {
     switch (event) {
       case CounterEvent.decrement:
         yield currentState - 1;

--- a/packages/bloc/test/helpers/counter/on_error_bloc.dart
+++ b/packages/bloc/test/helpers/counter/on_error_bloc.dart
@@ -19,7 +19,7 @@ class OnErrorBloc extends Bloc<CounterEvent, int> {
   }
 
   @override
-  Stream<int> mapEventToState(int currentState, CounterEvent event) async* {
+  Stream<int> mapEventToState(CounterEvent event) async* {
     throw exception;
   }
 }

--- a/packages/bloc/test/helpers/simple/simple_bloc.dart
+++ b/packages/bloc/test/helpers/simple/simple_bloc.dart
@@ -8,7 +8,7 @@ class SimpleBloc extends Bloc<dynamic, String> {
   String get initialState => '';
 
   @override
-  Stream<String> mapEventToState(String currentState, dynamic event) {
+  Stream<String> mapEventToState(dynamic event) {
     return Observable.just('data');
   }
 }


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
YES

## Description
`mapEventToState` function signature changed (#161)
- `Stream<S> mapEventToState(S currentState, E event)` -> `Stream<S> mapEventToState(E event)`
- `currentState` can be accessed as a property of the bloc and no longer needs to be an argument.

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
None