### PR TITLE
Add BlocBuilder2...9

### DIFF
--- a/packages/flutter_bloc/lib/src/bloc_builder.dart
+++ b/packages/flutter_bloc/lib/src/bloc_builder.dart
@@ -5,9 +5,11 @@ import 'package:flutter/widgets.dart';
 import 'package:bloc/bloc.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+/// {@template flutter_bloc.bloc_builder.bloc_widget_builder}
 /// Signature for the builder function which takes the [BuildContext] and state
 /// and is responsible for returning a [Widget] which is to be rendered.
 /// This is analogous to the `builder` function in [StreamBuilder].
+/// {@endtemplate}
 typedef BlocWidgetBuilder<S> = Widget Function(BuildContext context, S state);
 
 /// Signature for the condition function which takes the previous state and the current state
@@ -16,12 +18,15 @@ typedef BlocWidgetBuilder<S> = Widget Function(BuildContext context, S state);
 typedef BlocBuilderCondition<S> = bool Function(S previous, S current);
 
 class BlocBuilder<B extends Bloc<dynamic, S>, S> extends BlocBuilderBase<B, S> {
+  /// {@template flutter_bloc.bloc_builder.builder}
   /// The `builder` function which will be invoked on each widget build.
   /// The `builder` takes the [BuildContext] and current bloc state and
   /// must return a [Widget].
   /// This is analogous to the `builder` function in [StreamBuilder].
+  /// {@endtemplate}
   final BlocWidgetBuilder<S> builder;
 
+  /// {@template flutter_bloc.bloc_builder.constructor}
   /// [BlocBuilder] handles building a widget in response to new states.
   /// [BlocBuilder] is analogous to [StreamBuilder] but has simplified API
   /// to reduce the amount of boilerplate code needed as well as bloc-specific performance improvements.
@@ -71,6 +76,7 @@ class BlocBuilder<B extends Bloc<dynamic, S>, S> extends BlocBuilderBase<B, S> {
   ///   }
   ///)
   /// ```
+  /// {@endtemplate}
   const BlocBuilder({
     Key key,
     @required this.builder,
@@ -83,6 +89,796 @@ class BlocBuilder<B extends Bloc<dynamic, S>, S> extends BlocBuilderBase<B, S> {
   Widget build(BuildContext context, S state) => builder(context, state);
 }
 
+/// {@macro flutter_bloc.bloc_builder.bloc_widget_builder}
+typedef BlocWidgetBuilder2<StateA, StateB> = Widget Function(
+  BuildContext context,
+  StateA stateA,
+  StateB stateB,
+);
+
+class BlocBuilder2<BlocA extends Bloc<dynamic, StateA>, StateA,
+    BlocB extends Bloc<dynamic, StateB>, StateB> extends StatelessWidget {
+  /// {@macro flutter_bloc.bloc_builder.builder}
+  final BlocWidgetBuilder2<StateA, StateB> builder;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateA> conditionA;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateB> conditionB;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc}
+  final BlocA blocA;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocB blocB;
+
+  /// {@macro flutter_bloc.bloc_builder.constructor}
+  const BlocBuilder2({
+    @required this.builder,
+    this.conditionA,
+    this.conditionB,
+    this.blocA,
+    this.blocB,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<BlocA, StateA>(
+      bloc: blocA,
+      condition: conditionA,
+      builder: (_, stateA) => BlocBuilder<BlocB, StateB>(
+        bloc: blocB,
+        condition: conditionB,
+        builder: (_, stateB) => builder(context, stateA, stateB),
+      ),
+    );
+  }
+}
+
+/// {@macro flutter_bloc.bloc_builder.bloc_widget_builder}
+typedef BlocWidgetBuilder3<StateA, StateB, StateC> = Widget Function(
+  BuildContext context,
+  StateA stateA,
+  StateB stateB,
+  StateC stateC,
+);
+
+class BlocBuilder3<
+    BlocA extends Bloc<dynamic, StateA>,
+    StateA,
+    BlocB extends Bloc<dynamic, StateB>,
+    StateB,
+    BlocC extends Bloc<dynamic, StateC>,
+    StateC> extends StatelessWidget {
+  /// {@macro flutter_bloc.bloc_builder.builder}
+  final BlocWidgetBuilder3<StateA, StateB, StateC> builder;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateA> conditionA;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateB> conditionB;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateC> conditionC;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocA blocA;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocB blocB;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocC blocC;
+
+  /// {@template flutter_bloc.bloc_builder.constructor}
+  const BlocBuilder3({
+    @required this.builder,
+    this.conditionA,
+    this.conditionB,
+    this.conditionC,
+    this.blocA,
+    this.blocB,
+    this.blocC,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder2<BlocA, StateA, BlocB, StateB>(
+      blocA: blocA,
+      blocB: blocB,
+      conditionA: conditionA,
+      conditionB: conditionB,
+      builder: (_, stateA, stateB) => BlocBuilder<BlocC, StateC>(
+        bloc: blocC,
+        condition: conditionC,
+        builder: (_, stateC) => builder(context, stateA, stateB, stateC),
+      ),
+    );
+  }
+}
+
+/// {@macro flutter_bloc.bloc_builder.bloc_widget_builder}
+typedef BlocWidgetBuilder4<StateA, StateB, StateC, StateD> = Widget Function(
+  BuildContext context,
+  StateA stateA,
+  StateB stateB,
+  StateC stateC,
+  StateD stateD,
+);
+
+class BlocBuilder4<
+    BlocA extends Bloc<dynamic, StateA>,
+    StateA,
+    BlocB extends Bloc<dynamic, StateB>,
+    StateB,
+    BlocC extends Bloc<dynamic, StateC>,
+    StateC,
+    BlocD extends Bloc<dynamic, StateD>,
+    StateD> extends StatelessWidget {
+  /// {@macro flutter_bloc.bloc_builder.builder}
+  final BlocWidgetBuilder4<StateA, StateB, StateC, StateD> builder;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateA> conditionA;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateB> conditionB;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateC> conditionC;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateD> conditionD;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocA blocA;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocB blocB;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocC blocC;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocD blocD;
+
+  /// {@template flutter_bloc.bloc_builder.constructor}
+  const BlocBuilder4({
+    @required this.builder,
+    this.conditionA,
+    this.conditionB,
+    this.conditionC,
+    this.conditionD,
+    this.blocA,
+    this.blocB,
+    this.blocC,
+    this.blocD,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder3<BlocA, StateA, BlocB, StateB, BlocC, StateC>(
+      blocA: blocA,
+      blocB: blocB,
+      blocC: blocC,
+      conditionA: conditionA,
+      conditionB: conditionB,
+      conditionC: conditionC,
+      builder: (_, stateA, stateB, stateC) => BlocBuilder<BlocD, StateD>(
+        bloc: blocD,
+        condition: conditionD,
+        builder: (_, stateD) =>
+            builder(context, stateA, stateB, stateC, stateD),
+      ),
+    );
+  }
+}
+
+/// {@macro flutter_bloc.bloc_builder.bloc_widget_builder}
+typedef BlocWidgetBuilder5<StateA, StateB, StateC, StateD, StateE> = Widget
+    Function(
+  BuildContext context,
+  StateA stateA,
+  StateB stateB,
+  StateC stateC,
+  StateD stateD,
+  StateE stateE,
+);
+
+class BlocBuilder5<
+    BlocA extends Bloc<dynamic, StateA>,
+    StateA,
+    BlocB extends Bloc<dynamic, StateB>,
+    StateB,
+    BlocC extends Bloc<dynamic, StateC>,
+    StateC,
+    BlocD extends Bloc<dynamic, StateD>,
+    StateD,
+    BlocE extends Bloc<dynamic, StateE>,
+    StateE> extends StatelessWidget {
+  /// {@macro flutter_bloc.bloc_builder.builder}
+  final BlocWidgetBuilder5<StateA, StateB, StateC, StateD, StateE> builder;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateA> conditionA;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateB> conditionB;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateC> conditionC;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateD> conditionD;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateE> conditionE;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocA blocA;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocB blocB;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocC blocC;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocD blocD;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocE blocE;
+
+  /// {@template flutter_bloc.bloc_builder.constructor}
+  const BlocBuilder5({
+    @required this.builder,
+    this.conditionA,
+    this.conditionB,
+    this.conditionC,
+    this.conditionD,
+    this.conditionE,
+    this.blocA,
+    this.blocB,
+    this.blocC,
+    this.blocD,
+    this.blocE,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder4<BlocA, StateA, BlocB, StateB, BlocC, StateC, BlocD,
+        StateD>(
+      blocA: blocA,
+      blocB: blocB,
+      blocC: blocC,
+      blocD: blocD,
+      conditionA: conditionA,
+      conditionB: conditionB,
+      conditionC: conditionC,
+      conditionD: conditionD,
+      builder: (_, stateA, stateB, stateC, stateD) =>
+          BlocBuilder<BlocE, StateE>(
+        bloc: blocE,
+        condition: conditionE,
+        builder: (_, stateE) =>
+            builder(context, stateA, stateB, stateC, stateD, stateE),
+      ),
+    );
+  }
+}
+
+/// {@macro flutter_bloc.bloc_builder.bloc_widget_builder}
+typedef BlocWidgetBuilder6<StateA, StateB, StateC, StateD, StateE, StateF>
+    = Widget Function(
+  BuildContext context,
+  StateA stateA,
+  StateB stateB,
+  StateC stateC,
+  StateD stateD,
+  StateE stateE,
+  StateF stateF,
+);
+
+class BlocBuilder6<
+    BlocA extends Bloc<dynamic, StateA>,
+    StateA,
+    BlocB extends Bloc<dynamic, StateB>,
+    StateB,
+    BlocC extends Bloc<dynamic, StateC>,
+    StateC,
+    BlocD extends Bloc<dynamic, StateD>,
+    StateD,
+    BlocE extends Bloc<dynamic, StateE>,
+    StateE,
+    BlocF extends Bloc<dynamic, StateF>,
+    StateF> extends StatelessWidget {
+  /// {@macro flutter_bloc.bloc_builder.builder}
+  final BlocWidgetBuilder6<StateA, StateB, StateC, StateD, StateE, StateF>
+      builder;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateA> conditionA;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateB> conditionB;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateC> conditionC;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateD> conditionD;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateE> conditionE;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateF> conditionF;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocA blocA;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocB blocB;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocC blocC;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocD blocD;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocE blocE;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocF blocF;
+
+  /// {@template flutter_bloc.bloc_builder.constructor}
+  const BlocBuilder6({
+    @required this.builder,
+    this.conditionA,
+    this.conditionB,
+    this.conditionC,
+    this.conditionD,
+    this.conditionE,
+    this.conditionF,
+    this.blocA,
+    this.blocB,
+    this.blocC,
+    this.blocD,
+    this.blocE,
+    this.blocF,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder5<BlocA, StateA, BlocB, StateB, BlocC, StateC, BlocD,
+        StateD, BlocE, StateE>(
+      blocA: blocA,
+      blocB: blocB,
+      blocC: blocC,
+      blocD: blocD,
+      blocE: blocE,
+      conditionA: conditionA,
+      conditionB: conditionB,
+      conditionC: conditionC,
+      conditionD: conditionD,
+      conditionE: conditionE,
+      builder: (_, stateA, stateB, stateC, stateD, stateE) =>
+          BlocBuilder<BlocF, StateF>(
+        bloc: blocF,
+        condition: conditionF,
+        builder: (_, stateF) =>
+            builder(context, stateA, stateB, stateC, stateD, stateE, stateF),
+      ),
+    );
+  }
+}
+
+/// {@macro flutter_bloc.bloc_builder.bloc_widget_builder}
+typedef BlocWidgetBuilder7<StateA, StateB, StateC, StateD, StateE, StateF,
+        StateG>
+    = Widget Function(
+  BuildContext context,
+  StateA stateA,
+  StateB stateB,
+  StateC stateC,
+  StateD stateD,
+  StateE stateE,
+  StateF stateF,
+  StateG stateG,
+);
+
+class BlocBuilder7<
+    BlocA extends Bloc<dynamic, StateA>,
+    StateA,
+    BlocB extends Bloc<dynamic, StateB>,
+    StateB,
+    BlocC extends Bloc<dynamic, StateC>,
+    StateC,
+    BlocD extends Bloc<dynamic, StateD>,
+    StateD,
+    BlocE extends Bloc<dynamic, StateE>,
+    StateE,
+    BlocF extends Bloc<dynamic, StateF>,
+    StateF,
+    BlocG extends Bloc<dynamic, StateG>,
+    StateG> extends StatelessWidget {
+  /// {@macro flutter_bloc.bloc_builder.builder}
+  final BlocWidgetBuilder7<StateA, StateB, StateC, StateD, StateE, StateF,
+      StateG> builder;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateA> conditionA;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateB> conditionB;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateC> conditionC;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateD> conditionD;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateE> conditionE;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateF> conditionF;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateG> conditionG;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocA blocA;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocB blocB;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocC blocC;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocD blocD;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocE blocE;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocF blocF;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocG blocG;
+
+  /// {@template flutter_bloc.bloc_builder.constructor}
+  const BlocBuilder7({
+    @required this.builder,
+    this.conditionA,
+    this.conditionB,
+    this.conditionC,
+    this.conditionD,
+    this.conditionE,
+    this.conditionF,
+    this.conditionG,
+    this.blocA,
+    this.blocB,
+    this.blocC,
+    this.blocD,
+    this.blocE,
+    this.blocF,
+    this.blocG,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder6<BlocA, StateA, BlocB, StateB, BlocC, StateC, BlocD,
+        StateD, BlocE, StateE, BlocF, StateF>(
+      blocA: blocA,
+      blocB: blocB,
+      blocC: blocC,
+      blocD: blocD,
+      blocE: blocE,
+      blocF: blocF,
+      conditionA: conditionA,
+      conditionB: conditionB,
+      conditionC: conditionC,
+      conditionD: conditionD,
+      conditionE: conditionE,
+      conditionF: conditionF,
+      builder: (_, stateA, stateB, stateC, stateD, stateE, stateF) =>
+          BlocBuilder<BlocG, StateG>(
+        bloc: blocG,
+        condition: conditionG,
+        builder: (_, stateG) => builder(
+            context, stateA, stateB, stateC, stateD, stateE, stateF, stateG),
+      ),
+    );
+  }
+}
+
+/// {@macro flutter_bloc.bloc_builder.bloc_widget_builder}
+typedef BlocWidgetBuilder8<StateA, StateB, StateC, StateD, StateE, StateF,
+        StateG, StateH>
+    = Widget Function(
+  BuildContext context,
+  StateA stateA,
+  StateB stateB,
+  StateC stateC,
+  StateD stateD,
+  StateE stateE,
+  StateF stateF,
+  StateG stateG,
+  StateH stateH,
+);
+
+class BlocBuilder8<
+    BlocA extends Bloc<dynamic, StateA>,
+    StateA,
+    BlocB extends Bloc<dynamic, StateB>,
+    StateB,
+    BlocC extends Bloc<dynamic, StateC>,
+    StateC,
+    BlocD extends Bloc<dynamic, StateD>,
+    StateD,
+    BlocE extends Bloc<dynamic, StateE>,
+    StateE,
+    BlocF extends Bloc<dynamic, StateF>,
+    StateF,
+    BlocG extends Bloc<dynamic, StateG>,
+    StateG,
+    BlocH extends Bloc<dynamic, StateH>,
+    StateH> extends StatelessWidget {
+  /// {@macro flutter_bloc.bloc_builder.builder}
+  final BlocWidgetBuilder8<StateA, StateB, StateC, StateD, StateE, StateF,
+      StateG, StateH> builder;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateA> conditionA;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateB> conditionB;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateC> conditionC;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateD> conditionD;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateE> conditionE;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateF> conditionF;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateG> conditionG;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateH> conditionH;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocA blocA;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocB blocB;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocC blocC;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocD blocD;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocE blocE;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocF blocF;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocG blocG;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocH blocH;
+
+  /// {@template flutter_bloc.bloc_builder.constructor}
+  const BlocBuilder8({
+    @required this.builder,
+    this.conditionA,
+    this.conditionB,
+    this.conditionC,
+    this.conditionD,
+    this.conditionE,
+    this.conditionF,
+    this.conditionG,
+    this.conditionH,
+    this.blocA,
+    this.blocB,
+    this.blocC,
+    this.blocD,
+    this.blocE,
+    this.blocF,
+    this.blocG,
+    this.blocH,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder7<BlocA, StateA, BlocB, StateB, BlocC, StateC, BlocD,
+        StateD, BlocE, StateE, BlocF, StateF, BlocG, StateG>(
+      blocA: blocA,
+      blocB: blocB,
+      blocC: blocC,
+      blocD: blocD,
+      blocE: blocE,
+      blocF: blocF,
+      blocG: blocG,
+      conditionA: conditionA,
+      conditionB: conditionB,
+      conditionC: conditionC,
+      conditionD: conditionD,
+      conditionE: conditionE,
+      conditionF: conditionF,
+      conditionG: conditionG,
+      builder: (_, stateA, stateB, stateC, stateD, stateE, stateF, stateG) =>
+          BlocBuilder<BlocH, StateH>(
+        bloc: blocH,
+        condition: conditionH,
+        builder: (_, stateH) => builder(context, stateA, stateB, stateC, stateD,
+            stateE, stateF, stateG, stateH),
+      ),
+    );
+  }
+}
+
+/// {@macro flutter_bloc.bloc_builder.bloc_widget_builder}
+typedef BlocWidgetBuilder9<StateA, StateB, StateC, StateD, StateE, StateF,
+        StateG, StateH, StateI>
+    = Widget Function(
+  BuildContext context,
+  StateA stateA,
+  StateB stateB,
+  StateC stateC,
+  StateD stateD,
+  StateE stateE,
+  StateF stateF,
+  StateG stateG,
+  StateH stateH,
+  StateI stateI,
+);
+
+class BlocBuilder9<
+    BlocA extends Bloc<dynamic, StateA>,
+    StateA,
+    BlocB extends Bloc<dynamic, StateB>,
+    StateB,
+    BlocC extends Bloc<dynamic, StateC>,
+    StateC,
+    BlocD extends Bloc<dynamic, StateD>,
+    StateD,
+    BlocE extends Bloc<dynamic, StateE>,
+    StateE,
+    BlocF extends Bloc<dynamic, StateF>,
+    StateF,
+    BlocG extends Bloc<dynamic, StateG>,
+    StateG,
+    BlocH extends Bloc<dynamic, StateH>,
+    StateH,
+    BlocI extends Bloc<dynamic, StateI>,
+    StateI> extends StatelessWidget {
+  /// {@macro flutter_bloc.bloc_builder.builder}
+  final BlocWidgetBuilder9<StateA, StateB, StateC, StateD, StateE, StateF,
+      StateG, StateH, StateI> builder;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateA> conditionA;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateB> conditionB;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateC> conditionC;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateD> conditionD;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateE> conditionE;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateF> conditionF;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateG> conditionG;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateH> conditionH;
+
+  /// {@macro flutter_bloc.bloc_builder.bloc_builder_condition}
+  final BlocBuilderCondition<StateI> conditionI;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocA blocA;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocB blocB;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocC blocC;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocD blocD;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocE blocE;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocF blocF;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocG blocG;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocH blocH;
+
+  /// {@template flutter_bloc.bloc_builder.bloc}
+  final BlocI blocI;
+
+  /// {@template flutter_bloc.bloc_builder.constructor}
+  const BlocBuilder9({
+    @required this.builder,
+    this.conditionA,
+    this.conditionB,
+    this.conditionC,
+    this.conditionD,
+    this.conditionE,
+    this.conditionF,
+    this.conditionG,
+    this.conditionH,
+    this.conditionI,
+    this.blocA,
+    this.blocB,
+    this.blocC,
+    this.blocD,
+    this.blocE,
+    this.blocF,
+    this.blocG,
+    this.blocH,
+    this.blocI,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder8<BlocA, StateA, BlocB, StateB, BlocC, StateC, BlocD,
+        StateD, BlocE, StateE, BlocF, StateF, BlocG, StateG, BlocH, StateH>(
+      blocA: blocA,
+      blocB: blocB,
+      blocC: blocC,
+      blocD: blocD,
+      blocE: blocE,
+      blocF: blocF,
+      blocG: blocG,
+      blocH: blocH,
+      conditionA: conditionA,
+      conditionB: conditionB,
+      conditionC: conditionC,
+      conditionD: conditionD,
+      conditionE: conditionE,
+      conditionF: conditionF,
+      conditionG: conditionG,
+      conditionH: conditionH,
+      builder:
+          (_, stateA, stateB, stateC, stateD, stateE, stateF, stateG, stateH) =>
+              BlocBuilder<BlocI, StateI>(
+        bloc: blocI,
+        condition: conditionI,
+        builder: (_, stateI) => builder(context, stateA, stateB, stateC, stateD,
+            stateE, stateF, stateG, stateH, stateI),
+      ),
+    );
+  }
+}
+
 abstract class BlocBuilderBase<B extends Bloc<dynamic, S>, S>
     extends StatefulWidget {
   /// Base class for widgets that build themselves based on interaction with
@@ -93,17 +889,21 @@ abstract class BlocBuilderBase<B extends Bloc<dynamic, S>, S>
   /// is defined by sub-classes.
   const BlocBuilderBase({Key key, this.bloc, this.condition}) : super(key: key);
 
+  /// {@template flutter_bloc.bloc_builder.bloc}
   /// The [Bloc] that the [BlocBuilderBase] will interact with.
   /// If omitted, [BlocBuilderBase] will automatically perform a lookup using
   /// [BlocProvider] and the current [BuildContext].
+  /// {@endtemplate}
   final B bloc;
 
+  /// {@template flutter_bloc.bloc_builder.bloc_builder_condition}
   /// The [BlocBuilderCondition] that the [BlocBuilderBase] will invoke.
   /// The `condition` function will be invoked on each bloc state change.
   /// The `condition` takes the previous state and current state and must return a `bool`
   /// which determines whether or not the `builder` function will be invoked.
   /// The previous state will be initialized to `currentState` when the [BlocBuilderBase] is initialized.
   /// `condition` is optional and if it isn't implemented, it will default to return `true`.
+  /// {@endtemplate}
   final BlocBuilderCondition<S> condition;
 
   /// Returns a [Widget] based on the [BuildContext] and current [state].

--- a/packages/flutter_bloc/test/bloc_builder_test.dart
+++ b/packages/flutter_bloc/test/bloc_builder_test.dart
@@ -468,4 +468,259 @@ void main() {
       expect(conditionalCounterText4.data, '2');
     });
   });
+
+  group('BlocBuilder2', () {
+    testWidgets('renders properly', (tester) async {
+      final blocA = CounterBloc();
+      final blocB = CounterBloc();
+      await tester.pumpWidget(
+        BlocBuilder2<CounterBloc, int, CounterBloc, int>(
+          blocA: blocA,
+          blocB: blocB,
+          builder: (context, stateA, stateB) => Container(
+            key: Key('__${stateA}_${stateB}__'),
+          ),
+        ),
+      );
+      expect(find.byKey(Key('__0_0__')), findsOneWidget);
+    });
+  });
+
+  group('BlocBuilder3', () {
+    testWidgets('renders properly', (tester) async {
+      final blocA = CounterBloc();
+      final blocB = CounterBloc();
+      final blocC = CounterBloc();
+      await tester.pumpWidget(
+        BlocBuilder3<CounterBloc, int, CounterBloc, int, CounterBloc, int>(
+          blocA: blocA,
+          blocB: blocB,
+          blocC: blocC,
+          builder: (context, stateA, stateB, stateC) => Container(
+            key: Key('__${stateA}_${stateB}_${stateC}__'),
+          ),
+        ),
+      );
+      expect(find.byKey(Key('__0_0_0__')), findsOneWidget);
+    });
+  });
+
+  group('BlocBuilder4', () {
+    testWidgets('renders properly', (tester) async {
+      final blocA = CounterBloc();
+      final blocB = CounterBloc();
+      final blocC = CounterBloc();
+      final blocD = CounterBloc();
+      await tester.pumpWidget(
+        BlocBuilder4<CounterBloc, int, CounterBloc, int, CounterBloc, int,
+            CounterBloc, int>(
+          blocA: blocA,
+          blocB: blocB,
+          blocC: blocC,
+          blocD: blocD,
+          builder: (context, stateA, stateB, stateC, stateD) => Container(
+            key: Key('__${stateA}_${stateB}_${stateC}_${stateD}__'),
+          ),
+        ),
+      );
+      expect(find.byKey(Key('__0_0_0_0__')), findsOneWidget);
+    });
+  });
+
+  group('BlocBuilder5', () {
+    testWidgets('renders properly', (tester) async {
+      final blocA = CounterBloc();
+      final blocB = CounterBloc();
+      final blocC = CounterBloc();
+      final blocD = CounterBloc();
+      final blocE = CounterBloc();
+      await tester.pumpWidget(
+        BlocBuilder5<CounterBloc, int, CounterBloc, int, CounterBloc, int,
+            CounterBloc, int, CounterBloc, int>(
+          blocA: blocA,
+          blocB: blocB,
+          blocC: blocC,
+          blocD: blocD,
+          blocE: blocE,
+          builder: (context, stateA, stateB, stateC, stateD, stateE) =>
+              Container(
+            key: Key('__${stateA}_${stateB}_${stateC}_${stateD}_${stateE}__'),
+          ),
+        ),
+      );
+      expect(find.byKey(Key('__0_0_0_0_0__')), findsOneWidget);
+    });
+  });
+
+  group('BlocBuilder6', () {
+    testWidgets('renders properly', (tester) async {
+      final blocA = CounterBloc();
+      final blocB = CounterBloc();
+      final blocC = CounterBloc();
+      final blocD = CounterBloc();
+      final blocE = CounterBloc();
+      final blocF = CounterBloc();
+      await tester.pumpWidget(
+        BlocBuilder6<CounterBloc, int, CounterBloc, int, CounterBloc, int,
+            CounterBloc, int, CounterBloc, int, CounterBloc, int>(
+          blocA: blocA,
+          blocB: blocB,
+          blocC: blocC,
+          blocD: blocD,
+          blocE: blocE,
+          blocF: blocF,
+          builder: (context, stateA, stateB, stateC, stateD, stateE, stateF) =>
+              Container(
+            key: Key(
+                '__${stateA}_${stateB}_${stateC}_${stateD}_${stateE}_${stateF}__'),
+          ),
+        ),
+      );
+      expect(find.byKey(Key('__0_0_0_0_0_0__')), findsOneWidget);
+    });
+  });
+
+  group('BlocBuilder7', () {
+    testWidgets('renders properly', (tester) async {
+      final blocA = CounterBloc();
+      final blocB = CounterBloc();
+      final blocC = CounterBloc();
+      final blocD = CounterBloc();
+      final blocE = CounterBloc();
+      final blocF = CounterBloc();
+      final blocG = CounterBloc();
+      await tester.pumpWidget(
+        BlocBuilder7<
+            CounterBloc,
+            int,
+            CounterBloc,
+            int,
+            CounterBloc,
+            int,
+            CounterBloc,
+            int,
+            CounterBloc,
+            int,
+            CounterBloc,
+            int,
+            CounterBloc,
+            int>(
+          blocA: blocA,
+          blocB: blocB,
+          blocC: blocC,
+          blocD: blocD,
+          blocE: blocE,
+          blocF: blocF,
+          blocG: blocG,
+          builder: (context, stateA, stateB, stateC, stateD, stateE, stateF,
+                  stateG) =>
+              Container(
+            key: Key(
+                '__${stateA}_${stateB}_${stateC}_${stateD}_${stateE}_${stateF}_${stateG}__'),
+          ),
+        ),
+      );
+      expect(find.byKey(Key('__0_0_0_0_0_0_0__')), findsOneWidget);
+    });
+  });
+
+  group('BlocBuilder8', () {
+    testWidgets('renders properly', (tester) async {
+      final blocA = CounterBloc();
+      final blocB = CounterBloc();
+      final blocC = CounterBloc();
+      final blocD = CounterBloc();
+      final blocE = CounterBloc();
+      final blocF = CounterBloc();
+      final blocG = CounterBloc();
+      final blocH = CounterBloc();
+      await tester.pumpWidget(
+        BlocBuilder8<
+            CounterBloc,
+            int,
+            CounterBloc,
+            int,
+            CounterBloc,
+            int,
+            CounterBloc,
+            int,
+            CounterBloc,
+            int,
+            CounterBloc,
+            int,
+            CounterBloc,
+            int,
+            CounterBloc,
+            int>(
+          blocA: blocA,
+          blocB: blocB,
+          blocC: blocC,
+          blocD: blocD,
+          blocE: blocE,
+          blocF: blocF,
+          blocG: blocG,
+          blocH: blocH,
+          builder: (context, stateA, stateB, stateC, stateD, stateE, stateF,
+                  stateG, stateH) =>
+              Container(
+            key: Key(
+                '__${stateA}_${stateB}_${stateC}_${stateD}_${stateE}_${stateF}_${stateG}_${stateH}__'),
+          ),
+        ),
+      );
+      expect(find.byKey(Key('__0_0_0_0_0_0_0_0__')), findsOneWidget);
+    });
+  });
+
+  group('BlocBuilder9', () {
+    testWidgets('renders properly', (tester) async {
+      final blocA = CounterBloc();
+      final blocB = CounterBloc();
+      final blocC = CounterBloc();
+      final blocD = CounterBloc();
+      final blocE = CounterBloc();
+      final blocF = CounterBloc();
+      final blocG = CounterBloc();
+      final blocH = CounterBloc();
+      final blocI = CounterBloc();
+      await tester.pumpWidget(
+        BlocBuilder9<
+            CounterBloc,
+            int,
+            CounterBloc,
+            int,
+            CounterBloc,
+            int,
+            CounterBloc,
+            int,
+            CounterBloc,
+            int,
+            CounterBloc,
+            int,
+            CounterBloc,
+            int,
+            CounterBloc,
+            int,
+            CounterBloc,
+            int>(
+          blocA: blocA,
+          blocB: blocB,
+          blocC: blocC,
+          blocD: blocD,
+          blocE: blocE,
+          blocF: blocF,
+          blocG: blocG,
+          blocH: blocH,
+          blocI: blocI,
+          builder: (context, stateA, stateB, stateC, stateD, stateE, stateF,
+                  stateG, stateH, stateI) =>
+              Container(
+            key: Key(
+                '__${stateA}_${stateB}_${stateC}_${stateD}_${stateE}_${stateF}_${stateG}_${stateH}_${stateI}__'),
+          ),
+        ),
+      );
+      expect(find.byKey(Key('__0_0_0_0_0_0_0_0_0__')), findsOneWidget);
+    });
+  });
 }


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Introduce `BlocBuilder2...9` (#538)

```dart
  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(title: Text('Example')),
      body: BlocBuilder2<BlocA, StateA, BlocB, StateB>(
        builder: (context, stateA, stateB) { ... },
      ),
    );
  }
```

```dart
  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(title: Text('Example')),
      body: BlocBuilder3<BlocA, StateA, BlocB, StateB, BlocC, StateC>(
        builder: (context, stateA, stateB, stateC) { ... },
      ),
    );
  }
```

## Todos
- [x] Tests
- [x] Documentation
- [x] Examples

## Impact to Remaining Code Base
None