### PR TITLE
Expose dispose method on BlocProvider

### DIFF
--- a/packages/flutter_bloc/README.md
+++ b/packages/flutter_bloc/README.md
@@ -50,7 +50,8 @@ BlocBuilder(
 
 ```dart
 BlocProvider(
-  bloc: BlocA(),
+  builder: (BuildContext context) => BlocA(),
+  dispose: (BuildContext context, BlocA bloc) => bloc.dispose(),
   child: ChildA(),
 );
 ```
@@ -67,11 +68,14 @@ By using `BlocProviderTree` we can go from:
 
 ```dart
 BlocProvider<BlocA>(
-  bloc: BlocA(),
+  builder: (BuildContext context) => BlocA(),
+  dispose: (BuildContext context, BlocA blocA) => blocA.dispose(),
   child: BlocProvider<BlocB>(
-    bloc: BlocB(),
+    builder: (BuildContext context) => BlocB(),
+    dispose: (BuildContext context, BlocB blocB) => blocB.dispose(),
     child: BlocProvider<BlocC>(
-      value: BlocC(),
+      builder: (BuildContext context) => BlocC(),
+      dispose: (BuildContext context, BlocC blocC) => blocC.dispose(),
       child: ChildA(),
     )
   )
@@ -83,9 +87,18 @@ to:
 ```dart
 BlocProviderTree(
   blocProviders: [
-    BlocProvider<BlocA>(bloc: BlocA()),
-    BlocProvider<BlocB>(bloc: BlocB()),
-    BlocProvider<BlocC>(bloc: BlocC()),
+    BlocProvider<BlocA>(
+      builder: (BuildContext context) => BlocA(),
+      dispose: (BuildContext context, BlocA blocA) => blocA.dispose(),
+    ),
+    BlocProvider<BlocB>(
+      builder: (BuildContext context) => BlocB(),
+      dispose: (BuildContext context, BlocB blocB) => blocB.dispose(),
+    ),
+    BlocProvider<BlocC>(
+      builder: (BuildContext context) => BlocC(),
+      dispose: (BuildContext context, BlocC blocC) => blocC.dispose(),
+    ),
   ],
   child: ChildA(),
 )
@@ -259,7 +272,7 @@ At this point we have successfully separated our presentational layer from our b
 - [Github Search](https://felangel.github.io/bloc/#/flutterangulargithubsearch) - an example of how to create a Github Search Application using the `bloc` and `flutter_bloc` packages.
 - [Weather](https://felangel.github.io/bloc/#/flutterweathertutorial) - an example of how to create a Weather Application using the `bloc` and `flutter_bloc` packages. The app uses a `RefreshIndicator` to implement "pull-to-refresh" as well as dynamic theming.
 - [Todos](https://felangel.github.io/bloc/#/fluttertodostutorial) - an example of how to create a Todos Application using the `bloc` and `flutter_bloc` packages.
-- [Timer](https://github.com/felangel/bloc/tree/master/examples/flutter_timer) - an example of how to create a Timer using the `bloc` and `flutter_bloc` packages.
+- [Timer](https://felangel.github.io/bloc/#/fluttertimertutorial) - an example of how to create a Timer using the `bloc` and `flutter_bloc` packages.
 
 ### Maintainers
 

--- a/packages/flutter_bloc/example/lib/main.dart
+++ b/packages/flutter_bloc/example/lib/main.dart
@@ -30,8 +30,14 @@ void main() {
   runApp(
     BlocProviderTree(
       blocProviders: [
-        BlocProvider<CounterBloc>(builder: (context) => CounterBloc()),
-        BlocProvider<ThemeBloc>(builder: (context) => ThemeBloc())
+        BlocProvider<CounterBloc>(
+          builder: (context) => CounterBloc(),
+          dispose: (context, bloc) => bloc.dispose(),
+        ),
+        BlocProvider<ThemeBloc>(
+          builder: (context) => ThemeBloc(),
+          dispose: (context, bloc) => bloc.dispose(),
+        )
       ],
       child: App(),
     ),


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
YES

## Description
- Update `BlocProvider` to expose `dispose` method to allow full control over when a bloc should be disposed.

This PR allows us to go from:
```dart
class MyApp extends StatefulWidget {
  State<MyApp> createState() => _MyAppState();
}

class _MyAppState extends State<MyApp> {
  MyBloc _myBloc;
  
  @override
  initState() {
    super.initState();
    _myBloc = MyBloc();
  }

  @override
  Widget build(BuildContext context) {
    return BlocProvider(
      bloc: _myBloc,
      child: MyPage(),
    );
  }

  @override
  dispose() {
    _myBloc.dispose();
    super.dispose();
  }
}
```

To this:

```dart
class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return BlocProvider(
      builder: (BuildContext context) => MyBloc(),
      dispose: (BuildContext context, MyBloc bloc) => bloc.dispose(),
      child: MyPage(),
    );
  }
}
```

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
BlocProvider to Automatically Dispose Blocs | [link](https://github.com/felangel/bloc/pull/344)

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
Breaking change to `flutter_bloc` API which will be included in `flutter_bloc` v0.16.0