### PR TITLE
Prevent implicit dynamic

### DIFF
--- a/extensions/vscode/snippets/snippets.json
+++ b/extensions/vscode/snippets/snippets.json
@@ -152,7 +152,7 @@
       "",
       "@immutable",
       "abstract class $1State extends Equatable {",
-      "\t$1State([List props = const []]) : super(props);",
+      "\t$1State([List props = const <dynamic>[]]) : super(props);",
       "}"
     ]
   },
@@ -165,7 +165,7 @@
       "",
       "@immutable",
       "abstract class $1Event extends Equatable {",
-      "\t$1Event([List props = const []]) : super(props);",
+      "\t$1Event([List props = const <dynamic>[]]) : super(props);",
       "}"
     ]
   }


### PR DESCRIPTION
#Status
**READY**

## Breaking Changes
NO

## Description
Prevent implicit `dynamic` in the generated BloC code as it violates a commonly used dart analyzer rule: `implicit-dynamic: false`.
Making `dynamic` implicit encourages using it and makes it harder to find where it's being used.

## Related PRs

## Todos

## Steps to Test or Reproduce

## Impact to Remaining Code Base
