### PR TITLE
Add transformStates to bloc

### DIFF
--- a/packages/bloc/CHANGELOG.md
+++ b/packages/bloc/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.15.0
+
+- Removed Bloc `event` Stream ([#326](https://github.com/felangel/bloc/issues/326))
+- Renamed `transform` to `transformEvents`
+- Added `transformStates` ([#382](https://github.com/felangel/bloc/issues/382))
+
 # 0.14.4
 
 Additional Dependency and Documentation Updates.

--- a/packages/bloc/README.md
+++ b/packages/bloc/README.md
@@ -44,7 +44,9 @@ This design pattern helps to separate _presentation_ from _business logic_. Foll
 
 **dispatch** is a method that takes an `event` and triggers `mapEventToState`. `dispatch` may be called from the presentation layer or from within the Bloc (see examples) and notifies the Bloc of a new `event`.
 
-**transform** is a method that transforms the `Stream<Event>` along with a `next` function into a `Stream<State>`. Events that should be processed by `mapEventToState` need to be passed to `next`. **By default `asyncExpand` is used to ensure all events are processed in the order in which they are received**. You can override `transform` for advanced usage in order to manipulate the frequency and specificity with which `mapEventToState` is called as well as which events are processed.
+**transformEvents** is a method that transforms the `Stream<Event>` along with a `next` function into a `Stream<State>`. Events that should be processed by `mapEventToState` need to be passed to `next`. **By default `asyncExpand` is used to ensure all events are processed in the order in which they are received**. You can override `transformEvents` for advanced usage in order to manipulate the frequency and specificity with which `mapEventToState` is called as well as which events are processed.
+
+**transformStates** is a method that transforms the `Stream<State>` into a new `Stream<State>`. By default `transformStates` returns the incoming `Stream<State>`. You can override `transformStates` for advanced usage in order to manipulate the frequency and specificity at which `transitions` (state changes) occur.
 
 **onEvent** is a method that can be overridden to handle whenever an `Event` is dispatched. **It is a great place to add bloc-specific logging/analytics**.
 

--- a/packages/bloc/pubspec.yaml
+++ b/packages/bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc
 description: A predictable state management library that helps implement the BLoC (Business Logic Component) design pattern.
-version: 0.14.4
+version: 0.15.0
 author: Felix Angelov <felangelov@gmail.com>
 repository: https://github.com/felangel/bloc
 issue_tracker: https://github.com/felangel/bloc/issues

--- a/packages/bloc/test/helpers/complex/complex_bloc.dart
+++ b/packages/bloc/test/helpers/complex/complex_bloc.dart
@@ -9,22 +9,29 @@ class ComplexBloc extends Bloc<ComplexEvent, ComplexState> {
   ComplexState get initialState => ComplexStateA();
 
   @override
-  Stream<ComplexState> transform(Stream<ComplexEvent> events, next) {
-    return super.transform(
-      (events as Observable<ComplexEvent>).distinct(),
-      next,
-    );
+  Stream<ComplexState> transformEvents(events, next) {
+    return (events as Observable<ComplexEvent>).switchMap(next);
   }
 
   @override
-  Stream<ComplexState> mapEventToState(ComplexEvent event) {
+  Stream<ComplexState> mapEventToState(ComplexEvent event) async* {
     if (event is ComplexEventA) {
-      return Observable.just(ComplexStateA());
+      yield ComplexStateA();
+    } else if (event is ComplexEventB) {
+      yield ComplexStateB();
+    } else if (event is ComplexEventC) {
+      await Future<void>.delayed(Duration(milliseconds: 100));
+      yield ComplexStateC();
+    } else if (event is ComplexEventD) {
+      await Future<void>.delayed(Duration(milliseconds: 100));
+      yield ComplexStateD();
     }
-    if (event is ComplexEventB) {
-      return Observable.just(ComplexStateB());
-    }
-    return Observable.just(ComplexStateC());
+  }
+
+  @override
+  Stream<ComplexState> transformStates(states) {
+    return (states as Observable<ComplexState>)
+        .debounceTime(Duration(milliseconds: 50));
   }
 
   @override
@@ -36,5 +43,7 @@ class ComplexBloc extends Bloc<ComplexEvent, ComplexState> {
 
   @override
   int get hashCode =>
-      initialState.hashCode ^ mapEventToState.hashCode ^ transform.hashCode;
+      initialState.hashCode ^
+      mapEventToState.hashCode ^
+      transformEvents.hashCode;
 }

--- a/packages/bloc/test/helpers/complex/complex_event.dart
+++ b/packages/bloc/test/helpers/complex/complex_event.dart
@@ -12,7 +12,7 @@ class ComplexEventA extends ComplexEvent {
       other is ComplexEventA && runtimeType == other.runtimeType;
 
   @override
-  int get hashCode => runtimeType.hashCode;
+  int get hashCode => 0;
 }
 
 class ComplexEventB extends ComplexEvent {
@@ -27,7 +27,7 @@ class ComplexEventB extends ComplexEvent {
       other is ComplexEventB && runtimeType == other.runtimeType;
 
   @override
-  int get hashCode => runtimeType.hashCode;
+  int get hashCode => 1;
 }
 
 class ComplexEventC extends ComplexEvent {
@@ -42,5 +42,20 @@ class ComplexEventC extends ComplexEvent {
       other is ComplexEventC && runtimeType == other.runtimeType;
 
   @override
-  int get hashCode => runtimeType.hashCode;
+  int get hashCode => 2;
+}
+
+class ComplexEventD extends ComplexEvent {
+  @override
+  bool operator ==(
+    Object other,
+  ) =>
+      identical(
+        this,
+        other,
+      ) ||
+      other is ComplexEventD && runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => 3;
 }

--- a/packages/bloc/test/helpers/complex/complex_state.dart
+++ b/packages/bloc/test/helpers/complex/complex_state.dart
@@ -45,7 +45,7 @@ class ComplexStateC extends ComplexState {
   int get hashCode => 2;
 }
 
-class ComplexStateUnknown extends ComplexState {
+class ComplexStateD extends ComplexState {
   @override
   bool operator ==(
     Object other,
@@ -54,7 +54,7 @@ class ComplexStateUnknown extends ComplexState {
         this,
         other,
       ) ||
-      other is ComplexStateUnknown && runtimeType == other.runtimeType;
+      other is ComplexStateD && runtimeType == other.runtimeType;
 
   @override
   int get hashCode => 3;

--- a/packages/bloc/test/helpers/counter/counter_bloc.dart
+++ b/packages/bloc/test/helpers/counter/counter_bloc.dart
@@ -57,5 +57,7 @@ class CounterBloc extends Bloc<CounterEvent, int> {
 
   @override
   int get hashCode =>
-      initialState.hashCode ^ mapEventToState.hashCode ^ transform.hashCode;
+      initialState.hashCode ^
+      mapEventToState.hashCode ^
+      transformEvents.hashCode;
 }

--- a/packages/bloc/test/transition_test.dart
+++ b/packages/bloc/test/transition_test.dart
@@ -47,10 +47,10 @@ void main() {
           () {
         expect(
           () => Transition<TransitionEvent, TransitionState>(
-                currentState: null,
-                event: SimpleTransitionEvent(),
-                nextState: SimpleTransitionState(),
-              ),
+            currentState: null,
+            event: SimpleTransitionEvent(),
+            nextState: SimpleTransitionState(),
+          ),
           throwsA(
             TypeMatcher<AssertionError>(),
           ),
@@ -61,10 +61,10 @@ void main() {
           () {
         expect(
           () => Transition<TransitionEvent, TransitionState>(
-                currentState: SimpleTransitionState(),
-                event: null,
-                nextState: SimpleTransitionState(),
-              ),
+            currentState: SimpleTransitionState(),
+            event: null,
+            nextState: SimpleTransitionState(),
+          ),
           throwsA(
             TypeMatcher<AssertionError>(),
           ),
@@ -76,10 +76,10 @@ void main() {
           () {
         expect(
           () => Transition<TransitionEvent, TransitionState>(
-                currentState: SimpleTransitionState(),
-                event: SimpleTransitionEvent(),
-                nextState: null,
-              ),
+            currentState: SimpleTransitionState(),
+            event: SimpleTransitionEvent(),
+            nextState: null,
+          ),
           throwsA(
             TypeMatcher<AssertionError>(),
           ),


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
YES

## Description

- Removed Bloc `event` Stream ([#326](https://github.com/felangel/bloc/issues/326))
- Renamed `transform` to `transformEvents`
- Added `transformStates` ([#382](https://github.com/felangel/bloc/issues/382))

### Examples

#### Only Process Latest Event
```dart
  @override
  Stream<State> transformEvents(events, next) {
    return (events as Observable<Event>).switchMap(next);
  }
```

#### Debounce Events
```dart
  @override
  Stream<State> transformEvents(events, next) {
    return super.transformEvents(
      (events as Observable<Event>).debounceTime(
        Duration(milliseconds: 300),
      ),
      next,
    );
  }
```

#### Debounce States
```dart
  @override
  Stream<State> transformStates(states) {
    return (states as Observable<State>)
        .debounceTime(Duration(seconds: 100));
  }
```

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
Breaking changes to bloc which will be included in v0.15.0