### PR TITLE
previousState updating

### DIFF
--- a/packages/flutter_bloc/lib/src/bloc_builder.dart
+++ b/packages/flutter_bloc/lib/src/bloc_builder.dart
@@ -167,8 +167,8 @@ class _BlocBuilderBaseState<B extends Bloc<dynamic, S>, S>
           setState(() {
             _state = state;
           });
+          _previousState = state;
         }
-        _previousState = state;
       });
     }
   }


### PR DESCRIPTION
## Status
READY

## Breaking Changes
NO

## Description
Currently `BlocBuilder` is changing its `previousState` no matter the `Widget` was built or not. But this PR will update `previousState` only if the `Widget` was rebuilt.

This might be helpful when number of streams do changes to the `State` in bloc, but you need to rebuild `Widget` only if the all the changes are correctly done.

## Todos
- [x] Tests
- [x] Documentation
- [x] Examples


## Impact to Remaining Code Base
This PR will affect:

* `BlocBuilder` build logic is changed
