### PR TITLE
Add MockBloc to bloc_test

### DIFF
--- a/packages/bloc_test/CHANGELOG.md
+++ b/packages/bloc_test/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.1.0
+
+- Added `MockBloc` for simplified bloc mocks
+- Documentation and example updates
+
 # 2.0.0
 
 - Updated to `bloc: ^2.0.0` and Documentation Updates

--- a/packages/bloc_test/README.md
+++ b/packages/bloc_test/README.md
@@ -19,9 +19,8 @@ A Dart package that makes testing blocs easy. Built to work with [bloc](https://
 
 ```dart
 import 'package:bloc_test/bloc_test.dart';
-import 'package:mockito/mockito.dart';
 
-class MockCounterBloc extends Mock implements CounterBloc {}
+class MockCounterBloc extends MockBloc<CounterEvent, int> implements CounterBloc {}
 ```
 
 ## Stub the Bloc Stream

--- a/packages/bloc_test/example/main.dart
+++ b/packages/bloc_test/example/main.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:bloc/bloc.dart';
 import 'package:bloc_test/bloc_test.dart';
-import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 enum CounterEvent { increment }
@@ -24,7 +23,8 @@ class CounterBloc extends Bloc<CounterEvent, int> {
 }
 
 // Mock Bloc
-class MockCounterBloc extends Mock implements CounterBloc {}
+class MockCounterBloc extends MockBloc<CounterEvent, int>
+    implements CounterBloc {}
 
 void main() {
   group('whenListen', () {

--- a/packages/bloc_test/lib/bloc_test.dart
+++ b/packages/bloc_test/lib/bloc_test.dart
@@ -2,4 +2,5 @@ library bloc_test;
 
 export 'src/bloc_test.dart';
 export 'src/emits_exactly.dart';
+export 'src/mock_bloc.dart';
 export 'src/when_listen.dart';

--- a/packages/bloc_test/lib/src/mock_bloc.dart
+++ b/packages/bloc_test/lib/src/mock_bloc.dart
@@ -1,0 +1,34 @@
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+import 'dart:async';
+
+import 'package:mockito/mockito.dart';
+
+/// Extend or mixin this class to mark the implementation as a [MockBloc].
+///
+/// A mocked bloc implements all fields and methods with a default
+/// implementation that does not throw a [NoSuchMethodError], and may be further
+/// customized at runtime to define how it may behave using [when] and [whenListen].
+///
+/// _**Note**: it is critical to explicitly provide the bloc event and state types_
+/// _when extending [MockBloc]_.
+///
+/// **GOOD**
+/// ```dart
+/// class MockCounterBloc extends MockBloc<CounterEvent, int>
+///   implements CounterBloc {}
+/// ```
+///
+/// **BAD**
+/// ```dart
+/// class MockCounterBloc extends MockBloc implements CounterBloc {}
+/// ```
+class MockBloc<E, S> extends Mock {
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    final memberName = invocation.memberName.toString().split('"')[1];
+    final result = super.noSuchMethod(invocation);
+    return (memberName == 'skip' && result == null)
+        ? Stream<S>.empty()
+        : result;
+  }
+}

--- a/packages/bloc_test/pubspec.yaml
+++ b/packages/bloc_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc_test
 description: A testing library which makes it easy to test blocs. Built to be used with the bloc state management package.
-version: 2.0.0
+version: 2.1.0
 author: Felix Angelov <felangelov@gmail.com>
 repository: https://github.com/felangel/bloc
 issue_tracker: https://github.com/felangel/bloc/issues

--- a/packages/bloc_test/test/emits_exactly_test.dart
+++ b/packages/bloc_test/test/emits_exactly_test.dart
@@ -8,7 +8,7 @@ void main() {
     test('throws AssertionError if bloc is null', () async {
       try {
         await emitsExactly(null, []);
-      } on Object catch (error) {
+      } on dynamic catch (error) {
         expect(error is AssertionError, true);
       }
     });

--- a/packages/bloc_test/test/mock_bloc_test.dart
+++ b/packages/bloc_test/test/mock_bloc_test.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:mockito/mockito.dart';
+
+import 'package:test/test.dart';
+
+import 'helpers/counter_bloc.dart';
+
+class MockCounterBloc extends MockBloc<CounterEvent, int>
+    implements CounterBloc {}
+
+void main() {
+  group('MockBloc', () {
+    CounterBloc counterBloc;
+
+    setUp(() {
+      counterBloc = MockCounterBloc();
+    });
+
+    test('is compatible with skip', () {
+      expect(counterBloc.skip(1) is Stream<int>, isTrue);
+    });
+
+    test('is compatible with when', () {
+      when(counterBloc.state).thenReturn(10);
+      expect(counterBloc.state, 10);
+    });
+
+    test('is automatically compatible with whenListen', () {
+      whenListen(counterBloc, Stream<int>.fromIterable([0, 1, 2, 3]));
+      expectLater(
+        counterBloc,
+        emitsInOrder(
+          <Matcher>[equals(0), equals(1), equals(2), equals(3), emitsDone],
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Add `MockBloc` to `bloc_test` in order to simplify bloc mocks (addresses #636)

Example:
```dart
class MockCounterBloc extends Mock implements CounterBloc {}

void main() {
  test('...', () {
    final bloc = MockCounterBloc();
    bloc.skip(1); // throws exception
  });
}
```

```dart
class MockCounterBloc extends MockBloc<CounterEvent, int> implements CounterBloc {}

void main() {
  test('...', () {
    final bloc = MockCounterBloc();
    bloc.skip(1); // is stubbed automatically to return an empty stream
  });
}
```

- `MockBloc` would also allow for specialized mocking functionality moving forward.

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
- New functionality to be included in bloc_test v2.1.0