### PR TITLE
[Patch] flutter_bloc condition (previous state)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ pubspec.lock
 coverage/
 .test_coverage.dart
 *.log
+flutter_export_environment.sh
 !packages/**/example/ios/
 !packages/**/example/android/

--- a/packages/flutter_bloc/CHANGELOG.md
+++ b/packages/flutter_bloc/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.1
+
+- Fix `BlocBuilder` and `BlocListener` condition behavior to set `previousState` to the previous state used by `BlocBuilder`/`BlocListener` instead of the previous state of the `bloc`.
+- Minor Documentation Updates
+
 # 2.0.0
 
 - Updated to `bloc: ^2.0.0` and Documentation Updates

--- a/packages/flutter_bloc/lib/src/bloc_builder.dart
+++ b/packages/flutter_bloc/lib/src/bloc_builder.dart
@@ -49,9 +49,11 @@ typedef BlocBuilderCondition<S> = bool Function(S previous, S current);
 /// An optional [condition] can be implemented for more granular control
 /// over how often [BlocBuilder] rebuilds.
 /// The [condition] function will be invoked on each [bloc] [state] change.
-/// The [condition] takes the previous [state] and current [state] and must return a [bool]
-/// which determines whether or not the [builder] function will be invoked.
-/// The previous [state] will be initialized to [state] when the [BlocBuilder] is initialized.
+/// The [condition] takes the previous [state] built by [BlocBuilder] and
+/// the current [state] of the [bloc] and must return a [bool] which determines
+/// whether or not the [builder] function will be invoked.
+/// The previous [state] will be initialized to the [state] of the [bloc]
+/// when the [BlocBuilder] is initialized.
 /// [condition] is optional and if it isn't implemented, it will default to `true`.
 ///
 /// ```dart
@@ -166,9 +168,9 @@ class _BlocBuilderBaseState<B extends Bloc<dynamic, S>, S>
         if (widget.condition?.call(_previousState, state) ?? true) {
           setState(() {
             _state = state;
+            _previousState = state;
           });
         }
-        _previousState = state;
       });
     }
   }

--- a/packages/flutter_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/bloc_listener.dart
@@ -50,9 +50,11 @@ typedef BlocListenerCondition<S> = bool Function(S previous, S current);
 /// An optional [condition] can be implemented for more granular control
 /// over when [listener] is called.
 /// The [condition] function will be invoked on each [bloc] [state] change.
-/// The [condition] takes the previous [state] and current [state] and must return a [bool]
-/// which determines whether or not the [listener] function will be invoked.
-/// The previous [state] will be initialized to [state] when the [BlocListener] is initialized.
+/// The [condition] takes the previous [state] handled by [BlocListener] and
+/// the current [state] of the [bloc] and must return a [bool] which determines
+/// whether or not the [listener] function will be invoked.
+/// The previous [state] will be initialized to the [state] of the [bloc]
+/// when the [BlocListener] is initialized.
 /// [condition] is optional and if it isn't implemented, it will default to `true`.
 ///
 /// ```dart
@@ -189,8 +191,8 @@ class _BlocListenerBaseState<B extends Bloc<dynamic, S>, S>
       _subscription = _bloc.skip(1).listen((S state) {
         if (widget.condition?.call(_previousState, state) ?? true) {
           widget.listener(context, state);
+          _previousState = state;
         }
-        _previousState = state;
       });
     }
   }

--- a/packages/flutter_bloc/pubspec.yaml
+++ b/packages/flutter_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_bloc
 description: Flutter Widgets that make it easy to implement the BLoC (Business Logic Component) design pattern. Built to be used with the bloc state management package.
-version: 2.0.0
+version: 2.0.1
 author: Felix Angelov <felangelov@gmail.com>
 repository: https://github.com/felangel/bloc
 issue_tracker: https://github.com/felangel/bloc/issues

--- a/packages/flutter_bloc/test/bloc_builder_test.dart
+++ b/packages/flutter_bloc/test/bloc_builder_test.dart
@@ -445,7 +445,7 @@ void main() {
 
       final conditionalCounterText3 =
           tester.widget(find.byKey(Key('myCounterAppTextCondition'))) as Text;
-      expect(conditionalCounterText3.data, '2');
+      expect(conditionalCounterText3.data, '0');
 
       await tester.tap(incrementButtonFinder);
       await tester.pumpAndSettle();
@@ -456,7 +456,7 @@ void main() {
 
       final conditionalCounterText4 =
           tester.widget(find.byKey(Key('myCounterAppTextCondition'))) as Text;
-      expect(conditionalCounterText4.data, '2');
+      expect(conditionalCounterText4.data, '3');
     });
   });
 }

--- a/packages/flutter_bloc/test/bloc_listener_test.dart
+++ b/packages/flutter_bloc/test/bloc_listener_test.dart
@@ -259,7 +259,6 @@ void main() {
             conditionCallCount++;
             latestPreviousState = previous;
             latestState = state;
-
             return true;
           },
           listener: (BuildContext context, int state) {},
@@ -271,6 +270,40 @@ void main() {
         expect(conditionCallCount, 1);
         expect(latestPreviousState, 0);
         expect(latestState, 1);
+      });
+    });
+
+    testWidgets(
+        'calls condition with previous listener state and current bloc state',
+        (WidgetTester tester) async {
+      int latestPreviousState;
+      int latestState;
+      var conditionCallCount = 0;
+      final counterBloc = CounterBloc();
+      final expectedStates = [0, 1, 2, 3];
+      await tester.pumpWidget(
+        BlocListener(
+          bloc: counterBloc,
+          condition: (int previous, int state) {
+            conditionCallCount++;
+            if (previous + state % 3 == 0) {
+              latestPreviousState = previous;
+              latestState = state;
+              return true;
+            }
+            return false;
+          },
+          listener: (BuildContext context, int state) {},
+          child: Container(),
+        ),
+      );
+      counterBloc.add(CounterEvent.increment);
+      counterBloc.add(CounterEvent.increment);
+      counterBloc.add(CounterEvent.increment);
+      expectLater(counterBloc, emitsInOrder(expectedStates)).then((_) {
+        expect(conditionCallCount, 3);
+        expect(latestPreviousState, 0);
+        expect(latestState, 3);
       });
     });
 


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Patch `BlocBuilder` and `BlocListener` condition to be called with the previous used state of the bloc rather than the previous state of the bloc (#671)

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
None