### PR TITLE
Update BlocProvider to Automatically Dispose Bloc

### DIFF
--- a/packages/flutter_bloc/CHANGELOG.md
+++ b/packages/flutter_bloc/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.17.0
+
+Update `BlocProvider` to automatically `dispose` the provided bloc and Documentation Updates.
+
 # 0.16.0
 
 Update `BlocProvider` to expose `builder` and `dispose` ([#344](https://github.com/felangel/bloc/pull/344) and [#347](https://github.com/felangel/bloc/pull/347)) and Documentation Updates

--- a/packages/flutter_bloc/README.md
+++ b/packages/flutter_bloc/README.md
@@ -46,12 +46,20 @@ BlocBuilder(
 )
 ```
 
-**BlocProvider** is a Flutter widget which provides a bloc to its children via `BlocProvider.of<T>(context)`. It is used as a DI widget so that a single instance of a bloc can be provided to multiple widgets within a subtree.
+**BlocProvider** is a Flutter widget which provides a bloc to its children via `BlocProvider.of<T>(context)`. It is used as a DI widget so that a single instance of a bloc can be provided to multiple widgets within a subtree. By default, `BlocProvider` automatically disposes the provided bloc when the `BlocProvider` widget is disposed. In a few edge cases, such as when using `BlocProvider` to provide an existing bloc to another route, it might be necessary to prevent automatic disposal of the bloc. In those cases, the `dispose` property can be set to `false`.
 
 ```dart
+// Automatically disposes the instance of BlocA
+// Recommended usage for most cases.
 BlocProvider(
   builder: (BuildContext context) => BlocA(),
-  dispose: (BuildContext context, BlocA bloc) => bloc.dispose(),
+  child: ChildA(),
+);
+
+// Does not automatically dispose the instance of BlocA.
+BlocProvider(
+  builder: (BuildContext context) => BlocA(),
+  dispose: false,
   child: ChildA(),
 );
 ```
@@ -69,13 +77,10 @@ By using `BlocProviderTree` we can go from:
 ```dart
 BlocProvider<BlocA>(
   builder: (BuildContext context) => BlocA(),
-  dispose: (BuildContext context, BlocA blocA) => blocA.dispose(),
   child: BlocProvider<BlocB>(
     builder: (BuildContext context) => BlocB(),
-    dispose: (BuildContext context, BlocB blocB) => blocB.dispose(),
     child: BlocProvider<BlocC>(
       builder: (BuildContext context) => BlocC(),
-      dispose: (BuildContext context, BlocC blocC) => blocC.dispose(),
       child: ChildA(),
     )
   )
@@ -89,15 +94,12 @@ BlocProviderTree(
   blocProviders: [
     BlocProvider<BlocA>(
       builder: (BuildContext context) => BlocA(),
-      dispose: (BuildContext context, BlocA blocA) => blocA.dispose(),
     ),
     BlocProvider<BlocB>(
       builder: (BuildContext context) => BlocB(),
-      dispose: (BuildContext context, BlocB blocB) => blocB.dispose(),
     ),
     BlocProvider<BlocC>(
       builder: (BuildContext context) => BlocC(),
-      dispose: (BuildContext context, BlocC blocC) => blocC.dispose(),
     ),
   ],
   child: ChildA(),

--- a/packages/flutter_bloc/example/lib/main.dart
+++ b/packages/flutter_bloc/example/lib/main.dart
@@ -32,11 +32,9 @@ void main() {
       blocProviders: [
         BlocProvider<CounterBloc>(
           builder: (context) => CounterBloc(),
-          dispose: (context, bloc) => bloc.dispose(),
         ),
         BlocProvider<ThemeBloc>(
           builder: (context) => ThemeBloc(),
-          dispose: (context, bloc) => bloc.dispose(),
         )
       ],
       child: App(),

--- a/packages/flutter_bloc/lib/src/bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/bloc_provider.dart
@@ -8,16 +8,14 @@ typedef BlocProviderBuilder<T extends Bloc<dynamic, dynamic>> = T Function(
   BuildContext context,
 );
 
-/// Signature for the `dispose` function which takes the [BuildContext] and is invoked
-/// when the `BlocProvider` is disposed.
-typedef BlocProviderDispose<T extends Bloc<dynamic, dynamic>> = void Function(
-  BuildContext context,
-  T bloc,
-);
-
 /// A Flutter widget which provides a bloc to its children via `BlocProvider.of(context)`.
 /// It is used as a DI widget so that a single instance of a bloc can be provided
 /// to multiple widgets within a subtree.
+///
+/// By default, `BlocProvider` automatically disposes the provided bloc when the `BlocProvider`
+/// widget is disposed. In a few edge cases, such as when using `BlocProvider` to provide an
+/// existing bloc to another route, it might be necessary to prevent automatic disposal of the bloc.
+/// In those cases, the `dispose` property can be set to `false`.
 class BlocProvider<T extends Bloc<dynamic, dynamic>> extends StatefulWidget {
   /// The [BlocProviderBuilder] which creates the [Bloc]
   /// that will be made available throughout the subtree.
@@ -26,16 +24,17 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>> extends StatefulWidget {
   /// The [Widget] and its descendants which will have access to the [Bloc].
   final Widget child;
 
-  /// The [BlocProviderDispose] which is called when the `BlocProvider` is disposed.
-  /// In most cases, the provided bloc should be disposed in the `dispose` callback.
-  /// The main exception to the rule is if a `BlocProvider` is used to provide
-  /// an existing bloc to a new route.
-  final BlocProviderDispose<T> dispose;
+  /// A `bool` which determines whether or not the [Bloc] should be automatically disposed
+  /// by [BlocProvider].
+  ///
+  /// The default value is `true` and it should only be set to `false` in very few cases
+  /// (such as where the multiple `BlocProviders` are used to provide the same [Bloc] across different routes).
+  final bool dispose;
 
   BlocProvider({
     Key key,
     @required this.builder,
-    this.dispose,
+    this.dispose = true,
     this.child,
   })  : assert(builder != null),
         super(key: key);
@@ -106,7 +105,9 @@ class _BlocProviderState<T extends Bloc<dynamic, dynamic>>
 
   @override
   void dispose() {
-    widget.dispose?.call(context, _bloc);
+    if (widget.dispose ?? true) {
+      _bloc.dispose();
+    }
     super.dispose();
   }
 }

--- a/packages/flutter_bloc/pubspec.yaml
+++ b/packages/flutter_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_bloc
 description: Flutter Widgets that make it easy to implement the BLoC (Business Logic Component) design pattern. Built to be used with the bloc state management package.
-version: 0.16.0
+version: 0.17.0
 author: Felix Angelov <felangelov@gmail.com>
 repository: https://github.com/felangel/bloc
 issue_tracker: https://github.com/felangel/bloc/issues


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
YES

## Description
Go from:

```dart
BlocProvider(
    builder: (context) => CounterBloc(),
    dispose: (context, bloc) => bloc.dispose(),
    child: Container(),
)
```

to

```dart
BlocProvider(
    builder: (context) => CounterBloc(),
    child: Container(),
)
```

And from:
```dart
BlocProvider(
    builder: (context) => CounterBloc(),
    dispose: (context, bloc) => null,
    child: Container(),
)
```

to

```dart
BlocProvider(
    builder: (context) => CounterBloc(),
    dispose: false,
    child: Container(),
)
```

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
Breaking API Change to `BlocProvider` which will be released in flutter_bloc v0.17.0