### PR TITLE
flutter_bloc v0.20.0-rc

### DIFF
--- a/packages/flutter_bloc/example/lib/main.dart
+++ b/packages/flutter_bloc/example/lib/main.dart
@@ -27,33 +27,26 @@ class SimpleBlocDelegate extends BlocDelegate {
 
 void main() {
   BlocSupervisor.delegate = SimpleBlocDelegate();
-  runApp(
-    MultiBlocProvider(
-      providers: [
-        BlocProvider<CounterBloc>(
-          builder: (context) => CounterBloc(),
-        ),
-        BlocProvider<ThemeBloc>(
-          builder: (context) => ThemeBloc(),
-        ),
-      ],
-      child: App(),
-    ),
-  );
+  runApp(App());
 }
 
 class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder(
-      bloc: BlocProvider.of<ThemeBloc>(context),
-      builder: (_, ThemeData theme) {
-        return MaterialApp(
-          title: 'Flutter Demo',
-          home: CounterPage(),
-          theme: theme,
-        );
-      },
+    return BlocProvider<ThemeBloc>(
+      builder: (context) => ThemeBloc(),
+      child: BlocBuilder<ThemeBloc, ThemeData>(
+        builder: (context, theme) {
+          return MaterialApp(
+            title: 'Flutter Demo',
+            home: BlocProvider(
+              builder: (context) => CounterBloc(),
+              child: CounterPage(),
+            ),
+            theme: theme,
+          );
+        },
+      ),
     );
   }
 }
@@ -61,14 +54,13 @@ class App extends StatelessWidget {
 class CounterPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final CounterBloc counterBloc = BlocProvider.of<CounterBloc>(context);
-    final ThemeBloc themeBloc = BlocProvider.of<ThemeBloc>(context);
+    final counterBloc = BlocProvider.of<CounterBloc>(context);
+    final themeBloc = BlocProvider.of<ThemeBloc>(context);
 
     return Scaffold(
       appBar: AppBar(title: Text('Counter')),
-      body: BlocBuilder<CounterEvent, int>(
-        bloc: counterBloc,
-        builder: (BuildContext context, int count) {
+      body: BlocBuilder<CounterBloc, int>(
+        builder: (context, count) {
           return Center(
             child: Text(
               '$count',

--- a/packages/flutter_bloc/lib/src/bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/bloc_provider.dart
@@ -3,7 +3,11 @@ import 'package:meta/meta.dart';
 import 'package:provider/provider.dart';
 import 'package:bloc/bloc.dart';
 
-class BlocProvider<T extends Bloc<dynamic, dynamic>> extends Provider<T> {
+class BlocProvider<T extends Bloc<dynamic, dynamic>>
+    extends ValueDelegateWidget<T> implements SingleChildCloneableWidget {
+  /// The [Widget] and its descendants which will have access to the [Bloc].
+  final Widget child;
+
   /// Takes a [ValueBuilder] that is responsible for
   /// building the bloc and a child which will have access to the bloc via `BlocProvider.of(context)`.
   /// It is used as a dependency injection (DI) widget so that a single instance of a bloc can be provided
@@ -19,12 +23,14 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>> extends Provider<T> {
   /// ```
   BlocProvider({
     Key key,
-    @required ValueBuilder<T> builder,
+    ValueBuilder<T> builder,
     Widget child,
-  }) : super(
+  }) : this._(
           key: key,
-          builder: builder,
-          dispose: (_, bloc) => bloc?.dispose(),
+          delegate: BuilderStateDelegate<T>(
+            builder,
+            dispose: (_, bloc) => bloc?.dispose(),
+          ),
           child: child,
         );
 
@@ -45,11 +51,19 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>> extends Provider<T> {
     Key key,
     @required T value,
     Widget child,
-  }) : super.value(
+  }) : this._(
           key: key,
-          value: value,
+          delegate: SingleValueDelegate<T>(value),
           child: child,
         );
+
+  /// Internal constructor responsible for creating the `BlocProvider`.
+  /// Used by the `BlocProvider` default and `value` constructors.
+  BlocProvider._({
+    Key key,
+    @required ValueStateDelegate<T> delegate,
+    this.child,
+  }) : super(key: key, delegate: delegate);
 
   /// Method that allows widgets to access a bloc instance as long as their `BuildContext`
   /// contains a [BlocProvider] instance.
@@ -80,5 +94,24 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>> extends Provider<T> {
         """,
       );
     }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return InheritedProvider<T>(
+      value: delegate.value,
+      child: Builder(
+        builder: (context) => child,
+      ),
+    );
+  }
+
+  @override
+  BlocProvider<T> cloneWithChild(Widget child) {
+    return BlocProvider<T>._(
+      key: key,
+      delegate: delegate,
+      child: child,
+    );
   }
 }

--- a/packages/flutter_bloc/lib/src/multi_bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/multi_bloc_listener.dart
@@ -20,15 +20,12 @@ class MultiBlocListener extends StatelessWidget {
   /// By using [MultiBlocListener] we can go from:
   ///
   /// ```dart
-  /// BlocListener<BlocAEvent, BlocAState>(
-  ///   bloc: BlocA(),
-  ///   listener: (BuildContext context, BlocAState state) {},
-  ///   child: BlocListener<BlocBEvent, BlocBState>(
-  ///     bloc: BlocB(),
-  ///     listener: (BuildContext context, BlocBState state) {},
-  ///     child: BlocListener<BlocCEvent, BlocCState>(
-  ///       bloc: BlocC(),
-  ///       listener: (BuildContext context, BlocCState state) {},
+  /// BlocListener<BlocA, BlocAState>(
+  ///   listener: (context, state) {},
+  ///   child: BlocListener<BlocB, BlocBState>(
+  ///     listener: (context, state) {},
+  ///     child: BlocListener<BlocC, BlocCState>(
+  ///       listener: (context, state) {},
   ///       child: ChildA(),
   ///     ),
   ///   ),
@@ -40,17 +37,14 @@ class MultiBlocListener extends StatelessWidget {
   /// ```dart
   /// MutliBlocListener(
   ///   listeners: [
-  ///     BlocListener<BlocAEvent, BlocAState>(
-  ///       bloc: BlocA(),
-  ///       listener: (BuildContext context, BlocAState state) {},
+  ///     BlocListener<BlocA, BlocAState>(
+  ///       listener: (context, state) {},
   ///     ),
-  ///     BlocListener<BlocBEvent, BlocBState>(
-  ///       bloc: BlocB(),
-  ///       listener: (BuildContext context, BlocBState state) {},
+  ///     BlocListener<BlocB, BlocBState>(
+  ///       listener: (context, state) {},
   ///     ),
-  ///     BlocListener<BlocCEvent, BlocCState>(
-  ///       bloc: BlocC(),
-  ///       listener: (BuildContext context, BlocCState state) {},
+  ///     BlocListener<BlocC, BlocCState>(
+  ///       listener: (context, state) {},
   ///     ),
   ///   ],
   ///   child: ChildA(),

--- a/packages/flutter_bloc/test/bloc_listener_test.dart
+++ b/packages/flutter_bloc/test/bloc_listener_test.dart
@@ -91,7 +91,7 @@ void main() {
         (WidgetTester tester) async {
       try {
         await tester.pumpWidget(
-          BlocListener<dynamic, dynamic>(
+          BlocListener<Bloc, dynamic>(
             bloc: null,
             listener: null,
             child: null,
@@ -107,7 +107,7 @@ void main() {
         (WidgetTester tester) async {
       try {
         await tester.pumpWidget(
-          BlocListener(
+          BlocListener<CounterBloc, int>(
             bloc: CounterBloc(),
             listener: null,
             child: null,
@@ -268,6 +268,37 @@ void main() {
           },
           listener: (BuildContext context, int state) {},
           child: Container(),
+        ),
+      );
+      counterBloc.dispatch(CounterEvent.increment);
+      expectLater(counterBloc.state, emitsInOrder(expectedStates)).then((_) {
+        expect(conditionCallCount, 1);
+        expect(latestPreviousState, 0);
+        expect(latestCurrentState, 1);
+      });
+    });
+
+    testWidgets('infers the bloc from the context if the bloc is not provided',
+        (WidgetTester tester) async {
+      int latestPreviousState;
+      int latestCurrentState;
+      int conditionCallCount = 0;
+      final counterBloc = CounterBloc();
+      final expectedStates = [0, 1];
+      await tester.pumpWidget(
+        BlocProvider.value(
+          value: counterBloc,
+          child: BlocListener<CounterBloc, int>(
+            condition: (int previous, int current) {
+              conditionCallCount++;
+              latestPreviousState = previous;
+              latestCurrentState = current;
+
+              return true;
+            },
+            listener: (BuildContext context, int state) {},
+            child: Container(),
+          ),
         ),
       );
       counterBloc.dispatch(CounterEvent.increment);

--- a/packages/flutter_bloc/test/bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/bloc_provider_test.dart
@@ -125,7 +125,7 @@ class CounterPage extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(title: Text('Counter')),
-      body: BlocBuilder<CounterEvent, int>(
+      body: BlocBuilder<CounterBloc, int>(
         bloc: _counterBloc,
         builder: (BuildContext context, int count) {
           if (onBuild != null) {
@@ -232,6 +232,25 @@ void main() {
       final Text _counterText = _counterFinder.evaluate().first.widget as Text;
       expect(_counterText.data, '0');
     });
+
+    testWidgets(
+      'passes bloc to children within same build',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: BlocProvider(
+                builder: (context) => CounterBloc(),
+                child: BlocBuilder<CounterBloc, int>(
+                  builder: (context, state) => Text('state: $state'),
+                ),
+              ),
+            ),
+          ),
+        );
+        expect(find.text('state: 0'), findsOneWidget);
+      },
+    );
 
     testWidgets('calls dispose on bloc automatically',
         (WidgetTester tester) async {

--- a/packages/flutter_bloc/test/multi_bloc_listener_test.dart
+++ b/packages/flutter_bloc/test/multi_bloc_listener_test.dart
@@ -80,14 +80,14 @@ void main() {
       await tester.pumpWidget(
         MultiBlocListener(
           listeners: [
-            BlocListener<CounterEvent, int>(
+            BlocListener<CounterBloc, int>(
               bloc: counterBlocA,
               listener: (BuildContext context, int state) {
                 listenerCallCountA++;
                 latestStateA = state;
               },
             ),
-            BlocListener<CounterEvent, int>(
+            BlocListener<CounterBloc, int>(
               bloc: counterBlocB,
               listener: (BuildContext context, int state) {
                 listenerCallCountB++;

--- a/packages/flutter_bloc/test/multi_bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/multi_bloc_provider_test.dart
@@ -102,7 +102,7 @@ class CounterPage extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(title: Text('Counter')),
-      body: BlocBuilder<CounterEvent, int>(
+      body: BlocBuilder<CounterBloc, int>(
         bloc: _counterBloc,
         builder: (BuildContext context, int count) {
           return Center(


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
YES

## Description

### Automatic Bloc Lookup

Instead of having to manually do the bloc lookup for `BlocBuilder` and `BlocListener` whenever the bloc is not specified, the default behavior will be to lookup the bloc via `BlocProvider` automatically.

#### BlocBuilder Current Usage
```dart
BlocBuilder(
  bloc: BlocProvider.of<CounterBloc>(context),
  builder: (BuildContext context, int state) { ... },
) 
```

#### BlocBuilder Updated Usage
```dart
BlocBuilder<CounterBloc, int>(
  builder: (context, state) { ... },
)
```

#### BlocListener Current Usage
```dart
BlocListener(
  bloc: BlocProvider.of<CounterBloc>(context),
  listener: (int previousState, int currentState) => { ... },
)
```

#### BlocListener Updated Usage
```dart
BlocListener<CounterBloc, int>(
  listener: (previousState, currentState) => { ... },
)
```

### BlocProvider within the same build

It is now possible to provide and access a bloc within the same `build`

```dart
@override
Widget build(BuildContext context) {
  return BlocProvider(
    builder: (context) => CounterBloc(),
    child: BlocBuilder<CounterBloc, int>(
        builder: (context, state) { ... }
    ),
  );
}
```

## Todos
- [x] Tests
- [x] Documentation
- [X] Examples

## Impact to Remaining Code Base
Breaking change which will be included in flutter_bloc v0.20.0