### PR TITLE
Add optional condition to BlocListener

### DIFF
--- a/packages/flutter_bloc/CHANGELOG.md
+++ b/packages/flutter_bloc/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.19.1
+
+Added optional `condition` to `BlocListener` to control listener calls
+
 # 0.19.0
 
 Addresses [#354](https://github.com/felangel/bloc/issues/354)

--- a/packages/flutter_bloc/pubspec.yaml
+++ b/packages/flutter_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_bloc
 description: Flutter Widgets that make it easy to implement the BLoC (Business Logic Component) design pattern. Built to be used with the bloc state management package.
-version: 0.19.0
+version: 0.19.1
 author: Felix Angelov <felangelov@gmail.com>
 repository: https://github.com/felangel/bloc
 issue_tracker: https://github.com/felangel/bloc/issues

--- a/packages/flutter_bloc/test/bloc_listener_test.dart
+++ b/packages/flutter_bloc/test/bloc_listener_test.dart
@@ -247,5 +247,161 @@ void main() {
       expect(listenerCallCount, 3);
       expect(latestState, 3);
     });
+
+    testWidgets(
+        'calls condition on single state change with correct previous and current states',
+        (WidgetTester tester) async {
+      int latestPreviousState;
+      int latestCurrentState;
+      int conditionCallCount = 0;
+      final counterBloc = CounterBloc();
+      final expectedStates = [0, 1];
+      await tester.pumpWidget(
+        BlocListener(
+          bloc: counterBloc,
+          condition: (int previous, int current) {
+            conditionCallCount++;
+            latestPreviousState = previous;
+            latestCurrentState = current;
+
+            return true;
+          },
+          listener: (BuildContext context, int state) {},
+          child: Container(),
+        ),
+      );
+      counterBloc.dispatch(CounterEvent.increment);
+      expectLater(counterBloc.state, emitsInOrder(expectedStates)).then((_) {
+        expect(conditionCallCount, 1);
+        expect(latestPreviousState, 0);
+        expect(latestCurrentState, 1);
+      });
+    });
+
+    testWidgets(
+        'calls condition on multiple state change with correct previous and current states',
+        (WidgetTester tester) async {
+      int latestPreviousState;
+      int latestCurrentState;
+      int conditionCallCount = 0;
+      final counterBloc = CounterBloc();
+      final expectedStates = [0, 1, 2];
+      await tester.pumpWidget(
+        BlocListener(
+          bloc: counterBloc,
+          condition: (int previous, int current) {
+            conditionCallCount++;
+            latestPreviousState = previous;
+            latestCurrentState = current;
+
+            return true;
+          },
+          listener: (BuildContext context, int state) {},
+          child: Container(),
+        ),
+      );
+      counterBloc.dispatch(CounterEvent.increment);
+      counterBloc.dispatch(CounterEvent.increment);
+
+      expectLater(counterBloc.state, emitsInOrder(expectedStates)).then((_) {
+        expect(conditionCallCount, 2);
+        expect(latestPreviousState, 1);
+        expect(latestCurrentState, 2);
+      });
+    });
+
+    testWidgets(
+        'not call listener when condition return false on single state change',
+        (WidgetTester tester) async {
+      int listenerCallCount = 0;
+      final counterBloc = CounterBloc();
+      final expectedStates = [0, 1];
+      await tester.pumpWidget(
+        BlocListener(
+          bloc: counterBloc,
+          condition: (int previous, int current) => false,
+          listener: (BuildContext context, int state) {
+            listenerCallCount++;
+          },
+          child: Container(),
+        ),
+      );
+      counterBloc.dispatch(CounterEvent.increment);
+      expectLater(counterBloc.state, emitsInOrder(expectedStates)).then((_) {
+        expect(listenerCallCount, 0);
+      });
+    });
+
+    testWidgets(
+        'call listener when condition return true on single state change',
+        (WidgetTester tester) async {
+      int listenerCallCount = 0;
+      final counterBloc = CounterBloc();
+      final expectedStates = [0, 1];
+      await tester.pumpWidget(
+        BlocListener(
+          bloc: counterBloc,
+          condition: (int previous, int current) => true,
+          listener: (BuildContext context, int state) {
+            listenerCallCount++;
+          },
+          child: Container(),
+        ),
+      );
+      counterBloc.dispatch(CounterEvent.increment);
+      expectLater(counterBloc.state, emitsInOrder(expectedStates)).then((_) {
+        expect(listenerCallCount, 1);
+      });
+    });
+
+    testWidgets(
+        'not calls listener when condition return false on multiple state change',
+        (WidgetTester tester) async {
+      int listenerCallCount = 0;
+      final counterBloc = CounterBloc();
+      final expectedStates = [0, 1, 2, 3, 4];
+      await tester.pumpWidget(
+        BlocListener(
+          bloc: counterBloc,
+          condition: (int previous, int current) => false,
+          listener: (BuildContext context, int state) {
+            listenerCallCount++;
+          },
+          child: Container(),
+        ),
+      );
+      counterBloc.dispatch(CounterEvent.increment);
+      counterBloc.dispatch(CounterEvent.increment);
+      counterBloc.dispatch(CounterEvent.increment);
+      counterBloc.dispatch(CounterEvent.increment);
+      expectLater(counterBloc.state, emitsInOrder(expectedStates)).then((_) {
+        expect(listenerCallCount, 0);
+      });
+    });
+
+    testWidgets(
+        'calls listener when condition return true on multiple state change',
+        (WidgetTester tester) async {
+      int listenerCallCount = 0;
+      final counterBloc = CounterBloc();
+      final expectedStates = [0, 1, 2, 3, 4];
+      await tester.pumpWidget(
+        BlocListener(
+          bloc: counterBloc,
+          condition: (int previous, int current) => true,
+          listener: (BuildContext context, int state) {
+            listenerCallCount++;
+          },
+          child: Container(),
+        ),
+      );
+      counterBloc.dispatch(CounterEvent.increment);
+      counterBloc.dispatch(CounterEvent.increment);
+      counterBloc.dispatch(CounterEvent.increment);
+      counterBloc.dispatch(CounterEvent.increment);
+      expectLater(counterBloc.state, emitsInOrder(expectedStates)).then((_) {
+        expect(listenerCallCount, 4);
+      });
+    });
   });
 }


### PR DESCRIPTION
## Status
**Development**

## Breaking Changes
 NO

## Description

Add an optional `condition` property to `BlocListener` which takes the `previousState` and `currentState` as arguments and must return a `bool` which determines whether or not call listener

## Usage

```dart
import 'package:equatable/equatable.dart';

enum SessionState { notInitialized, signedIn, notSignedIn }

class AuthState extends Equatable {
  final bool isLoading;
  final SessionState sessionState;

  AuthState(this.isLoading, this.sessionState)
      : super([isLoading, sessionState]);
}
```

```dart
...
@override
  Stream<AuthState> mapEventToState(AuthEvent event) async*{
    if (event == AuthEvent.SignOut) {
      yield currentState.copyWith(true);
      await _signOut();
      yield currentState.copyWith(false, SessionState.notSignedIn);
    }
  }
...
```

```dart
...
@override
  Widget build(BuildContext context) {
    return BlocListener(
      bloc: authBloc,
      condition: (AuthState previous, AuthState current) =>
          previous.sessionState != current.sessionState,
      listener: (BuildContext context, AuthState state) {
        if (state.sessionState == SessionState.signedIn) {
          Navigator.pushNamed(context, HomeScreen.routeName);
        }
      },
      child: MyChild(),
    );
  }
...
```

In the above example, the listener `push` a widget only when `sessionState`  change to `signedIn`.

Without condition, this widget push multiple times `HomeScreen` when `isLoading` change and `sessionState` is `signedIn` , for example when try to sign out, the state change because `isLoading` change but while `sessionState` is `signedIn`, the listener `push` `HomeScreen` again.

This is only a example, you can imagine other cases with other bloc, when you need to show a dialog, snakcbar, etc.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Examples

## Impact to Remaining Code Base
> None
