### PR TITLE
Deprecate Bloc.state

### DIFF
--- a/packages/bloc/CHANGELOG.md
+++ b/packages/bloc/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.15.1
+
+- Deprecated `state` in favor of `stream` ([#558](https://github.com/felangel/bloc/issues/558))
+
 # 0.15.0
 
 - Removed Bloc `event` Stream ([#326](https://github.com/felangel/bloc/issues/326))

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -11,9 +11,19 @@ abstract class Bloc<Event, State> {
 
   BehaviorSubject<State> _stateSubject;
 
+  /// `Deprecated`, please use `stream` instead.
+  /// `state` will be removed in 0.16.0 (https://github.com/felangel/bloc/issues/558)
+  ///
   /// Returns [Stream] of [State]s.
   /// Usually consumed by the presentation layer.
+  @Deprecated(
+    'Please use stream instead. Will be removed in v0.16.0 (https://github.com/felangel/bloc/issues/558)',
+  )
   Stream<State> get state => _stateSubject.stream;
+
+  /// Returns [Stream] of [State]s.
+  /// Usually consumed by the presentation layer.
+  Stream<State> get stream => _stateSubject.stream;
 
   /// Returns the [State] before any [Event]s have been `dispatched`.
   State get initialState;

--- a/packages/bloc/pubspec.yaml
+++ b/packages/bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc
 description: A predictable state management library that helps implement the BLoC (Business Logic Component) design pattern.
-version: 0.15.0
+version: 0.15.1
 author: Felix Angelov <felangelov@gmail.com>
 repository: https://github.com/felangel/bloc
 issue_tracker: https://github.com/felangel/bloc/issues

--- a/packages/bloc/test/deprecated_bloc_test.dart
+++ b/packages/bloc/test/deprecated_bloc_test.dart
@@ -26,7 +26,7 @@ void main() {
         final List<Matcher> expectedStates = [equals(''), emitsDone];
 
         expectLater(
-          simpleBloc.stream,
+          simpleBloc.state,
           emitsInOrder(expectedStates),
         );
 
@@ -43,14 +43,14 @@ void main() {
 
       test('state should equal initial state before any events are dispatched',
           () async {
-        final initialState = await simpleBloc.stream.first;
+        final initialState = await simpleBloc.state.first;
         expect(initialState, simpleBloc.initialState);
       });
 
       test('should map single event to correct state', () {
         final List<String> expectedStates = ['', 'data'];
 
-        expectLater(simpleBloc.stream, emitsInOrder(expectedStates))
+        expectLater(simpleBloc.state, emitsInOrder(expectedStates))
             .then((dynamic _) {
           verify(
             delegate.onTransition(
@@ -71,7 +71,7 @@ void main() {
       test('should map multiple events to correct states', () {
         final List<String> expectedStates = ['', 'data'];
 
-        expectLater(simpleBloc.stream, emitsInOrder(expectedStates))
+        expectLater(simpleBloc.state, emitsInOrder(expectedStates))
             .then((dynamic _) {
           verify(
             delegate.onTransition(
@@ -111,7 +111,7 @@ void main() {
         ];
 
         expectLater(
-          complexBloc.stream,
+          complexBloc.state,
           emitsInOrder(expectedStates),
         );
 
@@ -128,7 +128,7 @@ void main() {
 
       test('state should equal initial state before any events are dispatched',
           () async {
-        final initialState = await complexBloc.stream.first;
+        final initialState = await complexBloc.state.first;
         expect(initialState, complexBloc.initialState);
       });
 
@@ -138,7 +138,7 @@ void main() {
           ComplexStateB(),
         ];
 
-        expectLater(complexBloc.stream, emitsInOrder(expectedStates))
+        expectLater(complexBloc.state, emitsInOrder(expectedStates))
             .then((dynamic _) {
           verify(
             delegate.onTransition(
@@ -166,7 +166,7 @@ void main() {
         ];
 
         expectLater(
-          complexBloc.stream,
+          complexBloc.state,
           emitsInOrder(expectedStates),
         );
 
@@ -224,7 +224,7 @@ void main() {
 
       test('state should equal initial state before any events are dispatched',
           () async {
-        final initialState = await counterBloc.stream.first;
+        final initialState = await counterBloc.state.first;
         expect(initialState, counterBloc.initialState);
       });
 
@@ -235,7 +235,7 @@ void main() {
         ];
 
         expectLater(
-          counterBloc.stream,
+          counterBloc.state,
           emitsInOrder(expectedStates),
         ).then((dynamic _) {
           expectLater(transitions, expectedTransitions);
@@ -264,7 +264,7 @@ void main() {
         ];
 
         expectLater(
-          counterBloc.stream,
+          counterBloc.state,
           emitsInOrder(expectedStates),
         ).then((dynamic _) {
           expect(transitions, expectedTransitions);
@@ -326,7 +326,7 @@ void main() {
         ];
 
         expectLater(
-          asyncBloc.stream,
+          asyncBloc.state,
           emitsInOrder(expectedStates),
         );
 
@@ -342,7 +342,7 @@ void main() {
         ];
 
         expectLater(
-          asyncBloc.stream,
+          asyncBloc.state,
           emitsInOrder(expectedStates),
         );
 
@@ -362,7 +362,7 @@ void main() {
 
       test('state should equal initial state before any events are dispatched',
           () async {
-        final initialState = await asyncBloc.stream.first;
+        final initialState = await asyncBloc.state.first;
         expect(initialState, asyncBloc.initialState);
       });
 
@@ -373,7 +373,7 @@ void main() {
           AsyncState(isLoading: false, hasError: false, isSuccess: true),
         ];
 
-        expectLater(asyncBloc.stream, emitsInOrder(expectedStates))
+        expectLater(asyncBloc.state, emitsInOrder(expectedStates))
             .then((dynamic _) {
           verify(
             delegate.onTransition(
@@ -446,7 +446,7 @@ void main() {
         final List<int> expected = [0, -1];
         final CounterExceptionBloc _bloc = CounterExceptionBloc();
 
-        expectLater(_bloc.stream, emitsInOrder(expected));
+        expectLater(_bloc.state, emitsInOrder(expected));
 
         _bloc.dispatch(CounterEvent.increment);
         _bloc.dispatch(CounterEvent.decrement);
@@ -464,7 +464,7 @@ void main() {
               expectedStacktrace = stacktrace;
             });
 
-        expectLater(_bloc.stream, emitsInOrder(<int>[0])).then((dynamic _) {
+        expectLater(_bloc.state, emitsInOrder(<int>[0])).then((dynamic _) {
           expect(expectedError, exception);
           expect(expectedStacktrace, isNotNull);
         });
@@ -482,7 +482,7 @@ void main() {
           },
         );
 
-        expectLater(_bloc.stream, emitsInOrder(<int>[0])).then((dynamic _) {
+        expectLater(_bloc.state, emitsInOrder(<int>[0])).then((dynamic _) {
           expect(
             capturedError,
             isStateError,
@@ -504,7 +504,7 @@ void main() {
         final List<int> expected = [0, -1];
         final CounterErrorBloc _bloc = CounterErrorBloc();
 
-        expectLater(_bloc.stream, emitsInOrder(expected));
+        expectLater(_bloc.state, emitsInOrder(expected));
 
         _bloc.dispatch(CounterEvent.increment);
         _bloc.dispatch(CounterEvent.decrement);
@@ -522,7 +522,7 @@ void main() {
               expectedStacktrace = stacktrace;
             });
 
-        expectLater(_bloc.stream, emitsInOrder(<int>[0])).then((dynamic _) {
+        expectLater(_bloc.state, emitsInOrder(<int>[0])).then((dynamic _) {
           expect(expectedError, error);
           expect(expectedStacktrace, isNotNull);
         });


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Deprecate `bloc.state` in favor of `bloc.stream` (#558)

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
- `bloc.state` will be removed in `v0.16.0`