### PR TITLE
Handle exceptions in onTransition

### DIFF
--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -161,9 +161,13 @@ abstract class Bloc<Event, State> extends Stream<State> implements Sink<Event> {
           event: currentEvent,
           nextState: nextState,
         );
-        BlocSupervisor.delegate.onTransition(this, transition);
-        onTransition(transition);
-        _stateSubject.add(nextState);
+        try {
+          BlocSupervisor.delegate.onTransition(this, transition);
+          onTransition(transition);
+          _stateSubject.add(nextState);
+        } on Object catch (error) {
+          _handleError(error);
+        }
       },
     );
   }

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -442,29 +442,29 @@ void main() {
 
     group('== operator', () {
       test('returns true for the same two CounterBlocs', () {
-        final _blocA = CounterBloc();
-        final _blocB = CounterBloc();
+        final blocA = CounterBloc();
+        final blocB = CounterBloc();
 
-        expect(_blocA == _blocB, true);
+        expect(blocA == blocB, true);
       });
 
       test('returns false for the two different Blocs', () {
-        final _blocA = CounterBloc();
-        final _blocB = ComplexBloc();
+        final blocA = CounterBloc();
+        final blocB = ComplexBloc();
 
-        expect(_blocA == _blocB, false);
+        expect(blocA == blocB, false);
       });
     });
 
     group('Exception', () {
       test('does not break stream', () {
         final expected = [0, -1];
-        final _bloc = CounterExceptionBloc();
+        final bloc = CounterExceptionBloc();
 
-        expectLater(_bloc, emitsInOrder(expected));
+        expectLater(bloc, emitsInOrder(expected));
 
-        _bloc.add(CounterEvent.increment);
-        _bloc.add(CounterEvent.decrement);
+        bloc.add(CounterEvent.increment);
+        bloc.add(CounterEvent.decrement);
       });
 
       test('triggers onError from mapEventToState', () {
@@ -472,7 +472,7 @@ void main() {
         Object expectedError;
         StackTrace expectedStacktrace;
 
-        final _bloc = OnExceptionBloc(
+        final bloc = OnExceptionBloc(
             exception: exception,
             onErrorCallback: (Object error, StackTrace stacktrace) {
               expectedError = error;
@@ -480,20 +480,20 @@ void main() {
             });
 
         expectLater(
-          _bloc,
+          bloc,
           emitsInOrder(<int>[0]),
         ).then((dynamic _) {
           expect(expectedError, exception);
           expect(expectedStacktrace, isNotNull);
         });
 
-        _bloc.add(CounterEvent.increment);
+        bloc.add(CounterEvent.increment);
       });
 
       test('triggers onError from add', () {
         Object capturedError;
         StackTrace capturedStacktrace;
-        final _bloc = CounterBloc(
+        final bloc = CounterBloc(
           onErrorCallback: (Object error, StackTrace stacktrace) {
             capturedError = error;
             capturedStacktrace = stacktrace;
@@ -501,7 +501,7 @@ void main() {
         );
 
         expectLater(
-          _bloc,
+          bloc,
           emitsInOrder(<int>[0]),
         ).then((dynamic _) {
           expect(
@@ -515,20 +515,27 @@ void main() {
           expect(capturedStacktrace, isNull);
         });
 
-        _bloc.close();
-        _bloc.add(CounterEvent.increment);
+        bloc.close();
+        bloc.add(CounterEvent.increment);
       });
     });
 
     group('Error', () {
+      MockBlocDelegate delegate;
+
+      setUp(() {
+        delegate = MockBlocDelegate();
+        BlocSupervisor.delegate = delegate;
+      });
+
       test('does not break stream', () {
         final expected = [0, -1];
-        final _bloc = CounterErrorBloc();
+        final bloc = CounterErrorBloc();
 
-        expectLater(_bloc, emitsInOrder(expected));
+        expectLater(bloc, emitsInOrder(expected));
 
-        _bloc.add(CounterEvent.increment);
-        _bloc.add(CounterEvent.decrement);
+        bloc.add(CounterEvent.increment);
+        bloc.add(CounterEvent.decrement);
       });
 
       test('triggers onError from mapEventToState', () {
@@ -536,22 +543,47 @@ void main() {
         Object expectedError;
         StackTrace expectedStacktrace;
 
-        final _bloc = OnErrorBloc(
-            error: error,
-            onErrorCallback: (Object error, StackTrace stacktrace) {
-              expectedError = error;
-              expectedStacktrace = stacktrace;
-            });
+        final bloc = OnErrorBloc(
+          error: error,
+          onErrorCallback: (Object error, StackTrace stacktrace) {
+            expectedError = error;
+            expectedStacktrace = stacktrace;
+          },
+        );
 
         expectLater(
-          _bloc,
+          bloc,
           emitsInOrder(<int>[0]),
         ).then((dynamic _) {
           expect(expectedError, error);
           expect(expectedStacktrace, isNotNull);
         });
 
-        _bloc.add(CounterEvent.increment);
+        bloc.add(CounterEvent.increment);
+      });
+
+      test('triggers onError from onTransition', () {
+        final error = Error();
+        Object expectedError;
+        StackTrace expectedStacktrace;
+
+        final bloc = OnTransitionErrorBloc(
+          error: error,
+          onErrorCallback: (Object error, StackTrace stacktrace) {
+            expectedError = error;
+            expectedStacktrace = stacktrace;
+          },
+        );
+
+        expectLater(
+          bloc,
+          emitsInOrder(<int>[0]),
+        ).then((dynamic _) {
+          expect(expectedError, error);
+          expect(expectedStacktrace, isNull);
+          expect(bloc.state, 0);
+        });
+        bloc.add(CounterEvent.increment);
       });
     });
   });

--- a/packages/bloc/test/helpers/counter/counter.dart
+++ b/packages/bloc/test/helpers/counter/counter.dart
@@ -3,3 +3,4 @@ export './counter_error_bloc.dart';
 export './counter_exception_bloc.dart';
 export './on_error_bloc.dart';
 export './on_exception_bloc.dart';
+export './on_transition_error_bloc.dart';

--- a/packages/bloc/test/helpers/counter/on_transition_error_bloc.dart
+++ b/packages/bloc/test/helpers/counter/on_transition_error_bloc.dart
@@ -1,0 +1,38 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+
+import '../counter/counter_bloc.dart';
+
+class OnTransitionErrorBloc extends Bloc<CounterEvent, int> {
+  final Function onErrorCallback;
+  final Error error;
+
+  OnTransitionErrorBloc({this.error, this.onErrorCallback});
+
+  @override
+  int get initialState => 0;
+
+  @override
+  void onError(Object error, StackTrace stacktrace) {
+    onErrorCallback(error, stacktrace);
+  }
+
+  @override
+  void onTransition(Transition<CounterEvent, int> transition) {
+    super.onTransition(transition);
+    throw error;
+  }
+
+  @override
+  Stream<int> mapEventToState(CounterEvent event) async* {
+    switch (event) {
+      case CounterEvent.increment:
+        yield state + 1;
+        break;
+      case CounterEvent.decrement:
+        yield state - 1;
+        break;
+    }
+  }
+}


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Exceptions thrown in `onTransition` should be passed to `onError` and should not break bloc functionality (#641)

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
None