### PR TITLE
Bloc implements Sink<Event>

### DIFF
--- a/packages/bloc/README.md
+++ b/packages/bloc/README.md
@@ -26,11 +26,11 @@ This design pattern helps to separate _presentation_ from _business logic_. Foll
 
 ## Glossary
 
-**Events** are the input to a Bloc. They are commonly UI events such as button presses. `Events` are `dispatched` and then converted to `States`.
+**Events** are the input to a Bloc. They are commonly UI events such as button presses. `Events` are `added` to the Bloc and then converted to `States`.
 
 **States** are the output of a Bloc. Presentation components can listen to the stream of states and redraw portions of themselves based on the given state (see `BlocBuilder` for more details).
 
-**Transitions** occur when an `Event` is `dispatched` after `mapEventToState` has been called but before the `Bloc`'s state has been updated. A `Transition` consists of the currentState, the event which was dispatched, and the nextState.
+**Transitions** occur when an `Event` is `added` after `mapEventToState` has been called but before the `Bloc`'s state has been updated. A `Transition` consists of the currentState, the event which was added, and the nextState.
 
 **BlocSupervisor** oversees `Bloc`s and delegates to `BlocDelegate`.
 
@@ -40,25 +40,25 @@ This design pattern helps to separate _presentation_ from _business logic_. Foll
 
 **initialState** is the state before any events have been processed (before `mapEventToState` has ever been called). `initialState` **must be implemented**.
 
-**mapEventToState** is a method that **must be implemented** when a class extends `Bloc`. The function takes the incoming event as an argument. `mapEventToState` is called whenever an event is `dispatched` by the presentation layer. `mapEventToState` must convert that event into a new state and return the new state in the form of a `Stream` which is consumed by the presentation layer.
+**mapEventToState** is a method that **must be implemented** when a class extends `Bloc`. The function takes the incoming event as an argument. `mapEventToState` is called whenever an event is `added` by the presentation layer. `mapEventToState` must convert that event into a new state and return the new state in the form of a `Stream` which is consumed by the presentation layer.
 
-**dispatch** is a method that takes an `event` and triggers `mapEventToState`. `dispatch` may be called from the presentation layer or from within the Bloc (see examples) and notifies the Bloc of a new `event`.
+**add** is a method that takes an `event` and triggers `mapEventToState`. `add` may be called from the presentation layer or from within the Bloc (see examples) and notifies the Bloc of a new `event`.
 
 **transformEvents** is a method that transforms the `Stream<Event>` along with a `next` function into a `Stream<State>`. Events that should be processed by `mapEventToState` need to be passed to `next`. **By default `asyncExpand` is used to ensure all events are processed in the order in which they are received**. You can override `transformEvents` for advanced usage in order to manipulate the frequency and specificity with which `mapEventToState` is called as well as which events are processed.
 
 **transformStates** is a method that transforms the `Stream<State>` into a new `Stream<State>`. By default `transformStates` returns the incoming `Stream<State>`. You can override `transformStates` for advanced usage in order to manipulate the frequency and specificity at which `transitions` (state changes) occur.
 
-**onEvent** is a method that can be overridden to handle whenever an `Event` is dispatched. **It is a great place to add bloc-specific logging/analytics**.
+**onEvent** is a method that can be overridden to handle whenever an `Event` is added. **It is a great place to add bloc-specific logging/analytics**.
 
-**onTransition** is a method that can be overridden to handle whenever a `Transition` occurs. A `Transition` occurs when a new `Event` is dispatched and `mapEventToState` is called. `onTransition` is called before a `Bloc`'s state has been updated. **It is a great place to add bloc-specific logging/analytics**.
+**onTransition** is a method that can be overridden to handle whenever a `Transition` occurs. A `Transition` occurs when a new `Event` is added and `mapEventToState` is called. `onTransition` is called before a `Bloc`'s state has been updated. **It is a great place to add bloc-specific logging/analytics**.
 
 **onError** is a method that can be overridden to handle whenever an `Exception` is thrown. By default all exceptions will be ignored and `Bloc` functionality will be unaffected. **It is a great place to add bloc-specific error handling**.
 
-**dispose** is a method that closes the `event` and `state` streams. `Dispose` should be called when a `Bloc` is no longer needed. Once `dispose` is called, `events` that are `dispatched` will not be processed and will result in an error being passed to `onError`. In addition, if `dispose` is called while `events` are still being processed, any `states` yielded after are ignored and will not result in a `Transition`.
+**close** is a method that closes the `event` and `state` streams. `close` should be called when a `Bloc` is no longer needed. Once `close` is called, `events` that are `added` will not be processed and will result in an error being passed to `onError`. In addition, if `close` is called while `events` are still being processed, any `states` yielded after are ignored and will not result in a `Transition`.
 
 ## BlocDelegate Interface
 
-**onEvent** is a method that can be overridden to handle whenever an `Event` is dispatched to **any** `Bloc`. **It is a great place to add universal logging/analytics**.
+**onEvent** is a method that can be overridden to handle whenever an `Event` is added to **any** `Bloc`. **It is a great place to add universal logging/analytics**.
 
 **onTransition** is a method that can be overridden to handle whenever a `Transition` occurs in **any** `Bloc`. **It is a great place to add universal logging/analytics**.
 
@@ -95,19 +95,19 @@ As a result, we need to define our `CounterEvent` like:
 enum CounterEvent { increment, decrement }
 ```
 
-Then we can dispatch events to our bloc like so:
+Then we can add events to our bloc like so:
 
 ```dart
 void main() {
   final counterBloc = CounterBloc();
 
-  counterBloc.dispatch(CounterEvent.increment);
-  counterBloc.dispatch(CounterEvent.increment);
-  counterBloc.dispatch(CounterEvent.increment);
+  counterBloc.add(CounterEvent.increment);
+  counterBloc.add(CounterEvent.increment);
+  counterBloc.add(CounterEvent.increment);
 
-  counterBloc.dispatch(CounterEvent.decrement);
-  counterBloc.dispatch(CounterEvent.decrement);
-  counterBloc.dispatch(CounterEvent.decrement);
+  counterBloc.add(CounterEvent.decrement);
+  counterBloc.add(CounterEvent.decrement);
+  counterBloc.add(CounterEvent.decrement);
 }
 ```
 
@@ -131,19 +131,19 @@ void main() {
 
   final counterBloc = CounterBloc();
 
-  counterBloc.dispatch(CounterEvent.increment); // { currentState: 0, event: CounterEvent.increment, nextState: 1 }
-  counterBloc.dispatch(CounterEvent.increment); // { currentState: 1, event: CounterEvent.increment, nextState: 2 }
-  counterBloc.dispatch(CounterEvent.increment); // { currentState: 2, event: CounterEvent.increment, nextState: 3 }
+  counterBloc.add(CounterEvent.increment); // { currentState: 0, event: CounterEvent.increment, nextState: 1 }
+  counterBloc.add(CounterEvent.increment); // { currentState: 1, event: CounterEvent.increment, nextState: 2 }
+  counterBloc.add(CounterEvent.increment); // { currentState: 2, event: CounterEvent.increment, nextState: 3 }
 
-  counterBloc.dispatch(CounterEvent.decrement); // { currentState: 3, event: CounterEvent.decrement, nextState: 2 }
-  counterBloc.dispatch(CounterEvent.decrement); // { currentState: 2, event: CounterEvent.decrement, nextState: 1 }
-  counterBloc.dispatch(CounterEvent.decrement); // { currentState: 1, event: CounterEvent.decrement, nextState: 0 }
+  counterBloc.add(CounterEvent.decrement); // { currentState: 3, event: CounterEvent.decrement, nextState: 2 }
+  counterBloc.add(CounterEvent.decrement); // { currentState: 2, event: CounterEvent.decrement, nextState: 1 }
+  counterBloc.add(CounterEvent.decrement); // { currentState: 1, event: CounterEvent.decrement, nextState: 0 }
 }
 ```
 
 At this point, all `Bloc` `Transitions` will be reported to the `SimpleBlocDelegate` and we can see them in the console after running our app.
 
-If we want to be able to handle any incoming `Events` that are dispatched to a `Bloc` we can also override `onEvent` in our `SimpleBlocDelegate`.
+If we want to be able to handle any incoming `Events` that are added to a `Bloc` we can also override `onEvent` in our `SimpleBlocDelegate`.
 
 ```dart
 class SimpleBlocDelegate extends BlocDelegate {

--- a/packages/bloc/example/main.dart
+++ b/packages/bloc/example/main.dart
@@ -52,17 +52,17 @@ void main() {
 
   final counterBloc = CounterBloc();
 
-  counterBloc.dispatch(CounterEvent.increment);
-  counterBloc.dispatch(CounterEvent.increment);
-  counterBloc.dispatch(CounterEvent.increment);
+  counterBloc.add(CounterEvent.increment);
+  counterBloc.add(CounterEvent.increment);
+  counterBloc.add(CounterEvent.increment);
 
-  counterBloc.dispatch(CounterEvent.decrement);
-  counterBloc.dispatch(CounterEvent.decrement);
-  counterBloc.dispatch(CounterEvent.decrement);
+  counterBloc.add(CounterEvent.decrement);
+  counterBloc.add(CounterEvent.decrement);
+  counterBloc.add(CounterEvent.decrement);
 
-  counterBloc.dispatch(null); // Triggers Exception
+  counterBloc.add(null); // Triggers Exception
 
   // The exception triggers `SimpleBlocDelegate.onError` but does not impact bloc functionality.
-  counterBloc.dispatch(CounterEvent.increment);
-  counterBloc.dispatch(CounterEvent.decrement);
+  counterBloc.add(CounterEvent.increment);
+  counterBloc.add(CounterEvent.decrement);
 }

--- a/packages/bloc/example/pubspec.yaml
+++ b/packages/bloc/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: example
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.0.0-dev.28.0 <3.0.0"
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
   bloc:

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -6,7 +6,7 @@ import 'package:rxdart/rxdart.dart';
 
 /// Takes a [Stream] of [Event]s as input
 /// and transforms them into a [Stream] of [State]s as output.
-abstract class Bloc<Event, State> extends Stream<State> {
+abstract class Bloc<Event, State> extends Stream<State> implements Sink<Event> {
   final PublishSubject<Event> _eventSubject = PublishSubject<Event>();
 
   BehaviorSubject<State> _stateSubject;
@@ -58,13 +58,12 @@ abstract class Bloc<Event, State> extends Stream<State> {
   /// A great spot to handle exceptions at the individual [Bloc] level.
   void onError(Object error, StackTrace stacktrace) => null;
 
-  /// Takes an [Event] and triggers `mapEventToState`.
-  /// `Dispatch` may be called from the presentation layer or from within the [Bloc].
-  /// `Dispatch` notifies the [Bloc] of a new [Event].
-  /// If `dispose` has already been called, any subsequent calls to `dispatch` will
+  /// Notifies the [Bloc] of a new [Event] which triggers `mapEventToState`.
+  /// If `close` has already been called, any subsequent calls to `add` will
   /// be delegated to the `onError` method which can be overriden at the [Bloc]
   /// as well as the [BlocDelegate] level.
-  void dispatch(Event event) {
+  @override
+  void add(Event event) {
     try {
       BlocSupervisor.delegate.onEvent(this, event);
       onEvent(event);
@@ -76,10 +75,29 @@ abstract class Bloc<Event, State> extends Stream<State> {
 
   /// Closes the [Event] and [State] [Stream]s.
   /// This method should be called when a [Bloc] is no longer needed.
-  /// Once `dispose` is called, events that are `dispatched` will not be
+  /// Once `close` is called, events that are `added` will not be
   /// processed and will result in an error being passed to `onError`.
-  /// In addition, if `dispose` is called while [Event]s are still being processed,
+  /// In addition, if `close` is called while [Event]s are still being processed,
   /// any [State]s yielded after are ignored and will not result in a [Transition].
+  @override
+  @mustCallSuper
+  void close() {
+    _eventSubject.close();
+    _stateSubject.close();
+  }
+
+  @Deprecated('Please use add instead.')
+  void dispatch(Event event) {
+    try {
+      BlocSupervisor.delegate.onEvent(this, event);
+      onEvent(event);
+      _eventSubject.sink.add(event);
+    } catch (error) {
+      _handleError(error);
+    }
+  }
+
+  @Deprecated('Please use close instead.')
   @mustCallSuper
   void dispose() {
     _eventSubject.close();

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -87,22 +87,11 @@ abstract class Bloc<Event, State> extends Stream<State> implements Sink<Event> {
   }
 
   @Deprecated('Please use add instead.')
-  void dispatch(Event event) {
-    try {
-      BlocSupervisor.delegate.onEvent(this, event);
-      onEvent(event);
-      _eventSubject.sink.add(event);
-    } catch (error) {
-      _handleError(error);
-    }
-  }
+  void dispatch(Event event) => add(event);
 
   @Deprecated('Please use close instead.')
   @mustCallSuper
-  void dispose() {
-    _eventSubject.close();
-    _stateSubject.close();
-  }
+  void dispose() => close();
 
   /// Transforms the `Stream<Event>` along with a `next` function into a `Stream<State>`.
   /// Events that should be processed by `mapEventToState` need to be passed to `next`.

--- a/packages/bloc/test/bloc_delegate_test.dart
+++ b/packages/bloc/test/bloc_delegate_test.dart
@@ -34,7 +34,7 @@ void main() {
         ).called(1);
       });
 
-      complexBloc.dispatch(ComplexEventB());
+      complexBloc.add(ComplexEventB());
     });
 
     test('is called when delegate is provided for multiple blocs', () {
@@ -76,8 +76,8 @@ void main() {
         ).called(1);
       });
 
-      complexBlocA.dispatch(ComplexEventB());
-      complexBlocB.dispatch(ComplexEventC());
+      complexBlocA.add(ComplexEventB());
+      complexBlocB.add(ComplexEventC());
     });
 
     test('is not called when delegate is not provided', () {
@@ -102,7 +102,7 @@ void main() {
         );
       });
 
-      complexBloc.dispatch(ComplexEventB());
+      complexBloc.add(ComplexEventB());
     });
   });
   group('onTransition', () {
@@ -136,7 +136,7 @@ void main() {
         ).called(1);
       });
 
-      complexBloc.dispatch(ComplexEventB());
+      complexBloc.add(ComplexEventB());
     });
 
     test('is called when delegate is provided for multiple blocs', () {
@@ -186,8 +186,8 @@ void main() {
         ).called(1);
       });
 
-      complexBlocA.dispatch(ComplexEventB());
-      complexBlocB.dispatch(ComplexEventC());
+      complexBlocA.add(ComplexEventB());
+      complexBlocB.add(ComplexEventC());
     });
 
     test('is not called when delegate is not provided', () {
@@ -216,7 +216,7 @@ void main() {
         );
       });
 
-      complexBloc.dispatch(ComplexEventB());
+      complexBloc.add(ComplexEventB());
     });
   });
 
@@ -246,7 +246,7 @@ void main() {
         expect(blocWithError, _bloc);
       });
 
-      _bloc.dispatch(CounterEvent.increment);
+      _bloc.add(CounterEvent.increment);
     });
   });
 }

--- a/packages/bloc/test/deprecated_bloc_test.dart
+++ b/packages/bloc/test/deprecated_bloc_test.dart
@@ -22,7 +22,7 @@ void main() {
         BlocSupervisor.delegate = delegate;
       });
 
-      test('close does not emit new states over the state stream', () {
+      test('dispose does not emit new states over the state stream', () {
         final List<Matcher> expectedStates = [equals(''), emitsDone];
 
         expectLater(
@@ -30,7 +30,7 @@ void main() {
           emitsInOrder(expectedStates),
         );
 
-        simpleBloc.close();
+        simpleBloc.dispose();
       });
 
       test('initialState returns correct value', () {
@@ -41,7 +41,7 @@ void main() {
         expect(simpleBloc.state, '');
       });
 
-      test('state should equal initial state before any events are added',
+      test('state should equal initial state before any events are dispatched',
           () async {
         final initialState = await simpleBloc.first;
         expect(initialState, simpleBloc.initialState);
@@ -67,7 +67,7 @@ void main() {
           expect(simpleBloc.state, 'data');
         });
 
-        simpleBloc.add('event');
+        simpleBloc.dispatch('event');
       });
 
       test('should map multiple events to correct states', () {
@@ -90,9 +90,9 @@ void main() {
           expect(simpleBloc.state, 'data');
         });
 
-        simpleBloc.add('event1');
-        simpleBloc.add('event2');
-        simpleBloc.add('event3');
+        simpleBloc.dispatch('event1');
+        simpleBloc.dispatch('event2');
+        simpleBloc.dispatch('event3');
       });
 
       test('isBroadcast returns true', () {
@@ -112,7 +112,7 @@ void main() {
         BlocSupervisor.delegate = delegate;
       });
 
-      test('close does not emit new states over the state stream', () {
+      test('dispose does not emit new states over the state stream', () {
         final List<Matcher> expectedStates = [
           equals(ComplexStateA()),
           emitsDone
@@ -123,7 +123,7 @@ void main() {
           emitsInOrder(expectedStates),
         );
 
-        complexBloc.close();
+        complexBloc.dispose();
       });
 
       test('initialState returns ComplexStateA', () {
@@ -134,7 +134,7 @@ void main() {
         expect(complexBloc.state, ComplexStateA());
       });
 
-      test('state should equal initial state before any events are added',
+      test('state should equal initial state before any events are dispatched',
           () async {
         final initialState = await complexBloc.first;
         expect(initialState, complexBloc.initialState);
@@ -163,7 +163,7 @@ void main() {
           expect(complexBloc.state, ComplexStateB());
         });
 
-        complexBloc.add(ComplexEventB());
+        complexBloc.dispatch(ComplexEventB());
       });
 
       test('should map multiple events to correct states', () async {
@@ -180,18 +180,18 @@ void main() {
           emitsInOrder(expectedStates),
         );
 
-        complexBloc.add(ComplexEventA());
+        complexBloc.dispatch(ComplexEventA());
         await Future<void>.delayed(Duration(milliseconds: 20));
-        complexBloc.add(ComplexEventB());
+        complexBloc.dispatch(ComplexEventB());
         await Future<void>.delayed(Duration(milliseconds: 20));
-        complexBloc.add(ComplexEventC());
+        complexBloc.dispatch(ComplexEventC());
         await Future<void>.delayed(Duration(milliseconds: 20));
-        complexBloc.add(ComplexEventD());
+        complexBloc.dispatch(ComplexEventD());
         await Future<void>.delayed(Duration(milliseconds: 200));
-        complexBloc.add(ComplexEventC());
-        complexBloc.add(ComplexEventA());
+        complexBloc.dispatch(ComplexEventC());
+        complexBloc.dispatch(ComplexEventA());
         await Future<void>.delayed(Duration(milliseconds: 120));
-        complexBloc.add(ComplexEventC());
+        complexBloc.dispatch(ComplexEventC());
       });
 
       test('isBroadcast returns true', () {
@@ -236,7 +236,7 @@ void main() {
         expect(counterBloc.state, 0);
       });
 
-      test('state should equal initial state before any events are added',
+      test('state should equal initial state before any events are dispatched',
           () async {
         final initialState = await counterBloc.first;
         expect(initialState, counterBloc.initialState);
@@ -266,7 +266,7 @@ void main() {
           expect(counterBloc.state, 1);
         });
 
-        counterBloc.add(CounterEvent.increment);
+        counterBloc.dispatch(CounterEvent.increment);
       });
 
       test('multiple Increment event updates state to 3', () {
@@ -315,9 +315,9 @@ void main() {
           expect(counterBloc.state, 3);
         });
 
-        counterBloc.add(CounterEvent.increment);
-        counterBloc.add(CounterEvent.increment);
-        counterBloc.add(CounterEvent.increment);
+        counterBloc.dispatch(CounterEvent.increment);
+        counterBloc.dispatch(CounterEvent.increment);
+        counterBloc.dispatch(CounterEvent.increment);
       });
 
       test('isBroadcast returns true', () {
@@ -337,7 +337,7 @@ void main() {
         BlocSupervisor.delegate = delegate;
       });
 
-      test('close does not emit new states over the state stream', () {
+      test('dispose does not emit new states over the state stream', () {
         final List<Matcher> expectedStates = [
           equals(AsyncState.initial()),
           emitsDone
@@ -348,11 +348,11 @@ void main() {
           emitsInOrder(expectedStates),
         );
 
-        asyncBloc.close();
+        asyncBloc.dispose();
       });
 
       test(
-          'close while events are pending does not emit new states or trigger onError',
+          'dispose while events are pending does not emit new states or trigger onError',
           () {
         final List<Matcher> expectedStates = [
           equals(AsyncState.initial()),
@@ -364,8 +364,8 @@ void main() {
           emitsInOrder(expectedStates),
         );
 
-        asyncBloc.add(AsyncEvent());
-        asyncBloc.close();
+        asyncBloc.dispatch(AsyncEvent());
+        asyncBloc.dispose();
 
         verifyNever(delegate.onError(any, any, any));
       });
@@ -378,7 +378,7 @@ void main() {
         expect(asyncBloc.state, AsyncState.initial());
       });
 
-      test('state should equal initial state before any events are added',
+      test('state should equal initial state before any events are dispatched',
           () async {
         final initialState = await asyncBloc.first;
         expect(initialState, asyncBloc.initialState);
@@ -441,7 +441,7 @@ void main() {
           );
         });
 
-        asyncBloc.add(AsyncEvent());
+        asyncBloc.dispatch(AsyncEvent());
       });
 
       test('isBroadcast returns true', () {
@@ -472,8 +472,8 @@ void main() {
 
         expectLater(_bloc, emitsInOrder(expected));
 
-        _bloc.add(CounterEvent.increment);
-        _bloc.add(CounterEvent.decrement);
+        _bloc.dispatch(CounterEvent.increment);
+        _bloc.dispatch(CounterEvent.decrement);
       });
 
       test('triggers onError from mapEventToState', () {
@@ -496,10 +496,10 @@ void main() {
           expect(expectedStacktrace, isNotNull);
         });
 
-        _bloc.add(CounterEvent.increment);
+        _bloc.dispatch(CounterEvent.increment);
       });
 
-      test('triggers onError from add', () {
+      test('triggers onError from dispatch', () {
         Object capturedError;
         StackTrace capturedStacktrace;
         final CounterBloc _bloc = CounterBloc(
@@ -524,8 +524,8 @@ void main() {
           expect(capturedStacktrace, isNull);
         });
 
-        _bloc.close();
-        _bloc.add(CounterEvent.increment);
+        _bloc.dispose();
+        _bloc.dispatch(CounterEvent.increment);
       });
     });
 
@@ -536,8 +536,8 @@ void main() {
 
         expectLater(_bloc, emitsInOrder(expected));
 
-        _bloc.add(CounterEvent.increment);
-        _bloc.add(CounterEvent.decrement);
+        _bloc.dispatch(CounterEvent.increment);
+        _bloc.dispatch(CounterEvent.decrement);
       });
 
       test('triggers onError from mapEventToState', () {
@@ -560,7 +560,7 @@ void main() {
           expect(expectedStacktrace, isNotNull);
         });
 
-        _bloc.add(CounterEvent.increment);
+        _bloc.dispatch(CounterEvent.increment);
       });
     });
   });


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Addresses #558 

```dart
bloc.dispatch
```

becomes

```dart
bloc.add
```

And

```dart
bloc.dispose
```

becomes

```dart
bloc.close
```

## Todos
- [X] Tests
- [X] Documentation
- [x] Examples

## Impact to Remaining Code Base
- `dispatch` and `dispose` are deprecated and will be removed in the next major version