### PR TITLE
deprecate bloc event stream

### DIFF
--- a/packages/bloc/CHANGELOG.md
+++ b/packages/bloc/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.14.2
+
+- Deprecated Bloc `event` Stream ([#326](https://github.com/felangel/bloc/issues/326))
+- Documentation Updates
+
 # 0.14.1
 
 Internal `BlocDelegate` update and Documentation Updates.

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -13,6 +13,9 @@ abstract class Bloc<Event, State> {
 
   /// Returns [Stream] of [Event]s.
   /// When an [Event] is dispatched, it is added to the [Stream].
+  @Deprecated(
+    'Will be removed in v0.15.0. Logic should not be written in response to Events. Please refer to onEvent in the Bloc and BlocDelegate classes for analytics.',
+  )
   Stream<Event> get event => _eventSubject.stream;
 
   /// Returns [Stream] of [State]s.

--- a/packages/bloc/pubspec.yaml
+++ b/packages/bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc
 description: A predictable state management library that helps implement the BLoC (Business Logic Component) design pattern.
-version: 0.14.1
+version: 0.14.2
 author: Felix Angelov <felangelov@gmail.com>
 repository: https://github.com/felangel/bloc
 issue_tracker: https://github.com/felangel/bloc/issues


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Deprecate the bloc `event` stream API (#326)

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
None