### PR TITLE
bloc_test emitsExactly supports Iterable<Matcher>

### DIFF
--- a/packages/bloc_test/CHANGELOG.md
+++ b/packages/bloc_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.0
+
+- `emitsExactly` and `blocTest` support `Iterable<Matcher` ([#695](https://github.com/felangel/bloc/issues/695)).
+
 # 2.1.0
 
 - Add `MockBloc` to `bloc_test` in order to simplify bloc mocks (addresses [#636](https://github.com/felangel/bloc/issues/636))

--- a/packages/bloc_test/README.md
+++ b/packages/bloc_test/README.md
@@ -65,14 +65,14 @@ group('CounterBloc', () {
 });
 ```
 
-**Note:** when using `blocTest` with state classes you may need to explicitly provide the state type to the `expect` parameter if Dart cannot infer the type properly.
+**Note:** when using [blocTest] with state classes which don't override `==` and `hashCode` you can provide an `Iterable` of matchers instead of explicit state instances.
 
 ```dart
 blocTest(
   'emits [StateA, StateB] when MyEvent is added',
   build: () => MyBloc(),
   act: (bloc) => bloc.add(MyEvent()),
-  expect: <State>[StateA(), StateB()],
+  expect: [isA<StateA>(), isA<StateB>()],
 );
 ```
 
@@ -92,6 +92,16 @@ group('CounterBloc', () {
     bloc.add(CounterEvent.increment);
     await emitsExactly(bloc, [0, 1]);
   });
+});
+```
+
+[emitsExactly] also supports `Matchers` for states which don't override `==` and `hashCode`.
+
+```dart
+test('emits [StateA, StateB] when EventB is added', () async {
+  final bloc = MyBloc();
+  bloc.add(EventB());
+  await emitsExactly(bloc, [isA<StateA>(), isA<StateB>()]);
 });
 ```
 

--- a/packages/bloc_test/lib/src/bloc_test.dart
+++ b/packages/bloc_test/lib/src/bloc_test.dart
@@ -17,7 +17,7 @@ import 'package:test/test.dart';
 /// [act] is an optional callback which will be invoked with the [bloc] under test
 /// and should be used to `add` events to the bloc.
 ///
-/// [expect] is an `Iterable<State>` which the [bloc]
+/// [expect] is an `Iterable` of matchers which the [bloc]
 /// under test is expected to emit after [act] is executed.
 ///
 /// ```dart
@@ -40,23 +40,23 @@ import 'package:test/test.dart';
 /// );
 /// ```
 ///
-/// **Note:** when using [blocTest] with state classes you may need to
-/// explicitly provide the state type to the [expect] parameter if
-/// Dart cannot infer the type properly.
+/// **Note:** when using [blocTest] with state classes which don't override
+/// `==` and `hashCode` you can provide an `Iterable` of matchers instead of
+/// explicit state instances.
 ///
 /// ```dart
 /// blocTest(
 ///  'emits [StateA, StateB] when MyEvent is added',
 ///  build: () => MyBloc(),
 ///  act: (bloc) => bloc.add(MyEvent()),
-///  expect: <State>[StateA(), StateB()],
+///  expect: [isA<StateA>(), isA<StateB>()],
 /// );
 /// ```
 @isTest
 void blocTest<B extends Bloc<Event, State>, Event, State>(
   String description, {
   @required B build(),
-  @required Iterable<State> expect,
+  @required Iterable expect,
   Future<void> Function(B bloc) act,
 }) {
   test(description, () async {

--- a/packages/bloc_test/lib/src/emits_exactly.dart
+++ b/packages/bloc_test/lib/src/emits_exactly.dart
@@ -14,9 +14,20 @@ import 'package:test/test.dart';
 ///   await emitsExactly(bloc, [0, 1]);
 /// });
 /// ```
+///
+/// [emitsExactly] also supports `Matchers` for states
+/// which don't override `==` and `hashCode`.
+///
+/// ```dart
+/// test('emits [StateA, StateB] when EventB is added', () async {
+///   final bloc = MyBloc();
+///   bloc.add(EventB());
+///   await emitsExactly(bloc, [isA<StateA>(), isA<StateB>()]);
+/// });
+/// ```
 Future<void> emitsExactly<B extends Bloc<dynamic, State>, State>(
   B bloc,
-  Iterable<State> expected,
+  Iterable expected,
 ) async {
   assert(bloc != null);
   final states = <State>[];

--- a/packages/bloc_test/pubspec.yaml
+++ b/packages/bloc_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc_test
 description: A testing library which makes it easy to test blocs. Built to be used with the bloc state management package.
-version: 2.1.0
+version: 2.2.0
 author: Felix Angelov <felangelov@gmail.com>
 repository: https://github.com/felangel/bloc
 issue_tracker: https://github.com/felangel/bloc/issues

--- a/packages/bloc_test/test/bloc_test_test.dart
+++ b/packages/bloc_test/test/bloc_test_test.dart
@@ -61,5 +61,20 @@ void main() {
         expect: [0, 1, 2],
       );
     });
+
+    group('ComplexBloc', () {
+      blocTest(
+        'emits [ComplexStateA] when nothing is added',
+        build: () => ComplexBloc(),
+        expect: [isA<ComplexStateA>()],
+      );
+
+      blocTest(
+        'emits [ComplexStateA, ComplexStateB] when ComplexEventB is added',
+        build: () => ComplexBloc(),
+        act: (bloc) => bloc.add(ComplexEventB()),
+        expect: [isA<ComplexStateA>(), isA<ComplexStateB>()],
+      );
+    });
   });
 }

--- a/packages/bloc_test/test/emits_exactly_test.dart
+++ b/packages/bloc_test/test/emits_exactly_test.dart
@@ -180,5 +180,71 @@ void main() {
         }
       });
     });
+
+    group('ComplexBloc', () {
+      test('emits [ComplexStateA, ComplexStateB] when ComplexEventB is added',
+          () async {
+        final bloc = ComplexBloc();
+        bloc.add(ComplexEventB());
+        await emitsExactly(bloc, [isA<ComplexStateA>(), isA<ComplexStateB>()]);
+      });
+
+      test('fails if bloc does not emit all states', () async {
+        try {
+          await emitsExactly(
+              ComplexBloc(), [isA<ComplexStateA>(), isA<ComplexStateB>()]);
+          fail('should throw');
+        } on TestFailure catch (error) {
+          expect(
+              error.message,
+              'Expected: [<<Instance of \'ComplexStateA\'>>, <<Instance of \'ComplexStateB\'>>]\n'
+              '  Actual: [Instance of \'ComplexStateA\']\n'
+              '   Which: shorter than expected at location [1]\n'
+              '');
+        }
+      });
+
+      test('fails if bloc does not emit correct states', () async {
+        try {
+          final bloc = ComplexBloc();
+          bloc.add(ComplexEventA());
+          await emitsExactly(
+            bloc,
+            [isA<ComplexStateA>(), isA<ComplexStateB>()],
+          );
+          fail('should throw');
+        } on TestFailure catch (error) {
+          expect(
+              error.message,
+              'Expected: [<<Instance of \'ComplexStateA\'>>, <<Instance of \'ComplexStateB\'>>]\n'
+              '  Actual: [Instance of \'ComplexStateA\', Instance of \'ComplexStateA\']\n'
+              '   Which: does not match <Instance of \'ComplexStateB\'> at location [1]\n'
+              '');
+        }
+      });
+
+      test('fails if expecting extra states', () async {
+        try {
+          final bloc = ComplexBloc();
+          bloc.add(ComplexEventB());
+          await emitsExactly(
+            bloc,
+            [isA<ComplexStateA>(), isA<ComplexStateB>(), isA<ComplexStateA>()],
+          );
+          fail('should throw');
+        } on TestFailure catch (error) {
+          expect(
+              error.message,
+              'Expected: [\n'
+              '            <<Instance of \'ComplexStateA\'>>,\n'
+              '            <<Instance of \'ComplexStateB\'>>,\n'
+              '            <<Instance of \'ComplexStateA\'>>\n'
+              '          ]\n'
+              '  Actual: [Instance of \'ComplexStateA\', Instance of \'ComplexStateB\']\n'
+              '   Which: shorter than expected at location [2]\n'
+              '');
+        }
+      });
+    });
   });
 }

--- a/packages/bloc_test/test/helpers/complex_bloc.dart
+++ b/packages/bloc_test/test/helpers/complex_bloc.dart
@@ -1,0 +1,31 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+
+abstract class ComplexEvent {}
+
+class ComplexEventA extends ComplexEvent {}
+
+class ComplexEventB extends ComplexEvent {}
+
+abstract class ComplexState {}
+
+class ComplexStateA extends ComplexState {}
+
+class ComplexStateB extends ComplexState {}
+
+class ComplexBloc extends Bloc<ComplexEvent, ComplexState> {
+  @override
+  ComplexState get initialState => ComplexStateA();
+
+  @override
+  Stream<ComplexState> mapEventToState(
+    ComplexEvent event,
+  ) async* {
+    if (event is ComplexEventA) {
+      yield ComplexStateA();
+    } else if (event is ComplexEventB) {
+      yield ComplexStateB();
+    }
+  }
+}

--- a/packages/bloc_test/test/helpers/helpers.dart
+++ b/packages/bloc_test/test/helpers/helpers.dart
@@ -1,4 +1,5 @@
 export 'async_counter_bloc.dart';
+export 'complex_bloc.dart';
 export 'counter_bloc.dart';
 export 'multi_counter_bloc.dart';
 export 'sum_bloc.dart';


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- `bloc_test` enhance `emitsExactly` to accept an `Iterable<Matcher>` (#695)

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
- Backward compatible feature which will be included in `bloc_test` v2.2.0