### PR TITLE
[flutter_firebase_login] add WidgetsFlutterBinding.ensureInitialized()

### DIFF
--- a/examples/flutter_firebase_login/lib/main.dart
+++ b/examples/flutter_firebase_login/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:flutter_firebase_login/splash_screen.dart';
 import 'package:flutter_firebase_login/simple_bloc_delegate.dart';
 
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
   BlocSupervisor.delegate = SimpleBlocDelegate();
   final UserRepository userRepository = UserRepository();
   runApp(


### PR DESCRIPTION
Add line:
`WidgetsFlutterBinding.ensureInitialized();`
to `lib/main.dart` `main()` to ensure plugin available in the flutter_firebase_login example.
See https://github.com/felangel/hydrated_bloc/issues/17

## Status
**READY** 
## Breaking Changes
NO

## Description
See above

## Related PRs
List related PRs against other branches:
Unknown

branch | PR
------ | ------
N/A

## Todos
N/A

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

Clone and test flutter_firebase_login example.
Shows blank screen without change.

## Impact to Remaining Code Base
This PR will affect:
N/A
* 
