### PR TITLE
update bloc.close to process pending events

### DIFF
--- a/packages/bloc/README.md
+++ b/packages/bloc/README.md
@@ -55,7 +55,7 @@ This design pattern helps to separate _presentation_ from _business logic_. Foll
 
 **onError** is a method that can be overridden to handle whenever an `Exception` is thrown. By default all exceptions will be ignored and `Bloc` functionality will be unaffected. **It is a great place to add bloc-specific error handling**.
 
-**close** is a method that closes the `event` and `state` streams. `close` should be called when a `Bloc` is no longer needed. Once `close` is called, `events` that are `added` will not be processed and will result in an error being passed to `onError`. In addition, if `close` is called while `events` are still being processed, any `states` yielded after are ignored and will not result in a `Transition`.
+**close** is a method that closes the `event` and `state` streams. `close` should be called when a `Bloc` is no longer needed. Once `close` is called, `events` that are `added` will not be processed and will result in an error being passed to `onError`. In addition, if `close` is called while `events` are still being processed the `bloc` will continue to process the pending `events` to completion.
 
 ## BlocDelegate Interface
 

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -81,12 +81,12 @@ abstract class Bloc<Event, State> extends Stream<State> implements Sink<Event> {
   /// Once [close] is called, `events` that are [add]ed will not be
   /// processed and will result in an error being passed to [onError].
   /// In addition, if [close] is called while `events` are still being processed,
-  /// any `states` yielded after are ignored and will not result in a `transition`.
+  /// the [bloc] will continue to process the pending `events` to completion.
   @override
   @mustCallSuper
-  void close() {
-    _eventSubject.close();
-    _stateSubject.close();
+  Future<void> close() async {
+    await _eventSubject.close();
+    await _stateSubject.close();
   }
 
   /// Transforms the [events] stream along with a [next] function into a `Stream<State>`.

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -346,17 +346,19 @@ void main() {
       });
 
       test(
-          'close while events are pending does not emit new states or trigger onError',
-          () {
-        final expectedStates = [equals(AsyncState.initial()), emitsDone];
-
-        expectLater(
-          asyncBloc,
-          emitsInOrder(expectedStates),
-        );
+          'close while events are pending finishes processing pending events and does not trigger onError',
+          () async {
+        final expectedStates = <AsyncState>[
+          AsyncState.initial(),
+          AsyncState.initial().copyWith(isLoading: true),
+          AsyncState.initial().copyWith(isSuccess: true),
+        ];
+        final states = <AsyncState>[];
+        asyncBloc.listen(states.add);
 
         asyncBloc.add(AsyncEvent());
-        asyncBloc.close();
+        await asyncBloc.close();
+        expect(states, expectedStates);
 
         verifyNever(delegate.onError(any, any, any));
       });


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
YES

## Description
Previously calling `close` on a bloc would immediately ignore all pending events. This pull request would change the behavior so that calling `close` would prevent new events from being processed while allowing pending events to finish being processed (see conversation in #611 and #639 for more details).

## Todos
- [X] Tests
- [x] Documentation
- [x] Examples

## Impact to Remaining Code Base
- Breaking change in bloc