### PR TITLE
dispose while events are pending does not emit new states or trigger onError

### DIFF
--- a/packages/bloc/README.md
+++ b/packages/bloc/README.md
@@ -50,7 +50,7 @@ This design pattern helps to separate _presentation_ from _business logic_. Foll
 
 **onError** is a method that can be overridden to handle whenever an `Exception` is thrown. By default all exceptions will be ignored and `Bloc` functionality will be unaffected. **It is a great place to add bloc-specific error handling**.
 
-**dispose** is a method that closes the `event` and `state` streams. `Dispose` should be called when a `Bloc` is no longer needed. Once `dispose` is called, `events` that are `dispatched` will not be processed and will result in an error being passed to `onError`.
+**dispose** is a method that closes the `event` and `state` streams. `Dispose` should be called when a `Bloc` is no longer needed. Once `dispose` is called, `events` that are `dispatched` will not be processed and will result in an error being passed to `onError`. In addition, if `dispose` is called while `events` are still being processed, any `states` yielded after are ignored and will not result in a `Transition`.
 
 ## BlocDelegate Interface
 

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -56,6 +56,8 @@ abstract class Bloc<Event, State> {
   /// This method should be called when a [Bloc] is no longer needed.
   /// Once `dispose` is called, events that are `dispatched` will not be
   /// processed and will result in an error being passed to `onError`.
+  /// In addition, if `dispose` is called while [Event]s are still being processed,
+  /// any [State]s yielded after are ignored and will not result in a [Transition].
   @mustCallSuper
   void dispose() {
     _eventSubject.close();
@@ -112,7 +114,7 @@ abstract class Bloc<Event, State> {
       return mapEventToState(currentEvent).handleError(_handleError);
     }).forEach(
       (State nextState) {
-        if (currentState == nextState) return;
+        if (currentState == nextState || _stateSubject.isClosed) return;
         final transition = Transition(
           currentState: currentState,
           event: currentEvent,

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -100,7 +100,7 @@ void main() {
       });
 
       test('dispose does not emit new states over the state stream', () {
-        final List<ComplexState> expected = [];
+        final List<ComplexState> expected = [ComplexStateA()];
 
         expectLater(
           complexBloc.state,
@@ -308,7 +308,7 @@ void main() {
       });
 
       test('dispose does not emit new states over the state stream', () {
-        final List<ComplexState> expected = [];
+        final List<AsyncState> expected = [AsyncState.initial()];
 
         expectLater(
           asyncBloc.state,
@@ -316,6 +316,22 @@ void main() {
         );
 
         asyncBloc.dispose();
+      });
+
+      test(
+          'dispose while events are pending does not emit new states or trigger onError',
+          () {
+        final List<AsyncState> expected = [AsyncState.initial()];
+
+        expectLater(
+          asyncBloc.state,
+          emitsInOrder(expected),
+        );
+
+        asyncBloc.dispatch(AsyncEvent());
+        asyncBloc.dispose();
+
+        verifyNever(delegate.onError(any, any));
       });
 
       test('initialState returns correct initial state', () {


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
When `dispose` is called on a `bloc` if events are pending, no new states are emitted and an exception is not passed to `onError`. (#257)


## Todos
- [X] Tests
- [X] Documentation
- [X] Examples


## Impact to Remaining Code Base
None