### PR TITLE
update angular_bloc to use bloc v0.16.0

### DIFF
--- a/examples/angular_counter/lib/src/counter_page/counter_bloc.dart
+++ b/examples/angular_counter/lib/src/counter_page/counter_bloc.dart
@@ -12,10 +12,10 @@ class CounterBloc extends Bloc<CounterEvent, int> {
   Stream<int> mapEventToState(CounterEvent event) async* {
     switch (event) {
       case CounterEvent.decrement:
-        yield currentState - 1;
+        yield state - 1;
         break;
       case CounterEvent.increment:
-        yield currentState + 1;
+        yield state + 1;
         break;
     }
   }

--- a/examples/angular_counter/lib/src/counter_page/counter_page_component.dart
+++ b/examples/angular_counter/lib/src/counter_page/counter_page_component.dart
@@ -20,14 +20,14 @@ class CounterPageComponent implements OnDestroy {
 
   @override
   void ngOnDestroy() {
-    counterBloc.dispose();
+    counterBloc.close();
   }
 
   void increment() {
-    counterBloc.dispatch(CounterEvent.increment);
+    counterBloc.add(CounterEvent.increment);
   }
 
   void decrement() {
-    counterBloc.dispatch(CounterEvent.decrement);
+    counterBloc.add(CounterEvent.decrement);
   }
 }

--- a/examples/angular_counter/pubspec.yaml
+++ b/examples/angular_counter/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
 
 dev_dependencies:
   angular_test: ^2.0.0
-  build_runner: ">=1.5.0 <2.0.0"
+  build_runner: ">=1.6.2 <2.0.0"
   build_test: ^0.10.2
   build_web_compilers: ">=1.2.0 <3.0.0"
   test: ^1.0.0

--- a/examples/github_search/angular_github_search/lib/src/search_form/search_bar/search_bar_component.dart
+++ b/examples/github_search/angular_github_search/lib/src/search_form/search_bar/search_bar_component.dart
@@ -11,6 +11,6 @@ class SearchBarComponent {
   GithubSearchBloc githubSearchBloc;
 
   void onTextChanged(String text) {
-    githubSearchBloc.dispatch(TextChanged(text: text));
+    githubSearchBloc.add(TextChanged(text: text));
   }
 }

--- a/examples/github_search/angular_github_search/lib/src/search_form/search_form_component.dart
+++ b/examples/github_search/angular_github_search/lib/src/search_form/search_form_component.dart
@@ -29,6 +29,6 @@ class SearchFormComponent implements OnInit, OnDestroy {
 
   @override
   void ngOnDestroy() {
-    githubSearchBloc.dispose();
+    githubSearchBloc.close();
   }
 }

--- a/packages/angular_bloc/CHANGELOG.md
+++ b/packages/angular_bloc/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.11.0
+
+Updated to `bloc: ^0.16.0` and Minor Updates to Documentation
+
 # 0.10.0
 
 Updated to `bloc: ^0.15.0` and Minor Updates to Documentation

--- a/packages/angular_bloc/README.md
+++ b/packages/angular_bloc/README.md
@@ -37,10 +37,10 @@ class CounterBloc extends Bloc<CounterEvent, int> {
   Stream<int> mapEventToState(CounterEvent event) async* {
     switch (event) {
       case CounterEvent.decrement:
-        yield currentState - 1;
+        yield state - 1;
         break;
       case CounterEvent.increment:
-        yield currentState + 1;
+        yield state + 1;
         break;
     }
   }
@@ -89,15 +89,15 @@ class CounterPageComponent implements OnInit, OnDestroy {
 
   @override
   void ngOnDestroy() {
-    counterBloc.dispose();
+    counterBloc.close();
   }
 
   void increment() {
-    counterBloc.dispatch(CounterEvent.increment);
+    counterBloc.add(CounterEvent.increment);
   }
 
   void decrement() {
-    counterBloc.dispatch(CounterEvent.decrement);
+    counterBloc.add(CounterEvent.decrement);
   }
 }
 ```

--- a/packages/angular_bloc/example/example.dart
+++ b/packages/angular_bloc/example/example.dart
@@ -28,10 +28,10 @@ class CounterBloc extends Bloc<CounterEvent, int> {
   Stream<int> mapEventToState(CounterEvent event) async* {
     switch (event) {
       case CounterEvent.decrement:
-        yield currentState - 1;
+        yield state - 1;
         break;
       case CounterEvent.increment:
-        yield currentState + 1;
+        yield state + 1;
         break;
     }
   }
@@ -56,14 +56,14 @@ class CounterPageComponent implements OnInit, OnDestroy {
 
   @override
   void ngOnDestroy() {
-    counterBloc.dispose();
+    counterBloc.close();
   }
 
   void increment() {
-    counterBloc.dispatch(CounterEvent.increment);
+    counterBloc.add(CounterEvent.increment);
   }
 
   void decrement() {
-    counterBloc.dispatch(CounterEvent.decrement);
+    counterBloc.add(CounterEvent.decrement);
   }
 }

--- a/packages/angular_bloc/lib/src/pipes/bloc_pipe.dart
+++ b/packages/angular_bloc/lib/src/pipes/bloc_pipe.dart
@@ -38,7 +38,7 @@ class BlocPipe implements OnDestroy, PipeTransform {
 
   void _subscribe(Bloc bloc) {
     _bloc = bloc;
-    _subscription = bloc.state.listen(
+    _subscription = bloc.listen(
         (Object value) => _updateLatestValue(bloc, value),
         onError: (dynamic e) => throw e);
   }

--- a/packages/angular_bloc/pubspec.yaml
+++ b/packages/angular_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: angular_bloc
 description: Angular Components that make it easy to implement the BLoC (Business Logic Component) design pattern. Built to be used with the bloc state management package.
-version: 0.10.0
+version: 0.11.0
 author: Felix Angelov <felangelov@gmail.com>
 repository: https://github.com/felangel/bloc
 issue_tracker: https://github.com/felangel/bloc/issues
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   angular: ^5.0.0
-  bloc: ^0.15.0
+  bloc: ^0.16.0
 
 dependency_overrides:
   package_resolver: 1.0.6

--- a/packages/angular_bloc/test/bloc_pipe_test.dart
+++ b/packages/angular_bloc/test/bloc_pipe_test.dart
@@ -21,10 +21,10 @@ class CounterBloc extends Bloc<CounterEvent, int> {
   Stream<int> mapEventToState(CounterEvent event) async* {
     switch (event) {
       case CounterEvent.decrement:
-        yield currentState - 1;
+        yield state - 1;
         break;
       case CounterEvent.increment:
-        yield currentState + 1;
+        yield state + 1;
         break;
     }
   }
@@ -48,7 +48,7 @@ void main() {
       });
       test('should return the latest available value', () async {
         pipe.transform(bloc);
-        bloc.dispatch(CounterEvent.increment);
+        bloc.add(CounterEvent.increment);
         Timer.run(expectAsync0(() {
           final dynamic res = pipe.transform(bloc);
           expect(res, 1);
@@ -59,7 +59,7 @@ void main() {
           'should return same value when nothing has changed '
           'since the last call', () async {
         pipe.transform(bloc);
-        bloc.dispatch(CounterEvent.increment);
+        bloc.add(CounterEvent.increment);
         Timer.run(expectAsync0(() {
           pipe.transform(bloc);
           expect(pipe.transform(bloc), 1);
@@ -73,7 +73,7 @@ void main() {
         var newBloc = CounterBloc();
         expect(pipe.transform(newBloc), 0);
         // this should not affect the pipe
-        bloc.dispatch(CounterEvent.increment);
+        bloc.add(CounterEvent.increment);
         Timer.run(expectAsync0(() {
           expect(pipe.transform(newBloc), 0);
         }));
@@ -83,7 +83,7 @@ void main() {
         // See https://github.com/dart-lang/angular2/issues/260
         final _bloc = CounterBloc();
         expect(pipe.transform(_bloc), 0);
-        _bloc.dispatch(CounterEvent.increment);
+        _bloc.add(CounterEvent.increment);
         Timer.run(expectAsync0(() {
           expect(pipe.transform(_bloc), 1);
         }));
@@ -91,7 +91,7 @@ void main() {
       test('should request a change detection check upon receiving a new value',
           () async {
         pipe.transform(bloc);
-        bloc.dispatch(CounterEvent.increment);
+        bloc.add(CounterEvent.increment);
         Timer(const Duration(milliseconds: 10), expectAsync0(() {
           verify(ref.markForCheck()).called(2);
         }));
@@ -105,7 +105,7 @@ void main() {
       test('should dispose of the existing subscription', () async {
         pipe.transform(bloc);
         pipe.ngOnDestroy();
-        bloc.dispatch(CounterEvent.increment);
+        bloc.add(CounterEvent.increment);
         Timer.run(expectAsync0(() {
           expect(pipe.transform(bloc), 0);
         }));


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
YES

## Description
- Update `angular_bloc` to use `bloc ^v0.16.0`

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
- Breaking changes which will be introduced in `angular_bloc v0.11.0`