### PR TITLE
Fix IntelliJ Plugin Compatibility Issues

### DIFF
--- a/extensions/intellij/intellij_generator_plugin/build.gradle
+++ b/extensions/intellij/intellij_generator_plugin/build.gradle
@@ -5,9 +5,20 @@ plugins {
 }
 
 group 'com.bloc'
-version '1.2'
+version '1.3'
+
+apply plugin: 'org.jetbrains.intellij'
+apply plugin: 'java'
+apply plugin: 'kotlin'
+apply plugin: 'idea'
 
 sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+intellij {
+    version '2017.3'
+    updateSinceUntilBuild false
+}
 
 repositories {
     mavenCentral()
@@ -30,5 +41,6 @@ patchPluginXml {
       * v1.0 - Initial release
       * v1.1 - Removed currentState from mapEventToState method
       * v1.2 - Support for IntelliJ 2019
+      * v1.3 - Bug Fixes for IntelliJ and Android Studio Compatibility
       """
 }

--- a/extensions/intellij/intellij_generator_plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/extensions/intellij/intellij_generator_plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Apr 18 19:36:22 CDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip

--- a/extensions/intellij/intellij_generator_plugin/src/main/java/com/bloc/intellij_generator_plugin/action/GenerateBlocAction.kt
+++ b/extensions/intellij/intellij_generator_plugin/src/main/java/com/bloc/intellij_generator_plugin/action/GenerateBlocAction.kt
@@ -39,8 +39,7 @@ class GenerateBlocAction : AnAction(), GenerateBlocDialog.Listener {
         e.dataContext.let {
             this.dataContext = it
             val presentation = e.presentation
-            val available = isAvailable(dataContext)
-            presentation.isEnabled = available
+            presentation.isEnabled = true
         }
     }
 
@@ -57,32 +56,6 @@ class GenerateBlocAction : AnAction(), GenerateBlocDialog.Listener {
                 "Generate a new Bloc",
                 null
             )
-        }
-    }
-
-    private fun isAvailable(dataContext: DataContext): Boolean {
-        val project = CommonDataKeys.PROJECT.getData(dataContext)
-        val view = LangDataKeys.IDE_VIEW.getData(dataContext)
-        return if (project == null || view == null || view.directories.isEmpty()) {
-            false
-        } else {
-            val projectFileIndex = ProjectRootManager.getInstance(project).fileIndex
-            view.directories.forEach { directory ->
-                if (projectFileIndex.isUnderSourceRootOfType(directory.virtualFile, JavaModuleSourceRootTypes.SOURCES) && packageExists(directory)) {
-                    return true
-                }
-            }
-            false
-        }
-    }
-
-    private fun packageExists(directory: PsiDirectory): Boolean {
-        val pkg = JavaDirectoryService.getInstance().getPackage(directory)
-        return if (pkg == null) {
-            false
-        } else {
-            val name = pkg.qualifiedName
-            name.isEmpty() || PsiNameHelper.getInstance(directory.project).isQualifiedName(name)
         }
     }
 

--- a/extensions/intellij/intellij_generator_plugin/src/main/resources/META-INF/plugin.xml
+++ b/extensions/intellij/intellij_generator_plugin/src/main/resources/META-INF/plugin.xml
@@ -9,6 +9,13 @@
         ]]>
     </description>
 
+    <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
+    <idea-version since-build="145.0"/>
+
+    <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
+       on how to target different products -->
+    <depends>com.intellij.modules.lang</depends>
+
     <actions>
         <group
                 description="Bloc architecture templates"


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Explicitly specify the `idea-version` in the `plugin.xml` to address #227 
- Also addresses #158 by allowing users to generate a bloc regardless of the current directory.

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
None