### PR TITLE
Update BlocProvider to automatically dispose blocs

### DIFF
--- a/packages/flutter_bloc/example/lib/main.dart
+++ b/packages/flutter_bloc/example/lib/main.dart
@@ -27,43 +27,30 @@ class SimpleBlocDelegate extends BlocDelegate {
 
 void main() {
   BlocSupervisor.delegate = SimpleBlocDelegate();
-  runApp(App());
+  runApp(
+    BlocProviderTree(
+      blocProviders: [
+        BlocProvider<CounterBloc>(builder: (context) => CounterBloc()),
+        BlocProvider<ThemeBloc>(builder: (context) => ThemeBloc())
+      ],
+      child: App(),
+    ),
+  );
 }
 
-class App extends StatefulWidget {
-  @override
-  State<StatefulWidget> createState() => _AppState();
-}
-
-class _AppState extends State<App> {
-  final CounterBloc _counterBloc = CounterBloc();
-  final ThemeBloc _themeBloc = ThemeBloc();
-
+class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return BlocProviderTree(
-      blocProviders: [
-        BlocProvider<CounterBloc>(bloc: _counterBloc),
-        BlocProvider<ThemeBloc>(bloc: _themeBloc)
-      ],
-      child: BlocBuilder(
-        bloc: _themeBloc,
-        builder: (_, ThemeData theme) {
-          return MaterialApp(
-            title: 'Flutter Demo',
-            home: CounterPage(),
-            theme: theme,
-          );
-        },
-      ),
+    return BlocBuilder(
+      bloc: BlocProvider.of<ThemeBloc>(context),
+      builder: (_, ThemeData theme) {
+        return MaterialApp(
+          title: 'Flutter Demo',
+          home: CounterPage(),
+          theme: theme,
+        );
+      },
     );
-  }
-
-  @override
-  void dispose() {
-    _counterBloc.dispose();
-    _themeBloc.dispose();
-    super.dispose();
   }
 }
 

--- a/packages/flutter_bloc/lib/src/bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/bloc_provider.dart
@@ -2,30 +2,41 @@ import 'package:flutter/widgets.dart';
 
 import 'package:bloc/bloc.dart';
 
+/// Signature for the builder function which takes the [BuildContext]
+/// and is responsible for returning a [Bloc] which is to be provided to the subtree.
+typedef BlocProviderBuilder<T extends Bloc<dynamic, dynamic>> = T Function(
+  BuildContext context,
+);
+
 /// A Flutter widget which provides a bloc to its children via `BlocProvider.of(context)`.
 /// It is used as a DI widget so that a single instance of a bloc can be provided
 /// to multiple widgets within a subtree.
-class BlocProvider<T extends Bloc<dynamic, dynamic>> extends InheritedWidget {
-  /// The [Bloc] which is to be made available throughout the subtree
-  final T bloc;
+///
+/// `BlocProvider` automatically calls `dispose` on the [Bloc] therefore
+/// `dispose` should not be manually called unless the bloc is initialized outside
+/// of `BlocProvider`.
+class BlocProvider<T extends Bloc<dynamic, dynamic>> extends StatefulWidget {
+  /// The [BlocProviderBuilder] which creates the [Bloc]
+  /// that will be made available throughout the subtree.
+  final BlocProviderBuilder<T> builder;
 
   /// The [Widget] and its descendants which will have access to the [Bloc].
   final Widget child;
 
-  BlocProvider({
-    Key key,
-    @required this.bloc,
-    this.child,
-  })  : assert(bloc != null),
-        super(key: key, child: child);
+  BlocProvider({Key key, @required this.builder, this.child})
+      : assert(builder != null),
+        super(key: key);
+
+  @override
+  State<BlocProvider<T>> createState() => _BlocProviderState<T>();
 
   /// Method that allows widgets to access the bloc as long as their `BuildContext`
   /// contains a `BlocProvider` instance.
   static T of<T extends Bloc<dynamic, dynamic>>(BuildContext context) {
-    final type = _typeOf<BlocProvider<T>>();
-    final BlocProvider<T> provider = context
+    final type = _typeOf<_InheritedBlocProvider<T>>();
+    final _InheritedBlocProvider<T> provider = context
         .ancestorInheritedElementForWidgetOfExactType(type)
-        ?.widget as BlocProvider<T>;
+        ?.widget as _InheritedBlocProvider<T>;
 
     if (provider == null) {
       throw FlutterError(
@@ -42,20 +53,66 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>> extends InheritedWidget {
     return provider?.bloc;
   }
 
+  /// Necessary to obtain generic [Type]
+  /// https://github.com/dart-lang/sdk/issues/11923
+  static Type _typeOf<T>() => T;
+
   /// Clone the current [BlocProvider] with a new child [Widget].
   /// All other values, including [Key] and [Bloc] are preserved.
   BlocProvider<T> copyWith(Widget child) {
     return BlocProvider<T>(
       key: key,
-      bloc: bloc,
+      builder: builder,
       child: child,
     );
   }
+}
 
-  /// Necessary to obtain generic [Type]
-  /// https://github.com/dart-lang/sdk/issues/11923
-  static Type _typeOf<T>() => T;
+class _BlocProviderState<T extends Bloc<dynamic, dynamic>>
+    extends State<BlocProvider<T>> {
+  T _bloc;
 
   @override
-  bool updateShouldNotify(BlocProvider oldWidget) => false;
+  void initState() {
+    super.initState();
+    _bloc = widget.builder?.call(context);
+    if (_bloc == null) {
+      throw FlutterError(
+        """
+        BlocProvider builder did not return a Bloc of type $T.        
+        This can happen if the builder is not implemented or does not return a Bloc.        
+        """,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _InheritedBlocProvider(
+      bloc: _bloc,
+      child: widget.child,
+    );
+  }
+
+  @override
+  void dispose() {
+    _bloc.dispose();
+    super.dispose();
+  }
+}
+
+class _InheritedBlocProvider<T extends Bloc<dynamic, dynamic>>
+    extends InheritedWidget {
+  final T bloc;
+
+  final Widget child;
+
+  _InheritedBlocProvider({
+    Key key,
+    @required this.bloc,
+    this.child,
+  }) : super(key: key, child: child);
+
+  @override
+  bool updateShouldNotify(_InheritedBlocProvider oldWidget) => false;
 }

--- a/packages/flutter_bloc/test/bloc_provider_tree_test.dart
+++ b/packages/flutter_bloc/test/bloc_provider_tree_test.dart
@@ -35,40 +35,19 @@ class MyAppNoChild extends StatelessWidget {
   }
 }
 
-class MyApp extends StatefulWidget {
-  @override
-  State<StatefulWidget> createState() => _MyAppState();
-}
-
-class _MyAppState extends State<MyApp> {
-  final CounterBloc _counterBloc = CounterBloc();
-  final ThemeBloc _themeBloc = ThemeBloc();
-
+class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return BlocProviderTree(
-      blocProviders: [
-        BlocProvider<CounterBloc>(bloc: _counterBloc),
-        BlocProvider<ThemeBloc>(bloc: _themeBloc)
-      ],
-      child: BlocBuilder(
-        bloc: _themeBloc,
-        builder: (_, ThemeData theme) {
-          return MaterialApp(
-            title: 'Flutter Demo',
-            home: CounterPage(),
-            theme: theme,
-          );
-        },
-      ),
+    return BlocBuilder(
+      bloc: BlocProvider.of<ThemeBloc>(context),
+      builder: (_, ThemeData theme) {
+        return MaterialApp(
+          title: 'Flutter Demo',
+          home: CounterPage(),
+          theme: theme,
+        );
+      },
     );
-  }
-
-  @override
-  void dispose() {
-    _counterBloc.dispose();
-    _themeBloc.dispose();
-    super.dispose();
   }
 }
 
@@ -187,7 +166,15 @@ void main() {
     });
 
     testWidgets('passes blocs to children', (WidgetTester tester) async {
-      await tester.pumpWidget(MyApp());
+      await tester.pumpWidget(
+        BlocProviderTree(
+          blocProviders: [
+            BlocProvider<CounterBloc>(builder: (context) => CounterBloc()),
+            BlocProvider<ThemeBloc>(builder: (context) => ThemeBloc())
+          ],
+          child: MyApp(),
+        ),
+      );
 
       final Finder _counterFinder = find.byKey((Key('counter_text')));
       expect(_counterFinder, findsOneWidget);


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
YES

## Description
Update `BlocProvider` to handle initializing and disposing the bloc to eliminate the need to create a `StatefulWidget` just to manage a bloc (#84).

This PR allows us to go from:
```dart
class MyApp extends StatefulWidget {
  State<MyApp> createState() => _MyAppState();
}

class _MyAppState extends State<MyApp> {
  MyBloc _myBloc;
  
  @override
  initState() {
    super.initState();
    _myBloc = MyBloc();
  }

  @override
  Widget build(BuildContext context) {
    return BlocProvider(
      bloc: _myBloc,
      child: MyPage(),
    );
  }

  @override
  dispose() {
    _myBloc.dispose();
    super.dispose();
  }
}
```

To this:

```dart
class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return BlocProvider(
      builder: (BuildContext context) => MyBloc(),
      child: MyPage(),
    );
  }
}
```

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
- Breaking change which will be included in flutter_bloc v0.16.0