### PR TITLE
expose bloc event stream

### DIFF
--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -11,8 +11,12 @@ abstract class Bloc<Event, State> {
 
   BehaviorSubject<State> _stateSubject;
 
+  /// Returns [Stream] of [Event]s.
+  /// When an [Event] is dispatched, it is added to the [Stream].
+  Stream<Event> get event => _eventSubject.stream;
+
   /// Returns [Stream] of [State]s.
-  /// Consumed by the presentation layer.
+  /// Usually consumed by the presentation layer.
   Stream<State> get state => _stateSubject.stream;
 
   /// Returns the [State] before any [Event]s have been `dispatched`.

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -22,11 +22,13 @@ void main() {
       });
 
       test('dispose does not emit new states over the state stream', () {
-        final List<String> expected = [''];
+        final List<String> expectedEvents = [];
+        final List<String> expectedStates = [''];
 
+        expectLater(simpleBloc.event, emitsInOrder(expectedEvents));
         expectLater(
           simpleBloc.state,
-          emitsInOrder(expected),
+          emitsInOrder(expectedStates),
         );
 
         simpleBloc.dispose();
@@ -47,9 +49,12 @@ void main() {
       });
 
       test('should map single event to correct state', () {
-        final List<String> expected = ['', 'data'];
+        final List<String> expectedEvents = ['event'];
+        final List<String> expectedStates = ['', 'data'];
 
-        expectLater(simpleBloc.state, emitsInOrder(expected)).then((dynamic _) {
+        expectLater(simpleBloc.event, emitsInOrder(expectedEvents));
+        expectLater(simpleBloc.state, emitsInOrder(expectedStates))
+            .then((dynamic _) {
           verify(
             delegate.onTransition(
               Transition<dynamic, String>(
@@ -66,9 +71,12 @@ void main() {
       });
 
       test('should map multiple events to correct states', () {
-        final List<String> expected = ['', 'data'];
+        final List<String> expectedEvents = ['event1', 'event2', 'event3'];
+        final List<String> expectedStates = ['', 'data'];
 
-        expectLater(simpleBloc.state, emitsInOrder(expected)).then((dynamic _) {
+        expectLater(simpleBloc.event, emitsInOrder(expectedEvents));
+        expectLater(simpleBloc.state, emitsInOrder(expectedStates))
+            .then((dynamic _) {
           verify(
             delegate.onTransition(
               Transition<dynamic, String>(
@@ -100,11 +108,13 @@ void main() {
       });
 
       test('dispose does not emit new states over the state stream', () {
-        final List<ComplexState> expected = [ComplexStateA()];
+        final List<ComplexEvent> expectedEvents = [];
+        final List<ComplexState> expectedStates = [ComplexStateA()];
 
+        expectLater(complexBloc.event, emitsInOrder(expectedEvents));
         expectLater(
           complexBloc.state,
-          emitsInOrder(expected),
+          emitsInOrder(expectedStates),
         );
 
         complexBloc.dispose();
@@ -125,12 +135,14 @@ void main() {
       });
 
       test('should map single event to correct state', () {
-        final List<ComplexState> expected = [
+        final List<ComplexEvent> expectedEvents = [ComplexEventB()];
+        final List<ComplexState> expectedStates = [
           ComplexStateA(),
           ComplexStateB(),
         ];
 
-        expectLater(complexBloc.state, emitsInOrder(expected))
+        expectLater(complexBloc.event, emitsInOrder(expectedEvents));
+        expectLater(complexBloc.state, emitsInOrder(expectedStates))
             .then((dynamic _) {
           verify(
             delegate.onTransition(
@@ -148,15 +160,26 @@ void main() {
       });
 
       test('should map multiple events to correct states', () {
-        final List<ComplexState> expected = [
+        final List<ComplexEvent> expectedEvents = [
+          ComplexEventA(),
+          ComplexEventB(),
+          ComplexEventB(),
+          ComplexEventC(),
+          ComplexEventC(),
+        ];
+        final List<ComplexState> expectedStates = [
           ComplexStateA(),
           ComplexStateB(),
           ComplexStateC(),
         ];
 
         expectLater(
+          complexBloc.event,
+          emitsInOrder(expectedEvents),
+        );
+        expectLater(
           complexBloc.state,
-          emitsInOrder(expected),
+          emitsInOrder(expectedStates),
         ).then((dynamic _) {
           verify(
             delegate.onTransition(
@@ -221,14 +244,19 @@ void main() {
       });
 
       test('single Increment event updates state to 1', () {
-        final List<int> expected = [0, 1];
+        final List<CounterEvent> expectedEvents = [CounterEvent.increment];
+        final List<int> expectedStates = [0, 1];
         final expectedTransitions = [
           'Transition { currentState: 0, event: CounterEvent.increment, nextState: 1 }'
         ];
 
         expectLater(
+          counterBloc.event,
+          emitsInOrder(expectedEvents),
+        );
+        expectLater(
           counterBloc.state,
-          emitsInOrder(expected),
+          emitsInOrder(expectedStates),
         ).then((dynamic _) {
           expectLater(transitions, expectedTransitions);
           verify(
@@ -247,7 +275,12 @@ void main() {
       });
 
       test('multiple Increment event updates state to 3', () {
-        final List<int> expected = [0, 1, 2, 3];
+        final List<CounterEvent> expectedEvents = [
+          CounterEvent.increment,
+          CounterEvent.increment,
+          CounterEvent.increment
+        ];
+        final List<int> expectedStates = [0, 1, 2, 3];
         final expectedTransitions = [
           'Transition { currentState: 0, event: CounterEvent.increment, nextState: 1 }',
           'Transition { currentState: 1, event: CounterEvent.increment, nextState: 2 }',
@@ -255,8 +288,12 @@ void main() {
         ];
 
         expectLater(
+          counterBloc.event,
+          emitsInOrder(expectedEvents),
+        );
+        expectLater(
           counterBloc.state,
-          emitsInOrder(expected),
+          emitsInOrder(expectedStates),
         ).then((dynamic _) {
           expect(transitions, expectedTransitions);
           verify(
@@ -308,11 +345,16 @@ void main() {
       });
 
       test('dispose does not emit new states over the state stream', () {
-        final List<AsyncState> expected = [AsyncState.initial()];
+        final List<AsyncEvent> expectedEvents = [];
+        final List<AsyncState> expectedStates = [AsyncState.initial()];
 
         expectLater(
+          asyncBloc.event,
+          emitsInOrder(expectedEvents),
+        );
+        expectLater(
           asyncBloc.state,
-          emitsInOrder(expected),
+          emitsInOrder(expectedStates),
         );
 
         asyncBloc.dispose();
@@ -321,11 +363,16 @@ void main() {
       test(
           'dispose while events are pending does not emit new states or trigger onError',
           () {
-        final List<AsyncState> expected = [AsyncState.initial()];
+        final List<AsyncEvent> expectedEvents = [AsyncEvent()];
+        final List<AsyncState> expectedStates = [AsyncState.initial()];
 
         expectLater(
+          asyncBloc.event,
+          emitsInOrder(expectedEvents),
+        );
+        expectLater(
           asyncBloc.state,
-          emitsInOrder(expected),
+          emitsInOrder(expectedStates),
         );
 
         asyncBloc.dispatch(AsyncEvent());
@@ -349,13 +396,16 @@ void main() {
       });
 
       test('should map single event to correct state', () {
-        final List<AsyncState> expected = [
+        final List<AsyncEvent> expectedEvents = [AsyncEvent()];
+        final List<AsyncState> expectedStates = [
           AsyncState(isLoading: false, hasError: false, isSuccess: false),
           AsyncState(isLoading: true, hasError: false, isSuccess: false),
           AsyncState(isLoading: false, hasError: false, isSuccess: true),
         ];
 
-        expectLater(asyncBloc.state, emitsInOrder(expected)).then((dynamic _) {
+        expectLater(asyncBloc.event, emitsInOrder(expectedEvents));
+        expectLater(asyncBloc.state, emitsInOrder(expectedStates))
+            .then((dynamic _) {
           verify(
             delegate.onTransition(
               Transition<AsyncEvent, AsyncState>(


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
Expose `Stream<Event` in bloc (similar to `state` stream). (#259)

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
None