### PR TITLE
Renamed BlocListenerTree to MultiBlocListener

### DIFF
--- a/packages/flutter_bloc/README.md
+++ b/packages/flutter_bloc/README.md
@@ -138,9 +138,9 @@ BlocListener(
 )
 ```
 
-**BlocListenerTree** is a Flutter widget that merges multiple `BlocListener` widgets into one.
-`BlocListenerTree` improves the readability and eliminates the need to nest multiple `BlocListeners`.
-By using `BlocListenerTree` we can go from:
+**MutliBlocListener** is a Flutter widget that merges multiple `BlocListener` widgets into one.
+`MutliBlocListener` improves the readability and eliminates the need to nest multiple `BlocListeners`.
+By using `MutliBlocListener` we can go from:
 
 ```dart
 BlocListener<BlocAEvent, BlocAState>(
@@ -161,8 +161,8 @@ BlocListener<BlocAEvent, BlocAState>(
 to:
 
 ```dart
-BlocListenerTree(
-  blocListeners: [
+MutliBlocListener(
+  listeners: [
     BlocListener<BlocAEvent, BlocAState>(
       bloc: BlocA(),
       listener: (BuildContext context, BlocAState state) {},

--- a/packages/flutter_bloc/lib/flutter_bloc.dart
+++ b/packages/flutter_bloc/lib/flutter_bloc.dart
@@ -3,6 +3,7 @@ library flutter_bloc;
 export './src/bloc_builder.dart';
 export './src/bloc_listener.dart';
 export './src/bloc_provider.dart';
+export './src/multi_bloc_listener.dart';
 export './src/multi_bloc_provider.dart';
 export './src/multi_repository_provider.dart';
 export './src/repository_provider.dart';

--- a/packages/flutter_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/bloc_listener.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
-import 'package:flutter/widgets.dart';
+
 import 'package:bloc/bloc.dart';
+import 'package:flutter/widgets.dart';
 
 /// Signature for the listener function which takes the [BuildContext] along with the bloc state
 /// and is responsible for executing in response to state changes.
@@ -34,6 +35,18 @@ class BlocListener<E, S> extends BlocListenerBase<E, S> {
   })  : assert(bloc != null),
         assert(listener != null),
         super(key: key, bloc: bloc, listener: listener);
+
+  /// Clones the current [BlocListener] with a new child [Widget].
+  /// All other values, including `key`, `bloc` and `listener` are preserved.
+  /// preserved.
+  BlocListener<E, S> copyWith(Widget child) {
+    return BlocListener<E, S>(
+      key: key,
+      bloc: bloc,
+      listener: listener,
+      child: child,
+    );
+  }
 
   @override
   Widget build(BuildContext context) => child;

--- a/packages/flutter_bloc/lib/src/multi_bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/multi_bloc_listener.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+/// A Flutter [Widget] that merges multiple [BlocListener] widgets into one widget tree.
+///
+/// [MultiBlocListener] improves the readability and eliminates the need
+/// to nest multiple [BlocListeners].
+///
+/// By using [MultiBlocListener] we can go from:
+///
+/// ```dart
+/// BlocListener<BlocAEvent, BlocAState>(
+///   bloc: BlocA(),
+///   listener: (BuildContext context, BlocAState state) {},
+///   child: BlocListener<BlocBEvent, BlocBState>(
+///     bloc: BlocB(),
+///     listener: (BuildContext context, BlocBState state) {},
+///     child: BlocListener<BlocCEvent, BlocCState>(
+///       bloc: BlocC(),
+///       listener: (BuildContext context, BlocCState state) {},
+///       child: ChildA(),
+///     ),
+///   ),
+/// )
+/// ```
+///
+/// to:
+///
+/// ```dart
+/// MutliBlocListener(
+///   listeners: [
+///     BlocListener<BlocAEvent, BlocAState>(
+///       bloc: BlocA(),
+///       listener: (BuildContext context, BlocAState state) {},
+///     ),
+///     BlocListener<BlocBEvent, BlocBState>(
+///       bloc: BlocB(),
+///       listener: (BuildContext context, BlocBState state) {},
+///     ),
+///     BlocListener<BlocCEvent, BlocCState>(
+///       bloc: BlocC(),
+///       listener: (BuildContext context, BlocCState state) {},
+///     ),
+///   ],
+///   child: ChildA(),
+/// )
+/// ```
+///
+/// [MultiBlocListener] converts the [BlocListener] list
+/// into a tree of nested [BlocListener] widgets.
+/// As a result, the only advantage of using [MultiBlocListener] is improved
+/// readability due to the reduction in nesting and boilerplate.
+class MultiBlocListener extends StatelessWidget {
+  /// The [BlocListener] list which is converted into a tree of [BlocListener] widgets.
+  /// The tree of [BlocListener] widgets is created in order meaning the first [BlocListener]
+  /// will be the top-most [BlocListener] and the last [BlocListener] will be a direct ancestor
+  /// of the `child` [Widget].
+  final List<BlocListener> listeners;
+
+  /// This [Widget] will be a direct descendent of the last [BlocListener] in `listeners`.
+  final Widget child;
+
+  const MultiBlocListener({
+    Key key,
+    @required this.listeners,
+    @required this.child,
+  })  : assert(listeners != null),
+        assert(child != null),
+        super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    Widget tree = child;
+    for (final blocListener in listeners.reversed) {
+      tree = blocListener.copyWith(tree);
+    }
+    return tree;
+  }
+}

--- a/packages/flutter_bloc/test/multi_bloc_listener_test.dart
+++ b/packages/flutter_bloc/test/multi_bloc_listener_test.dart
@@ -1,0 +1,120 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+enum CounterEvent { increment }
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+  @override
+  int get initialState => 0;
+
+  @override
+  Stream<int> mapEventToState(CounterEvent event) async* {
+    switch (event) {
+      case CounterEvent.increment:
+        yield currentState + 1;
+        break;
+    }
+  }
+}
+
+void main() {
+  group('MultiBlocListener', () {
+    testWidgets('throws if initialized with no listeners and no child',
+        (WidgetTester tester) async {
+      try {
+        await tester.pumpWidget(
+          MultiBlocListener(
+            listeners: null,
+            child: null,
+          ),
+        );
+      } catch (error) {
+        expect(error, isAssertionError);
+      }
+    });
+
+    testWidgets('throws if initialized with no listeners',
+        (WidgetTester tester) async {
+      try {
+        await tester.pumpWidget(
+          MultiBlocListener(
+            listeners: null,
+            child: Container(),
+          ),
+        );
+      } catch (error) {
+        expect(error, isAssertionError);
+      }
+    });
+
+    testWidgets('throws if initialized with no child',
+        (WidgetTester tester) async {
+      try {
+        await tester.pumpWidget(
+          MultiBlocListener(
+            listeners: [],
+            child: null,
+          ),
+        );
+      } catch (error) {
+        expect(error, isAssertionError);
+      }
+    });
+
+    testWidgets('calls listeners on state changes',
+        (WidgetTester tester) async {
+      int latestStateA;
+      int listenerCallCountA = 0;
+      final counterBlocA = CounterBloc();
+      final expectedStatesA = [0, 1, 2];
+
+      int latestStateB;
+      int listenerCallCountB = 0;
+      final counterBlocB = CounterBloc();
+      final expectedStatesB = [0, 1];
+
+      await tester.pumpWidget(
+        MultiBlocListener(
+          listeners: [
+            BlocListener<CounterEvent, int>(
+              bloc: counterBlocA,
+              listener: (BuildContext context, int state) {
+                listenerCallCountA++;
+                latestStateA = state;
+              },
+            ),
+            BlocListener<CounterEvent, int>(
+              bloc: counterBlocB,
+              listener: (BuildContext context, int state) {
+                listenerCallCountB++;
+                latestStateB = state;
+              },
+            ),
+          ],
+          child: Container(key: Key('multiBlocListener_child')),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(Key('multiBlocListener_child')), findsOneWidget);
+
+      counterBlocA.dispatch(CounterEvent.increment);
+      counterBlocA.dispatch(CounterEvent.increment);
+      counterBlocB.dispatch(CounterEvent.increment);
+
+      expectLater(counterBlocA.state, emitsInOrder(expectedStatesA)).then((_) {
+        expect(listenerCallCountA, 2);
+        expect(latestStateA, 2);
+      });
+
+      expectLater(counterBlocB.state, emitsInOrder(expectedStatesB)).then((_) {
+        expect(listenerCallCountB, 1);
+        expect(latestStateB, 1);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Status
**HOLD**

## Breaking Changes
YES

## Related PRs

branch | PR
------ | ------
provider | [link](https://github.com/felangel/bloc/pull/385)


## Todos
- [x] Tests
- [x] Documentation
- [x] Examples
