### PR TITLE
flutter_bloc : bloc_listener_tree

### DIFF
--- a/packages/flutter_bloc/lib/flutter_bloc.dart
+++ b/packages/flutter_bloc/lib/flutter_bloc.dart
@@ -2,5 +2,6 @@ library flutter_bloc;
 
 export './src/bloc_builder.dart';
 export './src/bloc_listener.dart';
-export './src/bloc_provider_tree.dart';
+export './src/bloc_listener_tree.dart';
 export './src/bloc_provider.dart';
+export './src/bloc_provider_tree.dart';

--- a/packages/flutter_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/bloc_listener.dart
@@ -1,8 +1,7 @@
 import 'dart:async';
 
-import 'package:flutter/widgets.dart';
-
 import 'package:bloc/bloc.dart';
+import 'package:flutter/widgets.dart';
 
 /// Signature for the listener function which takes the [BuildContext] along with the bloc state
 /// and is responsible for executing in response to state changes.
@@ -32,11 +31,22 @@ class BlocListener<E, S> extends BlocListenerBase<E, S> {
     Key key,
     @required this.bloc,
     @required this.listener,
-    @required this.child,
+    this.child,
   })  : assert(bloc != null),
         assert(listener != null),
-        assert(child != null),
         super(key: key, bloc: bloc, listener: listener);
+
+  /// Clone the current [BlocListener] with a new child [Widget].
+  /// All other values, including [Key], [Bloc] and [BlocWidgetListener] are
+  /// preserved.
+  BlocListener<E, S> copyWith(Widget child) {
+    return BlocListener<E, S>(
+      key: key,
+      bloc: bloc,
+      listener: listener,
+      child: child,
+    );
+  }
 
   @override
   Widget build(BuildContext context) => child;

--- a/packages/flutter_bloc/lib/src/bloc_listener_tree.dart
+++ b/packages/flutter_bloc/lib/src/bloc_listener_tree.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+/// A Flutter [Widget] that merges multiple [BlocListener] widgets into one widget tree.
+///
+/// [BlocListenerTree] improves the readability and eliminates the need
+/// to nest multiple [BlocListeners].
+///
+/// By using [BlocListenerTree] we can go from:
+///
+/// ```dart
+/// BlocListener<BlocAEvent, BlocAState>(
+///   bloc: BlocA(),
+///   listener: (BuildContext context, BlocAState state) {},
+///   child: BlocListener<BlocBEvent, BlocBState>(
+///     bloc: BlocB(),
+///     listener: (BuildContext context, BlocBState state) {},
+///     child: BlocListener<BlocCEvent, BlocCState>(
+///       bloc: BlocC(),
+///       listener: (BuildContext context, BlocCState state) {},
+///       child: ChildA(),
+///     ),
+///   ),
+/// )
+/// ```
+///
+/// to:
+///
+/// ```dart
+/// BlocListenerTree(
+///   blocListeners: [
+///     BlocListener<BlocAEvent, BlocAState>(
+///       bloc: BlocA(),
+///       listener: (BuildContext context, BlocAState state) {},
+///     ),
+///     BlocListener<BlocBEvent, BlocBState>(
+///       bloc: BlocB(),
+///       listener: (BuildContext context, BlocBState state) {},
+///     ),
+///     BlocListener<BlocCEvent, BlocCState>(
+///       bloc: BlocC(),
+///       listener: (BuildContext context, BlocCState state) {},
+///     ),
+///   ],
+///   child: ChildA(),
+/// )
+/// ```
+///
+/// [BlocListenerTree] converts the [BlocListener] list
+/// into a tree of nested [BlocListener] widgets.
+/// As a result, the only advantage of using [BlocListenerTree] is improved
+/// readability due to the reduction in nesting and boilerplate.
+class BlocListenerTree extends StatelessWidget {
+  /// The [BlocListener] list which is converted into a tree of [BlocListener] widgets.
+  /// The tree of [BlocListener] widgets is created in order meaning the first [BlocListener]
+  /// will be the top-most [BlocListener] and the last [BlocListener] will be a direct ancestor
+  /// of the `child` [Widget].
+  final List<BlocListener> blocListeners;
+
+  /// This [Widget] will be a direct descendent of the last [BlocListener] in `blocListeners`.
+  final Widget child;
+
+  BlocListenerTree({
+    Key key,
+    @required this.blocListeners,
+    @required this.child,
+  })  : assert(blocListeners != null),
+        assert(child != null),
+        super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    Widget tree = child;
+    for (final blocListener in blocListeners.reversed) {
+      tree = blocListener.copyWith(tree);
+    }
+    return tree;
+  }
+}

--- a/packages/flutter_bloc/lib/src/bloc_listener_tree.dart
+++ b/packages/flutter_bloc/lib/src/bloc_listener_tree.dart
@@ -60,7 +60,7 @@ class BlocListenerTree extends StatelessWidget {
   /// This [Widget] will be a direct descendent of the last [BlocListener] in `blocListeners`.
   final Widget child;
 
-  BlocListenerTree({
+  const BlocListenerTree({
     Key key,
     @required this.blocListeners,
     @required this.child,

--- a/packages/flutter_bloc/lib/src/bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/bloc_provider.dart
@@ -17,7 +17,7 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>> extends InheritedWidget {
     @required this.bloc,
     this.child,
   })  : assert(bloc != null),
-        super(key: key);
+        super(key: key, child: child);
 
   /// Method that allows widgets to access the bloc as long as their `BuildContext`
   /// contains a `BlocProvider` instance.

--- a/packages/flutter_bloc/lib/src/bloc_provider_tree.dart
+++ b/packages/flutter_bloc/lib/src/bloc_provider_tree.dart
@@ -49,7 +49,7 @@ class BlocProviderTree extends StatelessWidget {
   /// This [Widget] will be a direct descendent of the last [BlocProvider] in `blocProviders`.
   final Widget child;
 
-  BlocProviderTree({
+  const BlocProviderTree({
     Key key,
     @required this.blocProviders,
     @required this.child,

--- a/packages/flutter_bloc/test/bloc_listener_test.dart
+++ b/packages/flutter_bloc/test/bloc_listener_test.dart
@@ -119,22 +119,6 @@ void main() {
       }
     });
 
-    testWidgets('throws if initialized with null child',
-        (WidgetTester tester) async {
-      try {
-        await tester.pumpWidget(
-          BlocListener(
-            bloc: CounterBloc(),
-            listener: (BuildContext context, int state) {},
-            child: null,
-          ),
-        );
-        fail('should throw AssertionError');
-      } catch (error) {
-        expect(error, isAssertionError);
-      }
-    });
-
     testWidgets('renders child properly', (WidgetTester tester) async {
       final targetKey = Key('bloc_listener_container');
       await tester.pumpWidget(

--- a/packages/flutter_bloc/test/bloc_listener_tree_test.dart
+++ b/packages/flutter_bloc/test/bloc_listener_tree_test.dart
@@ -1,0 +1,207 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class MyAppNoBlocListenersNoChild extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return BlocListenerTree(
+      blocListeners: null,
+      child: null,
+    );
+  }
+}
+
+class MyAppNoBlocListeners extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return BlocListenerTree(
+      blocListeners: null,
+      child: Container(),
+    );
+  }
+}
+
+class MyAppNoChild extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return BlocListenerTree(
+      blocListeners: [],
+      child: null,
+    );
+  }
+}
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Demo',
+      home: CounterPage(),
+    );
+  }
+}
+
+class CounterPage extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => _CounterPageState();
+}
+
+class _CounterPageState extends State<CounterPage> {
+  final CounterBloc _counterBloc = CounterBloc();
+  final ThemeBloc _themeBloc = ThemeBloc();
+
+  @override
+  void dispose() {
+    _counterBloc.dispose();
+    _themeBloc.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Counter')),
+      body: BlocListenerTree(blocListeners: [
+        BlocListener<CounterEvent, int>(
+          bloc: _counterBloc,
+          listener: (BuildContext context, int state) {
+            Scaffold.of(context).showSnackBar(
+              SnackBar(
+                key: Key('snackbar_counter'),
+                content: Text(state.toString()),
+              ),
+            );
+          },
+        ),
+        BlocListener<ThemeEvent, ThemeData>(
+          bloc: _themeBloc,
+          listener: (BuildContext context, ThemeData state) {
+            Scaffold.of(context).showSnackBar(
+              SnackBar(
+                key: Key('snackbar_theme'),
+                content: Text(state.toString()),
+              ),
+            );
+          },
+        )
+      ], child: Container()),
+      floatingActionButton: Column(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: <Widget>[
+          Padding(
+            padding: EdgeInsets.symmetric(vertical: 5.0),
+            child: FloatingActionButton(
+              child: Icon(Icons.add),
+              onPressed: () {
+                _counterBloc.dispatch(CounterEvent.increment);
+              },
+            ),
+          ),
+          Padding(
+            padding: EdgeInsets.symmetric(vertical: 5.0),
+            child: FloatingActionButton(
+              child: Icon(Icons.remove),
+              onPressed: () {
+                _counterBloc.dispatch(CounterEvent.decrement);
+              },
+            ),
+          ),
+          Padding(
+            padding: EdgeInsets.symmetric(vertical: 5.0),
+            child: FloatingActionButton(
+              child: Icon(Icons.update),
+              onPressed: () {
+                _themeBloc.dispatch(ThemeEvent.toggle);
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+enum CounterEvent { increment, decrement }
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+  @override
+  int get initialState => 0;
+
+  @override
+  Stream<int> mapEventToState(CounterEvent event) async* {
+    switch (event) {
+      case CounterEvent.decrement:
+        yield currentState - 1;
+        break;
+      case CounterEvent.increment:
+        yield currentState + 1;
+        break;
+    }
+  }
+}
+
+enum ThemeEvent { toggle }
+
+class ThemeBloc extends Bloc<ThemeEvent, ThemeData> {
+  @override
+  ThemeData get initialState => ThemeData.light();
+
+  @override
+  Stream<ThemeData> mapEventToState(ThemeEvent event) async* {
+    switch (event) {
+      case ThemeEvent.toggle:
+        yield currentState == ThemeData.dark()
+            ? ThemeData.light()
+            : ThemeData.dark();
+        break;
+    }
+  }
+}
+
+void main() {
+  group('BlocListenerTree', () {
+    testWidgets('throws if initialized with no blocListeners and no child',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(MyAppNoBlocListenersNoChild());
+      expect(tester.takeException(), isInstanceOf<AssertionError>());
+    });
+
+    testWidgets('throws if initialized with no bloc',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(MyAppNoBlocListeners());
+      expect(tester.takeException(), isInstanceOf<AssertionError>());
+    });
+
+    testWidgets('throws if initialized with no child',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(MyAppNoChild());
+      expect(tester.takeException(), isInstanceOf<AssertionError>());
+    });
+
+    testWidgets('states handled by bloc listeners',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(MyApp());
+
+      final Finder _snackbarCounterFinder =
+          find.byKey((Key('snackbar_counter')));
+      final Finder _snackbarThemeFinder = find.byKey((Key('snackbar_theme')));
+
+      expectLater(_snackbarCounterFinder, findsOneWidget);
+      expectLater(_snackbarThemeFinder, findsOneWidget);
+
+      final Text _counterText =
+          _snackbarCounterFinder.evaluate().first.widget as Text;
+      final Text _themeText =
+          _snackbarCounterFinder.evaluate().first.widget as Text;
+
+      expectLater(_counterText.data, '0');
+
+      expectLater(_themeText.data, ThemeData.light().toString());
+    });
+  });
+}


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
Adding a `BlocListenerTree` widget to avoid nested `BlocListener`

## Todos
- [ ] Tests
- [x] Documentation
- [x] Examples

## Steps to Test or Reproduce
Just use this flutter App example :
```dart
import 'package:bloc/bloc.dart';
import 'package:flutter/material.dart';

void main() => runApp(MyApp());

class MyApp extends StatelessWidget {
  // This widget is the root of your application.
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Bloc Listener Text',
      theme: ThemeData(
        primarySwatch: Colors.blue,
      ),
      home: TestPage(),
    );
  }
}

class TestPage extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    BlocA blocA = BlocA();
    BlocB blocB = BlocB();
    Widget _widget = Center(
      child: ButtonBar(
        children: <Widget>[
          FlatButton(
            onPressed: () => blocA.dispatch(BlocATrigger()),
            child: Text('A'),
          ),
          FlatButton(
            onPressed: () => blocB.dispatch(BlocBTrigger()),
            child: Text('B'),
          ),
        ],
      ),
    );

    return Scaffold(
      body: BlocListenerTree(
        blocListeners: <BlocListener>[
          BlocListener<BlocAEvent, BlocAState>(
            bloc: blocA,
            listener: (BuildContext context, BlocAState state) {
              if (state is BlocAInitialized) {
                Scaffold.of(context)
                    .showSnackBar(SnackBar(content: Text(state.toString())));
              }
            },
          ),
          BlocListener<BlocBEvent, BlocBState>(
            bloc: blocB,
            listener: (BuildContext context, BlocBState state) {
              if (state is BlocBInitialized) {
                Scaffold.of(context)
                    .showSnackBar(SnackBar(content: Text(state.toString())));
              }
            },
            child: _widget,
          )
        ],
        child: _widget,
      ),
    );

    /// Instead of :
    return Scaffold(
      body: BlocListener<BlocAEvent, BlocAState>(
        bloc: blocA,
        listener: (BuildContext context, BlocAState state) {
          if (state is BlocAInitialized) {
            Scaffold.of(context)
                .showSnackBar(SnackBar(content: Text(state.toString())));
          }
        },
        child: BlocListener<BlocBEvent, BlocBState>(
          bloc: blocB,
          listener: (BuildContext context, BlocBState state) {
            if (state is BlocBInitialized) {
              Scaffold.of(context)
                  .showSnackBar(SnackBar(content: Text(state.toString())));
            }
          },
          child: _widget,
        ),
      ),
    );
  }
}


class BlocA extends Bloc<BlocATrigger, BlocAState> {
  @override
  BlocAState get initialState => BlocAInitialized();

  @override
  Stream<BlocAState> mapEventToState(BlocAEvent event) async* {
    if (event is BlocATrigger) {
      yield BlocALoading();
      Future.delayed(Duration(seconds: 1));
      yield BlocAInitialized();
    }
  }
}

abstract class BlocAEvent {}

class BlocATrigger extends BlocAEvent {}

abstract class BlocAState {}

class BlocALoading extends BlocAState {}

class BlocAInitialized extends BlocAState {
  @override
  String toString() {
    return 'BlocAInitialized{}';
  }
}


class BlocB extends Bloc<BlocBTrigger, BlocBState> {
  @override
  BlocBState get initialState => BlocBInitialized();

  @override
  Stream<BlocBState> mapEventToState(BlocBEvent event) async* {
    if (event is BlocBTrigger) {
      yield BlocBLoading();
      Future.delayed(Duration(seconds: 1));
      yield BlocBInitialized();
    }
  }
}

abstract class BlocBEvent {}

class BlocBTrigger extends BlocBEvent {}

abstract class BlocBState {}

class BlocBLoading extends BlocBState {
  @override
  String toString() {
    return 'BlocBLoading{}';
  }
}

class BlocBInitialized extends BlocBState {
  @override
  String toString() {
    return 'BlocBInitialized{}';
  }
}

```

## Impact to Remaining Code Base
This PR will affect:

* `BlocListener` (removing `@required` and assertion for the field `child`
* Unit tests
