### PR TITLE
Adding flush method

### DIFF
--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -86,6 +86,11 @@ abstract class Bloc<Event, State> extends Stream<State> implements Sink<Event> {
     _stateSubject.close();
   }
 
+  @visibleForTesting
+  Future<dynamic> flushAndClose() {
+    return _eventSubject.sink.close().whenComplete(() => close());
+  }
+
   /// Transforms the `Stream<Event>` along with a `next` function into a `Stream<State>`.
   /// Events that should be processed by `mapEventToState` need to be passed to `next`.
   /// By default `asyncExpand` is used to ensure all events are processed in the order

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:bloc/bloc.dart';
 import 'package:mockito/mockito.dart';
+import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
 
 import './helpers/helpers.dart';
@@ -382,6 +383,21 @@ void main() {
           () async {
         final initialState = await asyncBloc.first;
         expect(initialState, asyncBloc.initialState);
+      });
+
+      test('flush awaits for all emited events to complete', () async {
+        final List<AsyncState> expectedStates = [
+          AsyncState(isLoading: false, hasError: false, isSuccess: false),
+          AsyncState(isLoading: true, hasError: false, isSuccess: false),
+          AsyncState(isLoading: false, hasError: false, isSuccess: true),
+        ];
+        final replay = ReplaySubject<AsyncState>();
+        asyncBloc.pipe(replay.sink);
+
+        asyncBloc.add(AsyncEvent());
+
+        await asyncBloc.flushAndClose();
+        expect(replay.values, expectedStates);
       });
 
       test('should map single event to correct state', () {


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
Adding `Future<dynamic> flushAndDispose()` method to improve testing experience. Calling this method should ensure that all events are handle before closing bloc streams.

#### Detailed explanation what problem this change solves
With current Bloc implementations it is inconvenient to do TDD. We don't have a real way to assert that states stream is missing some particular state. Single option is to relay on tests timeout. Which is not a actual assert, consumes a lot of time if doing TDD and do not provide real reason why test failed.

## Related PRs

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Examples

## Steps to Test or Reproduce
Let's say we are using TDD and creating Counter app from examples. Writing test before implementing `increment` behavior.
### Before
```dart
test('single Increment event updates state to 1', () {
    final List<int> expected = [0, 1];

    expectLater(
        counterBloc.state,
        emitsInOrder(expected),
    );

    counterBloc.dispatch(CounterEvent.increment);
});
```
This fails **after 30seconds per test** with error:
```
ERROR: TimeoutException after 0:00:30.000000: Test timed out after 30 seconds
```
### After
```dart
test('single Increment event updates state to 1', () {
    final List<int> expected = [0, 1];

    expectLater(
        counterBloc.state,
        emitsInOrder(expected),
    );

    counterBloc.dispatch(CounterEvent.increment);
    counterBloc.flushAndDispose();
});
```
This fails almoust instantly and provides meaningful error:
```
ERROR: Expected: should do the following in order:
          • emit an event that <0>
          • emit an event that <1>
  Actual: <Instance of 'BehaviorSubject<int>'>
   Which: emitted • 0
                  x Stream closed.
            which didn't emit an event that <1>
```

## Impact to Remaining Code Base
This PR will affect:

* Nothing
