### PR TITLE
Expose ImmutableProvider and ImmutableProviderTree

### DIFF
--- a/packages/flutter_bloc/CHANGELOG.md
+++ b/packages/flutter_bloc/CHANGELOG.md
@@ -1,6 +1,10 @@
+# 0.18.0
+
+Expose `ImmutableProvider` & `ImmutableProviderTree` to enable developers to provide immutable values, such as repositories, throughout the widget tree ([#364](https://github.com/felangel/bloc/pull/364)) and Documentation Updates
+
 # 0.17.0
 
-Update `BlocProvider` to automatically `dispose` the provided bloc ([#349](https://github.com/felangel/bloc/pull/349)) and Documentation Updates.
+Update `BlocProvider` to automatically `dispose` the provided bloc ([#349](https://github.com/felangel/bloc/pull/349)) and Documentation Updates
 
 # 0.16.0
 

--- a/packages/flutter_bloc/README.md
+++ b/packages/flutter_bloc/README.md
@@ -180,6 +180,57 @@ BlocListenerTree(
 )
 ```
 
+**ImmutableProvider** is a Flutter widget which provides a value to its children via `ImmutableProvider.of<T>(context)`. It is used as a DI widget so that a single instance of an immutable value can be provided to multiple widgets within a subtree. `BlocProvider` is built on top of `ImmutableProvider` and should be used to provide blocs whereas `ImmutableProvider` should be used for other values such as repositories.
+
+```dart
+ImmutableProvider(
+  value: Repository(),
+  child: ChildA(),
+);
+```
+
+then from `ChildA` we can retrieve the `Repository` instance with:
+
+```dart
+ImmutableProvider.of<Repository>(context)
+```
+
+**ImmutableProviderTree** is a Flutter widget that merges multiple `ImmutableProvider` widgets into one.
+`ImmutableProviderTree` improves the readability and eliminates the need to nest multiple `ImmutableProviders`.
+By using `ImmutableProviderTree` we can go from:
+
+```dart
+ImmutableProvider<ValueA>(
+  value: ValueA(),
+  child: ImmutableProvider<ValueB>(
+    value: ValueB(),
+    child: ImmutableProvider<ValueC>(
+      value: ValueC(),
+      child: ChildA(),
+    )
+  )
+)
+```
+
+to:
+
+```dart
+ImmutableProviderTree(
+  immutableProviders: [
+    ImmutableProvider<ValueA>(
+      value: ValueA(),
+    ),
+    ImmutableProvider<ValueB>(
+      value: ValueB(),
+    ),
+    ImmutableProvider<ValueC>(
+      value: ValueC(),
+    ),
+  ],
+  child: ChildA(),
+)
+```
+
 ## Usage
 
 Lets take a look at how to use `BlocBuilder` to hook up a `CounterPage` widget to a `CounterBloc`.

--- a/packages/flutter_bloc/lib/flutter_bloc.dart
+++ b/packages/flutter_bloc/lib/flutter_bloc.dart
@@ -5,3 +5,5 @@ export './src/bloc_listener.dart';
 export './src/bloc_listener_tree.dart';
 export './src/bloc_provider.dart';
 export './src/bloc_provider_tree.dart';
+export './src/immutable_provider.dart';
+export './src/immutable_provider_tree.dart';

--- a/packages/flutter_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/bloc_listener.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:bloc/bloc.dart';
 import 'package:flutter/widgets.dart';
 
+import 'copyable.dart';
+
 /// Signature for the listener function which takes the [BuildContext] along with the bloc state
 /// and is responsible for executing in response to state changes.
 typedef BlocWidgetListener<S> = void Function(BuildContext context, S state);
@@ -13,7 +15,7 @@ typedef BlocWidgetListener<S> = void Function(BuildContext context, S state);
 /// such as navigation, showing a [SnackBar], showing a [Dialog], etc...
 /// The `listener` is guaranteed to only be called once for each state change unlike the
 /// `builder` in [BlocBuilder].
-class BlocListener<E, S> extends BlocListenerBase<E, S> {
+class BlocListener<E, S> extends BlocListenerBase<E, S> with Copyable {
   /// The [Bloc] whose state will be listened to.
   /// Whenever the bloc's state changes, `listener` will be invoked.
   final Bloc<E, S> bloc;
@@ -36,9 +38,10 @@ class BlocListener<E, S> extends BlocListenerBase<E, S> {
         assert(listener != null),
         super(key: key, bloc: bloc, listener: listener);
 
-  /// Clone the current [BlocListener] with a new child [Widget].
+  /// Clones the current [BlocListener] with a new child [Widget].
   /// All other values, including [Key], [Bloc] and [BlocWidgetListener] are
   /// preserved.
+  @override
   BlocListener<E, S> copyWith(Widget child) {
     return BlocListener<E, S>(
       key: key,

--- a/packages/flutter_bloc/lib/src/bloc_listener_tree.dart
+++ b/packages/flutter_bloc/lib/src/bloc_listener_tree.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import 'tree_buildable.dart';
+
 /// A Flutter [Widget] that merges multiple [BlocListener] widgets into one widget tree.
 ///
 /// [BlocListenerTree] improves the readability and eliminates the need
@@ -50,7 +52,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 /// into a tree of nested [BlocListener] widgets.
 /// As a result, the only advantage of using [BlocListenerTree] is improved
 /// readability due to the reduction in nesting and boilerplate.
-class BlocListenerTree extends StatelessWidget {
+class BlocListenerTree extends TreeBuildable<BlocListener> {
   /// The [BlocListener] list which is converted into a tree of [BlocListener] widgets.
   /// The tree of [BlocListener] widgets is created in order meaning the first [BlocListener]
   /// will be the top-most [BlocListener] and the last [BlocListener] will be a direct ancestor
@@ -64,16 +66,5 @@ class BlocListenerTree extends StatelessWidget {
     Key key,
     @required this.blocListeners,
     @required this.child,
-  })  : assert(blocListeners != null),
-        assert(child != null),
-        super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    Widget tree = child;
-    for (final blocListener in blocListeners.reversed) {
-      tree = blocListener.copyWith(tree);
-    }
-    return tree;
-  }
+  }) : super(key: key, copyables: blocListeners, child: child);
 }

--- a/packages/flutter_bloc/lib/src/bloc_provider_tree.dart
+++ b/packages/flutter_bloc/lib/src/bloc_provider_tree.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import 'tree_buildable.dart';
+
 /// A Flutter [Widget] that merges multiple [BlocProvider] widgets into one widget tree.
 ///
 /// [BlocProviderTree] improves the readability and eliminates the need
@@ -10,11 +12,11 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 ///
 /// ```dart
 /// BlocProvider<BlocA>(
-///   bloc: BlocA(),
+///   builder: (BuildContext context) => BlocA(),
 ///   child: BlocProvider<BlocB>(
-///     bloc: BlocB(),
+///     builder: (BuildContext context) => BlocB(),
 ///     child: BlocProvider<BlocC>(
-///       value: BlocC(),
+///       builder: (BuildContext context) => BlocC(),
 ///       child: ChildA(),
 ///     )
 ///   )
@@ -26,9 +28,15 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 /// ```dart
 /// BlocProviderTree(
 ///   blocProviders: [
-///     BlocProvider<BlocA>(bloc: BlocA()),
-///     BlocProvider<BlocB>(bloc: BlocB()),
-///     BlocProvider<BlocC>(bloc: BlocC()),
+///     BlocProvider<BlocA>(
+///       builder: (BuildContext context) => BlocA(),
+///     ),
+///     BlocProvider<BlocB>(
+///       builder: (BuildContext context) => BlocB(),
+///     ),
+///     BlocProvider<BlocC>(
+///       builder: (BuildContext context) => BlocC(),
+///     ),
 ///   ],
 ///   child: ChildA(),
 /// )
@@ -38,7 +46,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 /// into a tree of nested [BlocProvider] widgets.
 /// As a result, the only advantage of using [BlocProviderTree] is improved
 /// readability due to the reduction in nesting and boilerplate.
-class BlocProviderTree extends StatelessWidget {
+class BlocProviderTree extends TreeBuildable<BlocProvider> {
   /// The [BlocProvider] list which is converted into a tree of [BlocProvider] widgets.
   /// The tree of [BlocProvider] widgets is created in order meaning the first [BlocProvider]
   /// will be the top-most [BlocProvider] and the last [BlocProvider] will be a direct ancestor
@@ -53,16 +61,5 @@ class BlocProviderTree extends StatelessWidget {
     Key key,
     @required this.blocProviders,
     @required this.child,
-  })  : assert(blocProviders != null),
-        assert(child != null),
-        super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    Widget tree = child;
-    for (final blocProvider in blocProviders.reversed) {
-      tree = blocProvider.copyWith(tree);
-    }
-    return tree;
-  }
+  }) : super(key: key, copyables: blocProviders, child: child);
 }

--- a/packages/flutter_bloc/lib/src/copyable.dart
+++ b/packages/flutter_bloc/lib/src/copyable.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/widgets.dart';
+
+/// A mixin on `Widget` which exposes a `copyWith` method.
+mixin Copyable on Widget {
+  /// `copyWith` takes a child `Widget` and must create a copy of itself with the new child.
+  /// All values except child (including [Key]) should be preserved.
+  Widget copyWith(Widget child);
+}

--- a/packages/flutter_bloc/lib/src/immutable_provider.dart
+++ b/packages/flutter_bloc/lib/src/immutable_provider.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+import 'copyable.dart';
+
+/// A Flutter widget which provides an immutable value to its children via `ImmutableProvider.of(context)`.
+/// It is used as a DI widget so that a single instance of an immutable value can be provided
+/// to multiple widgets within a subtree.
+class ImmutableProvider<T> extends InheritedWidget with Copyable {
+  /// The immutable value which will be made availablee to the subtree
+  final T value;
+
+  const ImmutableProvider({
+    Key key,
+    @required this.value,
+    Widget child,
+  }) : super(key: key, child: child);
+
+  @override
+  bool updateShouldNotify(InheritedWidget _) => false;
+
+  /// Necessary to obtain generic [Type]
+  /// https://github.com/dart-lang/sdk/issues/11923
+  static Type _typeOf<T>() => T;
+
+  /// Method that allows widgets to access the value as long as their `BuildContext`
+  /// contains an `ImmutableProvider` instance.
+  static T of<T>(BuildContext context) {
+    final type = _typeOf<ImmutableProvider<T>>();
+    final provider = context
+        .ancestorInheritedElementForWidgetOfExactType(type)
+        ?.widget as ImmutableProvider<T>;
+
+    if (provider == null) {
+      throw FlutterError(
+        """
+        ImmutableProvider.of() called with a context that does not contain a value of type $T.
+        No ancestor could be found starting from the context that was passed to ImmutableProvider.of<$T>().
+        This can happen if the context you use comes from a widget above the ImmutableProvider.
+        This can also happen if you used ImmutableProviderTree and didn\'t explicity provide 
+        the ImmutableProvider types: ImmutableProvider(value: $T()) instead of ImmutableProvider<$T>(value: $T()).
+        The context used was: $context
+        """,
+      );
+    }
+
+    return provider.value;
+  }
+
+  /// Clones the current [ImmutableProvider] with a new child [Widget].
+  /// All other values, including `key` and `value` are preserved.
+  @override
+  ImmutableProvider<T> copyWith(Widget child) {
+    return ImmutableProvider<T>(
+      key: key,
+      value: value,
+      child: child,
+    );
+  }
+}

--- a/packages/flutter_bloc/lib/src/immutable_provider_tree.dart
+++ b/packages/flutter_bloc/lib/src/immutable_provider_tree.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'tree_buildable.dart';
+
+/// A Flutter [Widget] that merges multiple [ImmutableProvider] widgets into one widget tree.
+///
+/// [ImmutableProviderTree] improves the readability and eliminates the need
+/// to nest multiple [ImmutableProviders].
+///
+/// By using [ImmutableProviderTree] we can go from:
+///
+/// ```dart
+/// ImmutableProvider<ValueA>(
+///   value: ValueA(),
+///   child: ImmutableProvider<ValueB>(
+///     value: ValueB(),
+///     child: ImmutableProvider<ValueC>(
+///       value: ValueC(),
+///       child: ChildA(),
+///     )
+///   )
+/// )
+/// ```
+///
+/// to:
+///
+/// ```dart
+/// ImmutableProviderTree(
+///   immutableProviders: [
+///     ImmutableProvider<ValueA>(value: ValueA()),
+///     ImmutableProvider<ValueB>(value: ValueB()),
+///     ImmutableProvider<ValueC>(value: ValueC()),
+///   ],
+///   child: ChildA(),
+/// )
+/// ```
+///
+/// [ImmutableProviderTree] converts the [ImmutableProvider] list
+/// into a tree of nested [ImmutableProvider] widgets.
+/// As a result, the only advantage of using [ImmutableProviderTree] is improved
+/// readability due to the reduction in nesting and boilerplate.
+class ImmutableProviderTree extends TreeBuildable<ImmutableProvider> {
+  /// The [ImmutableProvider] list which is converted into a tree of [ImmutableProvider] widgets.
+  /// The tree of [ImmutableProvider] widgets is created in order meaning the first [ImmutableProvider]
+  /// will be the top-most [ImmutableProvider] and the last [ImmutableProvider] will be a direct ancestor
+  /// of the `child` [Widget].
+  final List<ImmutableProvider> immutableProviders;
+
+  /// The [Widget] and its descendants which will have access to every value provided by `immutableProviders`.
+  /// This [Widget] will be a direct descendent of the last [ImmutableProvider] in `immutableProviders`.
+  final Widget child;
+
+  const ImmutableProviderTree({
+    Key key,
+    @required this.immutableProviders,
+    @required this.child,
+  }) : super(key: key, copyables: immutableProviders, child: child);
+}

--- a/packages/flutter_bloc/lib/src/tree_buildable.dart
+++ b/packages/flutter_bloc/lib/src/tree_buildable.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/widgets.dart';
+
+import 'copyable.dart';
+
+/// [TreeBuildable] converts the [Copyable] list
+/// into a tree of nested [Copyable] widgets.
+/// As a result, the only advantage of using [TreeBuildable] is improved
+/// readability due to the reduction in nesting and boilerplate.
+class TreeBuildable<T extends Copyable> extends StatelessWidget {
+  /// The [Copyable] list which is converted into a tree of [Copyable] widgets.
+  /// The tree of [Copyable] widgets is created in order meaning the first [Copyable]
+  /// will be the top-most [Copyable] and the last [Copyable] will be a direct ancestor
+  /// of the `child` [Widget].
+  final List<T> copyables;
+
+  /// This [Widget] will be a direct descendent of the last [Copyable] in `Copyables`.
+  final Widget child;
+
+  const TreeBuildable({
+    Key key,
+    @required this.copyables,
+    @required this.child,
+  })  : assert(copyables != null),
+        assert(child != null),
+        super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    Widget tree = child;
+    for (final copyable in copyables.reversed) {
+      tree = copyable.copyWith(tree);
+    }
+    return tree;
+  }
+}

--- a/packages/flutter_bloc/pubspec.yaml
+++ b/packages/flutter_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_bloc
 description: Flutter Widgets that make it easy to implement the BLoC (Business Logic Component) design pattern. Built to be used with the bloc state management package.
-version: 0.17.0
+version: 0.18.0
 author: Felix Angelov <felangelov@gmail.com>
 repository: https://github.com/felangel/bloc
 issue_tracker: https://github.com/felangel/bloc/issues

--- a/packages/flutter_bloc/test/bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/bloc_provider_test.dart
@@ -190,16 +190,6 @@ class CounterBloc extends Bloc<CounterEvent, int> {
   }
 }
 
-class SimpleBloc extends Bloc<dynamic, String> {
-  @override
-  String get initialState => '';
-
-  @override
-  Stream<String> mapEventToState(dynamic event) async* {
-    yield 'state';
-  }
-}
-
 void main() {
   group('BlocProvider', () {
     testWidgets('throws if initialized with no builder',

--- a/packages/flutter_bloc/test/bloc_provider_tree_test.dart
+++ b/packages/flutter_bloc/test/bloc_provider_tree_test.dart
@@ -5,36 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:bloc/bloc.dart';
 
-class MyAppNoBlocProvidersNoChild extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return BlocProviderTree(
-      blocProviders: null,
-      child: null,
-    );
-  }
-}
-
-class MyAppNoBlocProviders extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return BlocProviderTree(
-      blocProviders: null,
-      child: Container(),
-    );
-  }
-}
-
-class MyAppNoChild extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return BlocProviderTree(
-      blocProviders: [],
-      child: null,
-    );
-  }
-}
-
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -149,20 +119,44 @@ void main() {
   group('BlocProviderTree', () {
     testWidgets('throws if initialized with no BlocProviders and no child',
         (WidgetTester tester) async {
-      await tester.pumpWidget(MyAppNoBlocProvidersNoChild());
-      expect(tester.takeException(), isInstanceOf<AssertionError>());
+      try {
+        await tester.pumpWidget(
+          BlocProviderTree(
+            blocProviders: null,
+            child: null,
+          ),
+        );
+      } catch (error) {
+        expect(error, isAssertionError);
+      }
     });
 
     testWidgets('throws if initialized with no bloc',
         (WidgetTester tester) async {
-      await tester.pumpWidget(MyAppNoBlocProviders());
-      expect(tester.takeException(), isInstanceOf<AssertionError>());
+      try {
+        await tester.pumpWidget(
+          BlocProviderTree(
+            blocProviders: null,
+            child: Container(),
+          ),
+        );
+      } catch (error) {
+        expect(error, isAssertionError);
+      }
     });
 
     testWidgets('throws if initialized with no child',
         (WidgetTester tester) async {
-      await tester.pumpWidget(MyAppNoChild());
-      expect(tester.takeException(), isInstanceOf<AssertionError>());
+      try {
+        await tester.pumpWidget(
+          BlocProviderTree(
+            blocProviders: [],
+            child: null,
+          ),
+        );
+      } catch (error) {
+        expect(error, isAssertionError);
+      }
     });
 
     testWidgets('passes blocs to children', (WidgetTester tester) async {
@@ -176,11 +170,14 @@ void main() {
         ),
       );
 
-      final Finder _counterFinder = find.byKey((Key('counter_text')));
-      expect(_counterFinder, findsOneWidget);
+      final MaterialApp materialApp = tester.widget(find.byType(MaterialApp));
+      expect(materialApp.theme, ThemeData.light());
 
-      final Text _counterText = _counterFinder.evaluate().first.widget as Text;
-      expect(_counterText.data, '0');
+      final Finder counterFinder = find.byKey((Key('counter_text')));
+      expect(counterFinder, findsOneWidget);
+
+      final Text counterText = tester.widget(counterFinder);
+      expect(counterText.data, '0');
     });
   });
 }

--- a/packages/flutter_bloc/test/immutable_provider_test.dart
+++ b/packages/flutter_bloc/test/immutable_provider_test.dart
@@ -1,0 +1,214 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class MyApp extends StatelessWidget {
+  final Value _value;
+  final Widget _child;
+
+  const MyApp({
+    Key key,
+    @required Value value,
+    bool dispose,
+    @required Widget child,
+  })  : _value = value,
+        _child = child,
+        super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: ImmutableProvider<Value>(
+        value: _value,
+        child: _child,
+      ),
+    );
+  }
+}
+
+class MyStatefulApp extends StatefulWidget {
+  final Widget child;
+
+  const MyStatefulApp({
+    Key key,
+    @required this.child,
+  }) : super(key: key);
+
+  @override
+  _MyStatefulAppState createState() => _MyStatefulAppState();
+}
+
+class _MyStatefulAppState extends State<MyStatefulApp> {
+  Value _value;
+
+  @override
+  void initState() {
+    _value = Value(0);
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: ImmutableProvider<Value>(
+        value: _value,
+        child: Scaffold(
+          appBar: AppBar(
+            title: Text('Counter'),
+            actions: <Widget>[
+              IconButton(
+                key: Key('iconButtonKey'),
+                icon: Icon(Icons.edit),
+                tooltip: 'Change State',
+                onPressed: () {
+                  setState(() {
+                    _value = Value(0);
+                  });
+                },
+              )
+            ],
+          ),
+          body: widget.child,
+        ),
+      ),
+    );
+  }
+}
+
+class MyAppNoProvider extends StatelessWidget {
+  final Widget _child;
+
+  const MyAppNoProvider({
+    Key key,
+    @required Widget child,
+  })  : _child = child,
+        super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: _child,
+    );
+  }
+}
+
+class CounterPage extends StatelessWidget {
+  final Function onBuild;
+
+  const CounterPage({Key key, this.onBuild}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    onBuild?.call();
+    Value value = ImmutableProvider.of<Value>(context);
+    assert(value != null);
+
+    return Scaffold(
+      appBar: AppBar(title: Text('Value')),
+      body: Center(
+        child: Text(
+          '${value.data}',
+          key: Key('value_data'),
+          style: TextStyle(fontSize: 24.0),
+        ),
+      ),
+    );
+  }
+}
+
+class RoutePage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: RaisedButton(
+        key: Key('route_button'),
+        onPressed: () {
+          Navigator.of(context).pushReplacement(
+            MaterialPageRoute<Widget>(builder: (context) => Container()),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class Value {
+  final int data;
+
+  Value(this.data);
+}
+
+void main() {
+  group('ImmutableProvider', () {
+    testWidgets('throws if initialized with no value',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(MyApp(
+        value: null,
+        child: CounterPage(),
+      ));
+      expect(tester.takeException(), isInstanceOf<AssertionError>());
+    });
+
+    testWidgets('throws if initialized with no child',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(MyApp(
+        value: Value(0),
+        child: null,
+      ));
+      expect(tester.takeException(), isInstanceOf<AssertionError>());
+    });
+
+    testWidgets('passes value to children', (WidgetTester tester) async {
+      final value = Value(0);
+      final CounterPage _child = CounterPage();
+      await tester.pumpWidget(MyApp(
+        value: value,
+        child: _child,
+      ));
+
+      final Finder _counterFinder = find.byKey((Key('value_data')));
+      expect(_counterFinder, findsOneWidget);
+
+      final Text _counterText = _counterFinder.evaluate().first.widget as Text;
+      expect(_counterText.data, '0');
+    });
+
+    testWidgets(
+        'should throw FlutterError if ImmutableProvider is not found in current context',
+        (WidgetTester tester) async {
+      final Widget _child = CounterPage();
+      await tester.pumpWidget(MyAppNoProvider(
+        child: _child,
+      ));
+      final dynamic exception = tester.takeException();
+      final expectedMessage = """
+        ImmutableProvider.of() called with a context that does not contain a value of type Value.
+        No ancestor could be found starting from the context that was passed to ImmutableProvider.of<Value>().
+        This can happen if the context you use comes from a widget above the ImmutableProvider.
+        This can also happen if you used ImmutableProviderTree and didn\'t explicity provide 
+        the ImmutableProvider types: ImmutableProvider(value: Value()) instead of ImmutableProvider<Value>(value: Value()).
+        The context used was: CounterPage(dirty)
+        """;
+      expect(exception is FlutterError, true);
+      expect(exception.message, expectedMessage);
+    });
+
+    testWidgets(
+        'should not rebuild widgets that inherited the value if the value is changed',
+        (WidgetTester tester) async {
+      int numBuilds = 0;
+      final Widget _child = CounterPage(
+        onBuild: () {
+          numBuilds++;
+        },
+      );
+      await tester.pumpWidget(MyStatefulApp(
+        child: _child,
+      ));
+      await tester.tap(find.byKey(Key('iconButtonKey')));
+      await tester.pumpAndSettle();
+      expect(numBuilds, 1);
+    });
+  });
+}

--- a/packages/flutter_bloc/test/immutable_provider_tree_test.dart
+++ b/packages/flutter_bloc/test/immutable_provider_tree_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Demo',
+      home: CounterPage(),
+    );
+  }
+}
+
+class CounterPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final ValueA valueA = ImmutableProvider.of<ValueA>(context);
+    final ValueB valueB = ImmutableProvider.of<ValueB>(context);
+
+    return Scaffold(
+      appBar: AppBar(title: Text('Counter')),
+      body: Column(
+        children: [
+          Text(
+            '${valueA.data}',
+            key: Key('valueA_data'),
+            style: TextStyle(fontSize: 24.0),
+          ),
+          Text(
+            '${valueB.data}',
+            key: Key('valueB_data'),
+            style: TextStyle(fontSize: 24.0),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class ValueA {
+  final int data;
+
+  ValueA(this.data);
+}
+
+class ValueB {
+  final int data;
+
+  ValueB(this.data);
+}
+
+void main() {
+  group('ImmutableProviderTree', () {
+    testWidgets('throws if initialized with no immutableProviders and no child',
+        (WidgetTester tester) async {
+      try {
+        await tester.pumpWidget(
+          ImmutableProviderTree(
+            immutableProviders: null,
+            child: null,
+          ),
+        );
+      } catch (error) {
+        expect(error, isAssertionError);
+      }
+    });
+
+    testWidgets('throws if initialized with no immutableProviders',
+        (WidgetTester tester) async {
+      try {
+        await tester.pumpWidget(
+          ImmutableProviderTree(
+            immutableProviders: null,
+            child: Container(),
+          ),
+        );
+      } catch (error) {
+        expect(error, isAssertionError);
+      }
+    });
+
+    testWidgets('throws if initialized with no child',
+        (WidgetTester tester) async {
+      try {
+        await tester.pumpWidget(
+          ImmutableProviderTree(
+            immutableProviders: [],
+            child: null,
+          ),
+        );
+      } catch (error) {
+        expect(error, isAssertionError);
+      }
+    });
+
+    testWidgets('passes values to children', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        ImmutableProviderTree(
+          immutableProviders: [
+            ImmutableProvider<ValueA>(value: ValueA(0)),
+            ImmutableProvider<ValueB>(value: ValueB(1)),
+          ],
+          child: MyApp(),
+        ),
+      );
+
+      final Finder valueAFinder = find.byKey((Key('valueA_data')));
+      expect(valueAFinder, findsOneWidget);
+
+      final Text valueAText = tester.widget(valueAFinder);
+      expect(valueAText.data, '0');
+
+      final Finder valueBFinder = find.byKey((Key('valueB_data')));
+      expect(valueBFinder, findsOneWidget);
+
+      final Text valueBText = tester.widget(valueBFinder);
+      expect(valueBText.data, '1');
+    });
+  });
+}


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
Allow developers to provide immutable values, such as repositories, throughout the widget tree (#354).

### Expose
- `ImmutableProvider`
- `ImmutableProviderTree`

### Refactor
- `BlocProvider`
- `BlocProviderTree`
- `BlocListener`
- `BlocListenerTree`

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
None