### PR TITLE
BlocListener should only be called on state changes

### DIFF
--- a/packages/flutter_bloc/CHANGELOG.md
+++ b/packages/flutter_bloc/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.18.2
+
+Fix `BlocListener` bug where `listener` gets called even when no state change occurs ([#368](https://github.com/felangel/bloc/issues/368)).
+
 # 0.18.1
 
 Minor Documentation Updates

--- a/packages/flutter_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/bloc_listener.dart
@@ -114,7 +114,7 @@ class _BlocListenerBaseState<E, S> extends State<BlocListenerBase<E, S>> {
 
   void _subscribe() {
     if (widget.bloc.state != null) {
-      _subscription = widget.bloc.state.listen((S state) {
+      _subscription = widget.bloc.state.skip(1).listen((S state) {
         widget.listener.call(context, state);
       });
     }

--- a/packages/flutter_bloc/pubspec.yaml
+++ b/packages/flutter_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_bloc
 description: Flutter Widgets that make it easy to implement the BLoC (Business Logic Component) design pattern. Built to be used with the bloc state management package.
-version: 0.18.1
+version: 0.18.2
 author: Felix Angelov <felangelov@gmail.com>
 repository: https://github.com/felangel/bloc
 issue_tracker: https://github.com/felangel/bloc/issues

--- a/packages/flutter_bloc/test/bloc_listener_test.dart
+++ b/packages/flutter_bloc/test/bloc_listener_test.dart
@@ -133,7 +133,7 @@ void main() {
       expect(find.byKey(targetKey), findsOneWidget);
     });
 
-    testWidgets('calls listener on every state change, including initial',
+    testWidgets('calls listener on single state change',
         (WidgetTester tester) async {
       int latestState;
       int listenerCallCount = 0;
@@ -151,7 +151,7 @@ void main() {
       );
       counterBloc.dispatch(CounterEvent.increment);
       expectLater(counterBloc.state, emitsInOrder(expectedStates)).then((_) {
-        expect(listenerCallCount, 2);
+        expect(listenerCallCount, 1);
         expect(latestState, 1);
       });
     });
@@ -175,7 +175,7 @@ void main() {
       counterBloc.dispatch(CounterEvent.increment);
       counterBloc.dispatch(CounterEvent.increment);
       expectLater(counterBloc.state, emitsInOrder(expectedStates)).then((_) {
-        expect(listenerCallCount, 3);
+        expect(listenerCallCount, 2);
         expect(latestState, 2);
       });
     });
@@ -198,19 +198,19 @@ void main() {
 
       await tester.tap(incrementFinder);
       await tester.pumpAndSettle();
-      expect(listenerCallCount, 2);
+      expect(listenerCallCount, 1);
       expect(latestState, 1);
 
       await tester.tap(incrementFinder);
       await tester.pumpAndSettle();
-      expect(listenerCallCount, 3);
+      expect(listenerCallCount, 2);
       expect(latestState, 2);
 
       await tester.tap(resetBlocFinder);
       await tester.pumpAndSettle();
       await tester.tap(incrementFinder);
       await tester.pumpAndSettle();
-      expect(listenerCallCount, 5);
+      expect(listenerCallCount, 3);
       expect(latestState, 1);
     });
 
@@ -232,19 +232,19 @@ void main() {
 
       await tester.tap(incrementFinder);
       await tester.pumpAndSettle();
-      expect(listenerCallCount, 2);
+      expect(listenerCallCount, 1);
       expect(latestState, 1);
 
       await tester.tap(incrementFinder);
       await tester.pumpAndSettle();
-      expect(listenerCallCount, 3);
+      expect(listenerCallCount, 2);
       expect(latestState, 2);
 
       await tester.tap(noopBlocFinder);
       await tester.pumpAndSettle();
       await tester.tap(incrementFinder);
       await tester.pumpAndSettle();
-      expect(listenerCallCount, 4);
+      expect(listenerCallCount, 3);
       expect(latestState, 3);
     });
   });

--- a/packages/flutter_bloc/test/bloc_listener_tree_test.dart
+++ b/packages/flutter_bloc/test/bloc_listener_tree_test.dart
@@ -107,12 +107,12 @@ void main() {
       counterBlocB.dispatch(CounterEvent.increment);
 
       expectLater(counterBlocA.state, emitsInOrder(expectedStatesA)).then((_) {
-        expect(listenerCallCountA, 3);
+        expect(listenerCallCountA, 2);
         expect(latestStateA, 2);
       });
 
       expectLater(counterBlocB.state, emitsInOrder(expectedStatesB)).then((_) {
-        expect(listenerCallCountB, 2);
+        expect(listenerCallCountB, 1);
         expect(latestStateB, 1);
       });
     });


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description

Revert changes introduced in #214 in order to guarantee that `BlocListener` is only called on state changes (addresses #368).

## Related PRs

branch | PR
------ | ------
master | #214 

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
Revert changes introduced in #214