### PR TITLE
Added 'const' for generated constructors

### DIFF
--- a/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/with_equatable/bloc_event.dart.template
+++ b/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/with_equatable/bloc_event.dart.template
@@ -3,5 +3,5 @@ import 'package:meta/meta.dart';
 
 @immutable
 abstract class ${bloc_pascal_case}Event extends Equatable {
-  ${bloc_pascal_case}Event([List props = const <dynamic>[]]) : super(props);
+  const ${bloc_pascal_case}Event([List props = const <dynamic>[]]) : super(props);
 }

--- a/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/with_equatable/bloc_state.dart.template
+++ b/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/with_equatable/bloc_state.dart.template
@@ -3,7 +3,7 @@ import 'package:meta/meta.dart';
 
 @immutable
 abstract class ${bloc_pascal_case}State extends Equatable {
-  ${bloc_pascal_case}State([List props = const <dynamic>[]]) : super(props);
+  const ${bloc_pascal_case}State([List props = const <dynamic>[]]) : super(props);
 }
 
 class Initial${bloc_pascal_case}State extends ${bloc_pascal_case}State {}

--- a/extensions/vscode/src/templates/bloc-event.template.ts
+++ b/extensions/vscode/src/templates/bloc-event.template.ts
@@ -16,7 +16,7 @@ import 'package:meta/meta.dart';
 
 @immutable
 abstract class ${pascalCaseBlocName}Event extends Equatable {
-  ${pascalCaseBlocName}Event([List props = const <dynamic>[]]) : super(props);
+  const ${pascalCaseBlocName}Event([List props = const <dynamic>[]]) : super(props);
 }
 `;
 }

--- a/extensions/vscode/src/templates/bloc-state.template.ts
+++ b/extensions/vscode/src/templates/bloc-state.template.ts
@@ -16,7 +16,7 @@ import 'package:meta/meta.dart';
 
 @immutable
 abstract class ${pascalCaseBlocName}State extends Equatable {
-  ${pascalCaseBlocName}State([List props = const <dynamic>[]]) : super(props);
+  const ${pascalCaseBlocName}State([List props = const <dynamic>[]]) : super(props);
 }
 
 class Initial${pascalCaseBlocName}State extends ${pascalCaseBlocName}State {}


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
Key word 'const' must be for linter prefer_const_constructors_in_immutables(https://dart-lang.github.io/linter/lints/prefer_const_constructors_in_immutables.html)

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Examples

## Steps to Test or Reproduce

```
- Run generate with Equatable flag
```

## Impact to Remaining Code Base
This PR will affect:

* Generate *State and *Event classes in mode with Equatable
