### PR TITLE
Refactor Bloc to extend Stream<State>

### DIFF
--- a/packages/bloc/example/main.dart
+++ b/packages/bloc/example/main.dart
@@ -14,12 +14,12 @@ class CounterBloc extends Bloc<CounterEvent, int> {
       case CounterEvent.decrement:
         // Simulating Network Latency
         await Future<void>.delayed(Duration(seconds: 1));
-        yield currentState - 1;
+        yield state - 1;
         break;
       case CounterEvent.increment:
         // Simulating Network Latency
         await Future<void>.delayed(Duration(milliseconds: 500));
-        yield currentState + 1;
+        yield state + 1;
         break;
       default:
         throw Exception('unhandled event: $event');

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -6,24 +6,51 @@ import 'package:rxdart/rxdart.dart';
 
 /// Takes a [Stream] of [Event]s as input
 /// and transforms them into a [Stream] of [State]s as output.
-abstract class Bloc<Event, State> {
+abstract class Bloc<Event, State> extends Stream<State> {
   final PublishSubject<Event> _eventSubject = PublishSubject<Event>();
 
   BehaviorSubject<State> _stateSubject;
 
-  /// Returns [Stream] of [State]s.
-  /// Usually consumed by the presentation layer.
-  Stream<State> get state => _stateSubject.stream;
+  /// Returns the current [State] of the [Bloc].
+  State get state => _stateSubject.value;
 
   /// Returns the [State] before any [Event]s have been `dispatched`.
   State get initialState;
 
-  /// Returns the current [State] of the [Bloc].
-  State get currentState => _stateSubject.value;
+  /// Returns whether the `Stream<State>` is a broadcast stream.
+  bool get isBroadcast => _stateSubject.stream.isBroadcast;
 
   Bloc() {
     _stateSubject = BehaviorSubject<State>.seeded(initialState);
     _bindStateSubject();
+  }
+
+  /// Adds a subscription to the `Stream<State>`.
+  /// Returns a [StreamSubscription] which handles events from the `Stream<State>`
+  /// using the provided [onData], [onError] and [onDone] handlers.
+  StreamSubscription<State> listen(
+    void onData(State value), {
+    Function onError,
+    void onDone(),
+    bool cancelOnError,
+  }) {
+    return _stateSubject.stream.listen(
+      onData,
+      onError: onError,
+      onDone: onDone,
+      cancelOnError: cancelOnError,
+    );
+  }
+
+  /// Returns a multi-subscription stream that produces the same events as this.
+  Stream<State> asBroadcastStream({
+    void onListen(StreamSubscription<State> subscription),
+    void onCancel(StreamSubscription<State> subscription),
+  }) {
+    return _stateSubject.stream.asBroadcastStream(
+      onListen: onListen,
+      onCancel: onCancel,
+    );
   }
 
   /// Called whenever an [Event] is dispatched to the [Bloc].
@@ -136,9 +163,9 @@ abstract class Bloc<Event, State> {
       return mapEventToState(currentEvent).handleError(_handleError);
     })).forEach(
       (State nextState) {
-        if (currentState == nextState || _stateSubject.isClosed) return;
+        if (state == nextState || _stateSubject.isClosed) return;
         final transition = Transition(
-          currentState: currentState,
+          currentState: state,
           event: currentEvent,
           nextState: nextState,
         );

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -18,7 +18,7 @@ abstract class Bloc<Event, State> extends Stream<State> {
   State get initialState;
 
   /// Returns whether the `Stream<State>` is a broadcast stream.
-  bool get isBroadcast => _stateSubject.stream.isBroadcast;
+  bool get isBroadcast => _stateSubject.isBroadcast;
 
   Bloc() {
     _stateSubject = BehaviorSubject<State>.seeded(initialState);
@@ -34,22 +34,11 @@ abstract class Bloc<Event, State> extends Stream<State> {
     void onDone(),
     bool cancelOnError,
   }) {
-    return _stateSubject.stream.listen(
+    return _stateSubject.listen(
       onData,
       onError: onError,
       onDone: onDone,
       cancelOnError: cancelOnError,
-    );
-  }
-
-  /// Returns a multi-subscription stream that produces the same events as this.
-  Stream<State> asBroadcastStream({
-    void onListen(StreamSubscription<State> subscription),
-    void onCancel(StreamSubscription<State> subscription),
-  }) {
-    return _stateSubject.stream.asBroadcastStream(
-      onListen: onListen,
-      onCancel: onCancel,
     );
   }
 

--- a/packages/bloc/test/bloc_delegate_test.dart
+++ b/packages/bloc/test/bloc_delegate_test.dart
@@ -23,7 +23,7 @@ void main() {
       when(delegate.onEvent(any, any)).thenReturn(null);
 
       expectLater(
-        complexBloc.state,
+        complexBloc,
         emitsInOrder(expectedStateAfterEventB),
       ).then((dynamic _) {
         verify(
@@ -53,7 +53,7 @@ void main() {
       when(delegate.onEvent(any, any)).thenReturn(null);
 
       expectLater(
-        complexBlocA.state,
+        complexBlocA,
         emitsInOrder(expectedStateAfterEventB),
       ).then((dynamic _) {
         verify(
@@ -65,7 +65,7 @@ void main() {
       });
 
       expectLater(
-        complexBlocB.state,
+        complexBlocB,
         emitsInOrder(expectedStateAfterEventC),
       ).then((dynamic _) {
         verify(
@@ -91,7 +91,7 @@ void main() {
       when(delegate.onEvent(any, any)).thenReturn(null);
 
       expectLater(
-        complexBloc.state,
+        complexBloc,
         emitsInOrder(expectedStateAfterEventB),
       ).then((dynamic _) {
         verifyNever(
@@ -121,7 +121,7 @@ void main() {
       when(delegate.onTransition(any, any)).thenReturn(null);
 
       expectLater(
-        complexBloc.state,
+        complexBloc,
         emitsInOrder(expectedStateAfterEventB),
       ).then((dynamic _) {
         verify(
@@ -155,7 +155,7 @@ void main() {
       when(delegate.onTransition(any, any)).thenReturn(null);
 
       expectLater(
-        complexBlocA.state,
+        complexBlocA,
         emitsInOrder(expectedStateAfterEventB),
       ).then((dynamic _) {
         verify(
@@ -171,7 +171,7 @@ void main() {
       });
 
       expectLater(
-        complexBlocB.state,
+        complexBlocB,
         emitsInOrder(expectedStateAfterEventC),
       ).then((dynamic _) {
         verify(
@@ -201,7 +201,7 @@ void main() {
       when(delegate.onTransition(any, any)).thenReturn(null);
 
       expectLater(
-        complexBloc.state,
+        complexBloc,
         emitsInOrder(expectedStateAfterEventB),
       ).then((dynamic _) {
         verifyNever(
@@ -238,7 +238,10 @@ void main() {
         errorHandled = true;
       });
 
-      expectLater(_bloc.state, emitsInOrder(<int>[0])).then((dynamic _) {
+      expectLater(
+        _bloc,
+        emitsInOrder(<int>[0]),
+      ).then((dynamic _) {
         expect(errorHandled, isTrue);
         expect(blocWithError, _bloc);
       });

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -26,7 +26,7 @@ void main() {
         final List<Matcher> expectedStates = [equals(''), emitsDone];
 
         expectLater(
-          simpleBloc.state,
+          simpleBloc,
           emitsInOrder(expectedStates),
         );
 
@@ -37,21 +37,23 @@ void main() {
         expect(simpleBloc.initialState, '');
       });
 
-      test('currentState returns correct value initially', () {
-        expect(simpleBloc.currentState, '');
+      test('state returns correct value initially', () {
+        expect(simpleBloc.state, '');
       });
 
       test('state should equal initial state before any events are dispatched',
           () async {
-        final initialState = await simpleBloc.state.first;
+        final initialState = await simpleBloc.first;
         expect(initialState, simpleBloc.initialState);
       });
 
       test('should map single event to correct state', () {
         final List<String> expectedStates = ['', 'data'];
 
-        expectLater(simpleBloc.state, emitsInOrder(expectedStates))
-            .then((dynamic _) {
+        expectLater(
+          simpleBloc,
+          emitsInOrder(expectedStates),
+        ).then((dynamic _) {
           verify(
             delegate.onTransition(
               simpleBloc,
@@ -62,7 +64,7 @@ void main() {
               ),
             ),
           ).called(1);
-          expect(simpleBloc.currentState, 'data');
+          expect(simpleBloc.state, 'data');
         });
 
         simpleBloc.dispatch('event');
@@ -71,8 +73,10 @@ void main() {
       test('should map multiple events to correct states', () {
         final List<String> expectedStates = ['', 'data'];
 
-        expectLater(simpleBloc.state, emitsInOrder(expectedStates))
-            .then((dynamic _) {
+        expectLater(
+          simpleBloc,
+          emitsInOrder(expectedStates),
+        ).then((dynamic _) {
           verify(
             delegate.onTransition(
               simpleBloc,
@@ -83,12 +87,20 @@ void main() {
               ),
             ),
           ).called(1);
-          expect(simpleBloc.currentState, 'data');
+          expect(simpleBloc.state, 'data');
         });
 
         simpleBloc.dispatch('event1');
         simpleBloc.dispatch('event2');
         simpleBloc.dispatch('event3');
+      });
+
+      test('isBroadcast returns true', () {
+        expect(simpleBloc.isBroadcast, isTrue);
+      });
+
+      test('asBroadcastStream returns a broadcastStream', () {
+        expect(simpleBloc.asBroadcastStream().isBroadcast, isTrue);
       });
     });
 
@@ -111,7 +123,7 @@ void main() {
         ];
 
         expectLater(
-          complexBloc.state,
+          complexBloc,
           emitsInOrder(expectedStates),
         );
 
@@ -122,13 +134,13 @@ void main() {
         expect(complexBloc.initialState, ComplexStateA());
       });
 
-      test('currentState returns correct value initially', () {
-        expect(complexBloc.currentState, ComplexStateA());
+      test('state returns correct value initially', () {
+        expect(complexBloc.state, ComplexStateA());
       });
 
       test('state should equal initial state before any events are dispatched',
           () async {
-        final initialState = await complexBloc.state.first;
+        final initialState = await complexBloc.first;
         expect(initialState, complexBloc.initialState);
       });
 
@@ -138,8 +150,10 @@ void main() {
           ComplexStateB(),
         ];
 
-        expectLater(complexBloc.state, emitsInOrder(expectedStates))
-            .then((dynamic _) {
+        expectLater(
+          complexBloc,
+          emitsInOrder(expectedStates),
+        ).then((dynamic _) {
           verify(
             delegate.onTransition(
               complexBloc,
@@ -150,7 +164,7 @@ void main() {
               ),
             ),
           ).called(1);
-          expect(complexBloc.currentState, ComplexStateB());
+          expect(complexBloc.state, ComplexStateB());
         });
 
         complexBloc.dispatch(ComplexEventB());
@@ -166,7 +180,7 @@ void main() {
         ];
 
         expectLater(
-          complexBloc.state,
+          complexBloc,
           emitsInOrder(expectedStates),
         );
 
@@ -182,6 +196,14 @@ void main() {
         complexBloc.dispatch(ComplexEventA());
         await Future<void>.delayed(Duration(milliseconds: 120));
         complexBloc.dispatch(ComplexEventC());
+      });
+
+      test('isBroadcast returns true', () {
+        expect(complexBloc.isBroadcast, isTrue);
+      });
+
+      test('asBroadcastStream returns a broadcastStream', () {
+        expect(complexBloc.asBroadcastStream().isBroadcast, isTrue);
       });
     });
 
@@ -218,13 +240,13 @@ void main() {
         expect(transitions.isEmpty, true);
       });
 
-      test('currentState returns correct value initially', () {
-        expect(counterBloc.currentState, 0);
+      test('state returns correct value initially', () {
+        expect(counterBloc.state, 0);
       });
 
       test('state should equal initial state before any events are dispatched',
           () async {
-        final initialState = await counterBloc.state.first;
+        final initialState = await counterBloc.first;
         expect(initialState, counterBloc.initialState);
       });
 
@@ -235,7 +257,7 @@ void main() {
         ];
 
         expectLater(
-          counterBloc.state,
+          counterBloc,
           emitsInOrder(expectedStates),
         ).then((dynamic _) {
           expectLater(transitions, expectedTransitions);
@@ -249,7 +271,7 @@ void main() {
               ),
             ),
           ).called(1);
-          expect(counterBloc.currentState, 1);
+          expect(counterBloc.state, 1);
         });
 
         counterBloc.dispatch(CounterEvent.increment);
@@ -264,7 +286,7 @@ void main() {
         ];
 
         expectLater(
-          counterBloc.state,
+          counterBloc,
           emitsInOrder(expectedStates),
         ).then((dynamic _) {
           expect(transitions, expectedTransitions);
@@ -298,12 +320,20 @@ void main() {
               ),
             ),
           ).called(1);
-          expect(counterBloc.currentState, 3);
+          expect(counterBloc.state, 3);
         });
 
         counterBloc.dispatch(CounterEvent.increment);
         counterBloc.dispatch(CounterEvent.increment);
         counterBloc.dispatch(CounterEvent.increment);
+      });
+
+      test('isBroadcast returns true', () {
+        expect(counterBloc.isBroadcast, isTrue);
+      });
+
+      test('asBroadcastStream returns a broadcastStream', () {
+        expect(counterBloc.asBroadcastStream().isBroadcast, isTrue);
       });
     });
 
@@ -326,7 +356,7 @@ void main() {
         ];
 
         expectLater(
-          asyncBloc.state,
+          asyncBloc,
           emitsInOrder(expectedStates),
         );
 
@@ -342,7 +372,7 @@ void main() {
         ];
 
         expectLater(
-          asyncBloc.state,
+          asyncBloc,
           emitsInOrder(expectedStates),
         );
 
@@ -356,13 +386,13 @@ void main() {
         expect(asyncBloc.initialState, AsyncState.initial());
       });
 
-      test('currentState returns correct value initially', () {
-        expect(asyncBloc.currentState, AsyncState.initial());
+      test('state returns correct value initially', () {
+        expect(asyncBloc.state, AsyncState.initial());
       });
 
       test('state should equal initial state before any events are dispatched',
           () async {
-        final initialState = await asyncBloc.state.first;
+        final initialState = await asyncBloc.first;
         expect(initialState, asyncBloc.initialState);
       });
 
@@ -373,8 +403,10 @@ void main() {
           AsyncState(isLoading: false, hasError: false, isSuccess: true),
         ];
 
-        expectLater(asyncBloc.state, emitsInOrder(expectedStates))
-            .then((dynamic _) {
+        expectLater(
+          asyncBloc,
+          emitsInOrder(expectedStates),
+        ).then((dynamic _) {
           verify(
             delegate.onTransition(
               asyncBloc,
@@ -412,7 +444,7 @@ void main() {
             ),
           ).called(1);
           expect(
-            asyncBloc.currentState,
+            asyncBloc.state,
             AsyncState(
               isLoading: false,
               hasError: false,
@@ -422,6 +454,14 @@ void main() {
         });
 
         asyncBloc.dispatch(AsyncEvent());
+      });
+
+      test('isBroadcast returns true', () {
+        expect(asyncBloc.isBroadcast, isTrue);
+      });
+
+      test('asBroadcastStream returns a broadcastStream', () {
+        expect(asyncBloc.asBroadcastStream().isBroadcast, isTrue);
       });
     });
 
@@ -446,7 +486,7 @@ void main() {
         final List<int> expected = [0, -1];
         final CounterExceptionBloc _bloc = CounterExceptionBloc();
 
-        expectLater(_bloc.state, emitsInOrder(expected));
+        expectLater(_bloc, emitsInOrder(expected));
 
         _bloc.dispatch(CounterEvent.increment);
         _bloc.dispatch(CounterEvent.decrement);
@@ -464,7 +504,10 @@ void main() {
               expectedStacktrace = stacktrace;
             });
 
-        expectLater(_bloc.state, emitsInOrder(<int>[0])).then((dynamic _) {
+        expectLater(
+          _bloc,
+          emitsInOrder(<int>[0]),
+        ).then((dynamic _) {
           expect(expectedError, exception);
           expect(expectedStacktrace, isNotNull);
         });
@@ -482,7 +525,10 @@ void main() {
           },
         );
 
-        expectLater(_bloc.state, emitsInOrder(<int>[0])).then((dynamic _) {
+        expectLater(
+          _bloc,
+          emitsInOrder(<int>[0]),
+        ).then((dynamic _) {
           expect(
             capturedError,
             isStateError,
@@ -504,7 +550,7 @@ void main() {
         final List<int> expected = [0, -1];
         final CounterErrorBloc _bloc = CounterErrorBloc();
 
-        expectLater(_bloc.state, emitsInOrder(expected));
+        expectLater(_bloc, emitsInOrder(expected));
 
         _bloc.dispatch(CounterEvent.increment);
         _bloc.dispatch(CounterEvent.decrement);
@@ -522,7 +568,10 @@ void main() {
               expectedStacktrace = stacktrace;
             });
 
-        expectLater(_bloc.state, emitsInOrder(<int>[0])).then((dynamic _) {
+        expectLater(
+          _bloc,
+          emitsInOrder(<int>[0]),
+        ).then((dynamic _) {
           expect(expectedError, error);
           expect(expectedStacktrace, isNotNull);
         });

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -98,10 +98,6 @@ void main() {
       test('isBroadcast returns true', () {
         expect(simpleBloc.isBroadcast, isTrue);
       });
-
-      test('asBroadcastStream returns a broadcastStream', () {
-        expect(simpleBloc.asBroadcastStream().isBroadcast, isTrue);
-      });
     });
 
     group('Complex Bloc', () {
@@ -200,10 +196,6 @@ void main() {
 
       test('isBroadcast returns true', () {
         expect(complexBloc.isBroadcast, isTrue);
-      });
-
-      test('asBroadcastStream returns a broadcastStream', () {
-        expect(complexBloc.asBroadcastStream().isBroadcast, isTrue);
       });
     });
 
@@ -331,10 +323,6 @@ void main() {
       test('isBroadcast returns true', () {
         expect(counterBloc.isBroadcast, isTrue);
       });
-
-      test('asBroadcastStream returns a broadcastStream', () {
-        expect(counterBloc.asBroadcastStream().isBroadcast, isTrue);
-      });
     });
 
     group('Async Bloc', () {
@@ -458,10 +446,6 @@ void main() {
 
       test('isBroadcast returns true', () {
         expect(asyncBloc.isBroadcast, isTrue);
-      });
-
-      test('asBroadcastStream returns a broadcastStream', () {
-        expect(asyncBloc.asBroadcastStream().isBroadcast, isTrue);
       });
     });
 

--- a/packages/bloc/test/helpers/async/async_bloc.dart
+++ b/packages/bloc/test/helpers/async/async_bloc.dart
@@ -10,8 +10,8 @@ class AsyncBloc extends Bloc<AsyncEvent, AsyncState> {
 
   @override
   Stream<AsyncState> mapEventToState(AsyncEvent event) async* {
-    yield currentState.copyWith(isLoading: true);
+    yield state.copyWith(isLoading: true);
     await Future<void>.delayed(Duration(milliseconds: 500));
-    yield currentState.copyWith(isLoading: false, isSuccess: true);
+    yield state.copyWith(isLoading: false, isSuccess: true);
   }
 }

--- a/packages/bloc/test/helpers/counter/counter_bloc.dart
+++ b/packages/bloc/test/helpers/counter/counter_bloc.dart
@@ -25,10 +25,10 @@ class CounterBloc extends Bloc<CounterEvent, int> {
   Stream<int> mapEventToState(CounterEvent event) async* {
     switch (event) {
       case CounterEvent.decrement:
-        yield currentState - 1;
+        yield state - 1;
         break;
       case CounterEvent.increment:
-        yield currentState + 1;
+        yield state + 1;
         break;
     }
   }

--- a/packages/bloc/test/helpers/counter/counter_error_bloc.dart
+++ b/packages/bloc/test/helpers/counter/counter_error_bloc.dart
@@ -12,7 +12,7 @@ class CounterErrorBloc extends Bloc<CounterEvent, int> {
   Stream<int> mapEventToState(CounterEvent event) async* {
     switch (event) {
       case CounterEvent.decrement:
-        yield currentState - 1;
+        yield state - 1;
         break;
       case CounterEvent.increment:
         throw Error();

--- a/packages/bloc/test/helpers/counter/counter_exception_bloc.dart
+++ b/packages/bloc/test/helpers/counter/counter_exception_bloc.dart
@@ -12,7 +12,7 @@ class CounterExceptionBloc extends Bloc<CounterEvent, int> {
   Stream<int> mapEventToState(CounterEvent event) async* {
     switch (event) {
       case CounterEvent.decrement:
-        yield currentState - 1;
+        yield state - 1;
         break;
       case CounterEvent.increment:
         throw Exception('fatal exception');


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
YES

## Description
- Addresses #558 

### Refactor `Bloc` to extend `Stream<State>`
```dart
bloc.state.listen(print);
```

becomes

```dart
bloc.listen(print);
```

### Rename `currentState` to `state`

```dart
bloc.currentState
```

becomes

```dart
bloc.state
```

## Todos
- [X] Tests
- [ ] Documentation (will be added in a separate PR to avoid confusion before the update is published)
- [x] Examples

## Impact to Remaining Code Base
- Breaking change to the bloc API which will require a major version bump + updates to `flutter_bloc` and `angular_bloc`