### PR TITLE
Include bloc in BlocDelegate onTransition and onError

### DIFF
--- a/packages/bloc/README.md
+++ b/packages/bloc/README.md
@@ -110,8 +110,8 @@ As our app grows and relies on multiple `Blocs`, it becomes useful to see the `T
 ```dart
 class SimpleBlocDelegate extends BlocDelegate {
   @override
-  void onTransition(Transition transition) {
-    super.onTransition(transition);
+  void onTransition(Bloc bloc, Transition transition) {
+    super.onTransition(bloc, transition);
     print(transition);
   }
 }
@@ -142,14 +142,14 @@ If we want to be able to handle any `Exceptions` that might be thrown in `mapEve
 ```dart
 class SimpleBlocDelegate extends BlocDelegate {
   @override
-  void onTransition(Transition transition) {
-    super.onTransition(transition);
+  void onTransition(Bloc bloc, Transition transition) {
+    super.onTransition(bloc, transition);
     print(transition);
   }
 
   @override
-  void onError(Object error, StackTrace stacktrace) {
-    super.onError(error, stacktrace);
+  void onError(Bloc bloc, Object error, StackTrace stacktrace) {
+    super.onError(bloc, error, stacktrace);
     print('$error, $stacktrace');
   }
 }

--- a/packages/bloc/example/main.dart
+++ b/packages/bloc/example/main.dart
@@ -29,15 +29,15 @@ class CounterBloc extends Bloc<CounterEvent, int> {
 
 class SimpleBlocDelegate extends BlocDelegate {
   @override
-  void onTransition(Transition transition) {
-    super.onTransition(transition);
-    print(transition);
+  void onTransition(Bloc bloc, Transition transition) {
+    super.onTransition(bloc, transition);
+    print('bloc: ${bloc.runtimeType}, transition: $transition');
   }
 
   @override
-  void onError(Object error, StackTrace stacktrace) {
-    super.onError(error, stacktrace);
-    print(error);
+  void onError(Bloc bloc, Object error, StackTrace stacktrace) {
+    super.onError(bloc, error, stacktrace);
+    print('bloc: ${bloc.runtimeType}, error: $error');
   }
 }
 

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -124,7 +124,7 @@ abstract class Bloc<Event, State> {
           event: currentEvent,
           nextState: nextState,
         );
-        BlocSupervisor().delegate?.onTransition(transition);
+        BlocSupervisor().delegate?.onTransition(this, transition);
         onTransition(transition);
         _stateSubject.add(nextState);
       },
@@ -133,6 +133,6 @@ abstract class Bloc<Event, State> {
 
   void _handleError(Object error, [StackTrace stacktrace]) {
     onError(error, stacktrace);
-    BlocSupervisor().delegate?.onError(error, stacktrace);
+    BlocSupervisor().delegate?.onError(this, error, stacktrace);
   }
 }

--- a/packages/bloc/lib/src/bloc_delegate.dart
+++ b/packages/bloc/lib/src/bloc_delegate.dart
@@ -4,16 +4,17 @@ import 'package:meta/meta.dart';
 /// Handles events from all [Bloc]s
 /// which are delegated by the [BlocSupervisor].
 class BlocDelegate {
-  /// Called whenever a transition occurs with the given [Transition] in any [Bloc].
+  /// Called whenever a transition occurs in any [Bloc] with the given [Bloc] and [Transition].
   /// A [Transition] occurs when a new [Event] is dispatched and `mapEventToState` executed.
   /// `onTransition` is called before a [Bloc]'s state has been updated.
   /// A great spot to add universal logging/analytics.
   @mustCallSuper
-  void onTransition(Transition transition) => null;
+  void onTransition(Bloc bloc, Transition transition) => null;
 
-  /// Called whenever an [Exception] is thrown within `mapEventToState` for any [Bloc].
+  /// Called whenever an [Exception] is thrown in any [Bloc]
+  /// with the given [Bloc], [Exception], and [StackTrace].
   /// The stacktrace argument may be `null` if the state stream received an error without a [StackTrace].
   /// A great spot to add universal error handling.
   @mustCallSuper
-  void onError(Object error, StackTrace stacktrace) => null;
+  void onError(Bloc bloc, Object error, StackTrace stacktrace) => null;
 }

--- a/packages/bloc/test/bloc_delegate_test.dart
+++ b/packages/bloc/test/bloc_delegate_test.dart
@@ -9,7 +9,7 @@ class MockBlocDelegate extends Mock implements BlocDelegate {}
 void main() {
   group('onTransition', () {
     test('returns null on base delegate', () {
-      BlocDelegate().onTransition(null);
+      BlocDelegate().onTransition(null, null);
     });
 
     test('is called when delegate is provided', () {
@@ -20,7 +20,7 @@ void main() {
         ComplexStateB(),
       ];
       BlocSupervisor().delegate = delegate;
-      when(delegate.onTransition(any)).thenReturn(null);
+      when(delegate.onTransition(any, any)).thenReturn(null);
 
       expectLater(
         complexBloc.state,
@@ -28,6 +28,7 @@ void main() {
       ).then((dynamic _) {
         verify(
           delegate.onTransition(
+            complexBloc,
             Transition<ComplexEvent, ComplexState>(
               currentState: ComplexStateA(),
               event: ComplexEventB(),
@@ -53,7 +54,7 @@ void main() {
         ComplexStateC()
       ];
       BlocSupervisor().delegate = delegate;
-      when(delegate.onTransition(any)).thenReturn(null);
+      when(delegate.onTransition(any, any)).thenReturn(null);
 
       expectLater(
         complexBlocA.state,
@@ -61,6 +62,7 @@ void main() {
       ).then((dynamic _) {
         verify(
           delegate.onTransition(
+            complexBlocA,
             Transition<ComplexEvent, ComplexState>(
               currentState: ComplexStateA(),
               event: ComplexEventB(),
@@ -76,6 +78,7 @@ void main() {
       ).then((dynamic _) {
         verify(
           delegate.onTransition(
+            complexBlocB,
             Transition<ComplexEvent, ComplexState>(
               currentState: ComplexStateA(),
               event: ComplexEventC(),
@@ -97,7 +100,7 @@ void main() {
         ComplexStateB()
       ];
       BlocSupervisor().delegate = null;
-      when(delegate.onTransition(any)).thenReturn(null);
+      when(delegate.onTransition(any, any)).thenReturn(null);
 
       expectLater(
         complexBloc.state,
@@ -105,6 +108,7 @@ void main() {
       ).then((dynamic _) {
         verifyNever(
           delegate.onTransition(
+            complexBloc,
             Transition<ComplexEvent, ComplexState>(
               currentState: ComplexStateA(),
               event: ComplexEventB(),
@@ -120,21 +124,25 @@ void main() {
 
   group('onError', () {
     test('returns null on base delegate', () {
-      BlocDelegate().onError(null, null);
+      BlocDelegate().onError(null, null, null);
     });
 
     test('is called on bloc exception', () {
       bool errorHandled = false;
+      Bloc blocWithError;
 
       final delegate = MockBlocDelegate();
       final CounterExceptionBloc _bloc = CounterExceptionBloc();
       BlocSupervisor().delegate = delegate;
 
-      when(delegate.onError(any, any))
-          .thenAnswer((dynamic _) => errorHandled = true);
+      when(delegate.onError(any, any, any)).thenAnswer((Invocation invocation) {
+        blocWithError = invocation.positionalArguments[0] as Bloc;
+        errorHandled = true;
+      });
 
       expectLater(_bloc.state, emitsInOrder(<int>[0])).then((dynamic _) {
         expect(errorHandled, isTrue);
+        expect(blocWithError, _bloc);
       });
 
       _bloc.dispatch(CounterEvent.increment);

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -16,7 +16,7 @@ void main() {
       setUp(() {
         simpleBloc = SimpleBloc();
         delegate = MockBlocDelegate();
-        when(delegate.onTransition(any)).thenReturn(null);
+        when(delegate.onTransition(any, any)).thenReturn(null);
 
         BlocSupervisor().delegate = delegate;
       });
@@ -57,6 +57,7 @@ void main() {
             .then((dynamic _) {
           verify(
             delegate.onTransition(
+              simpleBloc,
               Transition<dynamic, String>(
                 currentState: '',
                 event: 'event',
@@ -79,6 +80,7 @@ void main() {
             .then((dynamic _) {
           verify(
             delegate.onTransition(
+              simpleBloc,
               Transition<dynamic, String>(
                 currentState: '',
                 event: 'event1',
@@ -102,7 +104,7 @@ void main() {
       setUp(() {
         complexBloc = ComplexBloc();
         delegate = MockBlocDelegate();
-        when(delegate.onTransition(any)).thenReturn(null);
+        when(delegate.onTransition(any, any)).thenReturn(null);
 
         BlocSupervisor().delegate = delegate;
       });
@@ -146,6 +148,7 @@ void main() {
             .then((dynamic _) {
           verify(
             delegate.onTransition(
+              complexBloc,
               Transition<ComplexEvent, ComplexState>(
                 currentState: ComplexStateA(),
                 event: ComplexEventB(),
@@ -183,6 +186,7 @@ void main() {
         ).then((dynamic _) {
           verify(
             delegate.onTransition(
+              complexBloc,
               Transition<ComplexEvent, ComplexState>(
                 currentState: ComplexStateA(),
                 event: ComplexEventB(),
@@ -192,6 +196,7 @@ void main() {
           ).called(1);
           verify(
             delegate.onTransition(
+              complexBloc,
               Transition<ComplexEvent, ComplexState>(
                 currentState: ComplexStateB(),
                 event: ComplexEventC(),
@@ -223,7 +228,7 @@ void main() {
         transitions = [];
         counterBloc = CounterBloc(onTransitionCallback);
         delegate = MockBlocDelegate();
-        when(delegate.onTransition(any)).thenReturn(null);
+        when(delegate.onTransition(any, any)).thenReturn(null);
 
         BlocSupervisor().delegate = delegate;
       });
@@ -261,6 +266,7 @@ void main() {
           expectLater(transitions, expectedTransitions);
           verify(
             delegate.onTransition(
+              counterBloc,
               Transition<CounterEvent, int>(
                 currentState: 0,
                 event: CounterEvent.increment,
@@ -298,6 +304,7 @@ void main() {
           expect(transitions, expectedTransitions);
           verify(
             delegate.onTransition(
+              counterBloc,
               Transition<CounterEvent, int>(
                 currentState: 0,
                 event: CounterEvent.increment,
@@ -307,6 +314,7 @@ void main() {
           ).called(1);
           verify(
             delegate.onTransition(
+              counterBloc,
               Transition<CounterEvent, int>(
                 currentState: 1,
                 event: CounterEvent.increment,
@@ -316,6 +324,7 @@ void main() {
           ).called(1);
           verify(
             delegate.onTransition(
+              counterBloc,
               Transition<CounterEvent, int>(
                 currentState: 2,
                 event: CounterEvent.increment,
@@ -339,7 +348,7 @@ void main() {
       setUp(() {
         asyncBloc = AsyncBloc();
         delegate = MockBlocDelegate();
-        when(delegate.onTransition(any)).thenReturn(null);
+        when(delegate.onTransition(any, any)).thenReturn(null);
 
         BlocSupervisor().delegate = delegate;
       });
@@ -378,7 +387,7 @@ void main() {
         asyncBloc.dispatch(AsyncEvent());
         asyncBloc.dispose();
 
-        verifyNever(delegate.onError(any, any));
+        verifyNever(delegate.onError(any, any, any));
       });
 
       test('initialState returns correct initial state', () {
@@ -408,6 +417,7 @@ void main() {
             .then((dynamic _) {
           verify(
             delegate.onTransition(
+              asyncBloc,
               Transition<AsyncEvent, AsyncState>(
                 currentState: AsyncState(
                   isLoading: false,
@@ -425,6 +435,7 @@ void main() {
           ).called(1);
           verify(
             delegate.onTransition(
+              asyncBloc,
               Transition<AsyncEvent, AsyncState>(
                 currentState: AsyncState(
                   isLoading: true,


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
YES

## Description
`onTransition` and `onError` in `BlocDelegate` will now have a reference to the given `bloc`. (#259)

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
`BlocDelegate` implementations need to be updated.