### PR TITLE
Deprecate builder for create in BlocProvider/RepositoryProvider

### DIFF
--- a/packages/flutter_bloc/CHANGELOG.md
+++ b/packages/flutter_bloc/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.1.0
+
+- Deprecate `builder` in `BlocProvider` in favor of `create` to align with `provider`.
+- Deprecate `builder` in `RepositoryProvider` in favor of `create` to align with `provider`.
+
 # 2.0.1
 
 - Fix `BlocBuilder` and `BlocListener` condition behavior to set `previousState` to the previous state used by `BlocBuilder`/`BlocListener` instead of the previous state of the `bloc`.

--- a/packages/flutter_bloc/README.md
+++ b/packages/flutter_bloc/README.md
@@ -60,11 +60,11 @@ BlocBuilder<BlocA, BlocAState>(
 
 **BlocProvider** is a Flutter widget which provides a bloc to its children via `BlocProvider.of<T>(context)`. It is used as a dependency injection (DI) widget so that a single instance of a bloc can be provided to multiple widgets within a subtree.
 
-In most cases, `BlocProvider` should be used to build new `blocs` which will be made available to the rest of the subtree. In this case, since `BlocProvider` is responsible for creating the bloc, it will automatically handle closing the bloc.
+In most cases, `BlocProvider` should be used to create new `blocs` which will be made available to the rest of the subtree. In this case, since `BlocProvider` is responsible for creating the bloc, it will automatically handle closing the bloc.
 
 ```dart
 BlocProvider(
-  builder: (BuildContext context) => BlocA(),
+  create: (BuildContext context) => BlocA(),
   child: ChildA(),
 );
 ```
@@ -90,11 +90,11 @@ By using `MultiBlocProvider` we can go from:
 
 ```dart
 BlocProvider<BlocA>(
-  builder: (BuildContext context) => BlocA(),
+  create: (BuildContext context) => BlocA(),
   child: BlocProvider<BlocB>(
-    builder: (BuildContext context) => BlocB(),
+    create: (BuildContext context) => BlocB(),
     child: BlocProvider<BlocC>(
-      builder: (BuildContext context) => BlocC(),
+      create: (BuildContext context) => BlocC(),
       child: ChildA(),
     )
   )
@@ -107,13 +107,13 @@ to:
 MultiBlocProvider(
   providers: [
     BlocProvider<BlocA>(
-      builder: (BuildContext context) => BlocA(),
+      create: (BuildContext context) => BlocA(),
     ),
     BlocProvider<BlocB>(
-      builder: (BuildContext context) => BlocB(),
+      create: (BuildContext context) => BlocB(),
     ),
     BlocProvider<BlocC>(
-      builder: (BuildContext context) => BlocC(),
+      create: (BuildContext context) => BlocC(),
     ),
   ],
   child: ChildA(),
@@ -201,7 +201,7 @@ MultiBlocListener(
 
 ```dart
 RepositoryProvider(
-  builder: (context) => RepositoryA(),
+  create: (context) => RepositoryA(),
   child: ChildA(),
 );
 ```
@@ -218,11 +218,11 @@ By using `MultiRepositoryProvider` we can go from:
 
 ```dart
 RepositoryProvider<RepositoryA>(
-  builder: (context) => RepositoryA(),
+  create: (context) => RepositoryA(),
   child: RepositoryProvider<RepositoryB>(
-    builder: (context) => RepositoryB(),
+    create: (context) => RepositoryB(),
     child: RepositoryProvider<RepositoryC>(
-      builder: (context) => RepositoryC(),
+      create: (context) => RepositoryC(),
       child: ChildA(),
     )
   )
@@ -235,13 +235,13 @@ to:
 MultiRepositoryProvider(
   providers: [
     RepositoryProvider<RepositoryA>(
-      builder: (context) => RepositoryA(),
+      create: (context) => RepositoryA(),
     ),
     RepositoryProvider<RepositoryB>(
-      builder: (context) => RepositoryB(),
+      create: (context) => RepositoryB(),
     ),
     RepositoryProvider<RepositoryC>(
-      builder: (context) => RepositoryC(),
+      create: (context) => RepositoryC(),
     ),
   ],
   child: ChildA(),

--- a/packages/flutter_bloc/example/lib/main.dart
+++ b/packages/flutter_bloc/example/lib/main.dart
@@ -34,13 +34,13 @@ class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider<ThemeBloc>(
-      builder: (context) => ThemeBloc(),
+      create: (context) => ThemeBloc(),
       child: BlocBuilder<ThemeBloc, ThemeData>(
         builder: (context, theme) {
           return MaterialApp(
             title: 'Flutter Demo',
             home: BlocProvider(
-              builder: (context) => CounterBloc(),
+              create: (context) => CounterBloc(),
               child: CounterPage(),
             ),
             theme: theme,

--- a/packages/flutter_bloc/lib/src/bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/bloc_provider.dart
@@ -4,15 +4,15 @@ import 'package:bloc/bloc.dart';
 
 /// {@template blocprovider}
 /// Takes a [ValueBuilder] that is responsible for
-/// building the [bloc] and a [child] which will have access to the [bloc] via `BlocProvider.of(context)`.
+/// creating the [bloc] and a [child] which will have access to the [bloc] via `BlocProvider.of(context)`.
 /// It is used as a dependency injection (DI) widget so that a single instance of a [bloc] can be provided
 /// to multiple widgets within a subtree.
 ///
-/// Automatically handles closing the [bloc] when used with a [builder].
+/// Automatically handles closing the [bloc] when used with [create].
 ///
 /// ```dart
 /// BlocProvider(
-///   builder: (BuildContext context) => BlocA(),
+///   create: (BuildContext context) => BlocA(),
 ///   child: ChildA(),
 /// );
 /// ```
@@ -25,12 +25,14 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>>
   /// {@macro blocprovider}
   BlocProvider({
     Key key,
-    ValueBuilder<T> builder,
+    @Deprecated('will be removed in 3.0.0, use create instead')
+        ValueBuilder<T> builder,
+    @required ValueBuilder<T> create,
     Widget child,
   }) : this._(
           key: key,
           delegate: BuilderStateDelegate<T>(
-            builder,
+            create ?? builder,
             dispose: (_, bloc) => bloc?.close(),
           ),
           child: child,
@@ -42,7 +44,7 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>>
   /// to new routes.
   ///
   /// A new [bloc] should not be created in `BlocProvider.value`.
-  /// [bloc]s should always be created using the default constructor within the [builder].
+  /// [bloc]s should always be created using the default constructor within [create].
   ///
   /// ```dart
   /// BlocProvider.value(
@@ -89,8 +91,8 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>>
         1. The context you used comes from a widget above the BlocProvider.
         2. You used MultiBlocProvider and didn\'t explicity provide the BlocProvider types.
 
-        Good: BlocProvider<$T>(builder: (context) => $T())
-        Bad: BlocProvider(builder: (context) => $T()).
+        Good: BlocProvider<$T>(create: (context) => $T())
+        Bad: BlocProvider(create: (context) => $T()).
 
         The context used was: $context
         """,

--- a/packages/flutter_bloc/lib/src/multi_bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/multi_bloc_provider.dart
@@ -12,11 +12,11 @@ import 'package:provider/provider.dart';
 ///
 /// ```dart
 /// BlocProvider<BlocA>(
-///   builder: (BuildContext context) => BlocA(),
+///   create: (BuildContext context) => BlocA(),
 ///   child: BlocProvider<BlocB>(
-///     builder: (BuildContext context) => BlocB(),
+///     create: (BuildContext context) => BlocB(),
 ///     child: BlocProvider<BlocC>(
-///       builder: (BuildContext context) => BlocC(),
+///       create: (BuildContext context) => BlocC(),
 ///       child: ChildA(),
 ///     )
 ///   )
@@ -29,13 +29,13 @@ import 'package:provider/provider.dart';
 /// MultiBlocProvider(
 ///   providers: [
 ///     BlocProvider<BlocA>(
-///       builder: (BuildContext context) => BlocA(),
+///       create: (BuildContext context) => BlocA(),
 ///     ),
 ///     BlocProvider<BlocB>(
-///       builder: (BuildContext context) => BlocB(),
+///       create: (BuildContext context) => BlocB(),
 ///     ),
 ///     BlocProvider<BlocC>(
-///       builder: (BuildContext context) => BlocC(),
+///       create: (BuildContext context) => BlocC(),
 ///     ),
 ///   ],
 ///   child: ChildA(),

--- a/packages/flutter_bloc/lib/src/multi_repository_provider.dart
+++ b/packages/flutter_bloc/lib/src/multi_repository_provider.dart
@@ -12,11 +12,11 @@ import 'package:provider/provider.dart';
 ///
 /// ```dart
 /// RepositoryProvider<RepositoryA>(
-///   builder: (context) => RepositoryA(),
+///   create: (context) => RepositoryA(),
 ///   child: RepositoryProvider<RepositoryB>(
-///     builder: (context) => RepositoryB(),
+///     create: (context) => RepositoryB(),
 ///     child: RepositoryProvider<RepositoryC>(
-///       builder: (context) => RepositoryC(),
+///       create: (context) => RepositoryC(),
 ///       child: ChildA(),
 ///     )
 ///   )
@@ -28,9 +28,9 @@ import 'package:provider/provider.dart';
 /// ```dart
 /// MultiRepositoryProvider(
 ///   providers: [
-///     RepositoryProvider<RepositoryA>(builder: (context) => RepositoryA()),
-///     RepositoryProvider<RepositoryB>(builder: (context) => RepositoryB()),
-///     RepositoryProvider<RepositoryC>(builder: (context) => RepositoryC()),
+///     RepositoryProvider<RepositoryA>(create: (context) => RepositoryA()),
+///     RepositoryProvider<RepositoryB>(create: (context) => RepositoryB()),
+///     RepositoryProvider<RepositoryC>(create: (context) => RepositoryC()),
 ///   ],
 ///   child: ChildA(),
 /// )

--- a/packages/flutter_bloc/lib/src/repository_provider.dart
+++ b/packages/flutter_bloc/lib/src/repository_provider.dart
@@ -3,13 +3,13 @@ import 'package:provider/provider.dart';
 
 /// {@template repositoryprovider}
 /// Takes a `ValueBuilder` that is responsible for
-/// building the repository and a [child] which will have access to the repository via `RepositoryProvider.of(context)`.
+/// creating the repository and a [child] which will have access to the repository via `RepositoryProvider.of(context)`.
 /// It is used as a dependency injection (DI) widget so that a single instance of a repository can be provided
 /// to multiple widgets within a subtree.
 ///
 /// ```dart
 /// RepositoryProvider(
-///   builder: (context) => RepositoryA(),
+///   create: (context) => RepositoryA(),
 ///   child: ChildA(),
 /// );
 /// ```
@@ -18,11 +18,13 @@ class RepositoryProvider<T> extends Provider<T> {
   /// {@macro repositoryprovider}
   RepositoryProvider({
     Key key,
-    @required ValueBuilder<T> builder,
+    @required ValueBuilder<T> create,
+    @Deprecated('will be removed in 3.0.0, use create instead')
+        ValueBuilder<T> builder,
     Widget child,
   }) : super(
           key: key,
-          builder: builder,
+          create: create ?? builder,
           dispose: (_, __) {},
           child: child,
         );
@@ -55,8 +57,8 @@ class RepositoryProvider<T> extends Provider<T> {
         1. The context you used comes from a widget above the RepositoryProvider.
         2. You used MultiRepositoryProvider and didn\'t explicity provide the RepositoryProvider types.
 
-        Good: RepositoryProvider<$T>(builder: (context) => $T())
-        Bad: RepositoryProvider(builder: (context) => $T()).
+        Good: RepositoryProvider<$T>(create: (context) => $T())
+        Bad: RepositoryProvider(create: (context) => $T()).
 
         The context used was: $context
         """,

--- a/packages/flutter_bloc/pubspec.yaml
+++ b/packages/flutter_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_bloc
 description: Flutter Widgets that make it easy to implement the BLoC (Business Logic Component) design pattern. Built to be used with the bloc state management package.
-version: 2.0.1
+version: 2.1.0
 author: Felix Angelov <felangelov@gmail.com>
 repository: https://github.com/felangel/bloc
 issue_tracker: https://github.com/felangel/bloc/issues

--- a/packages/flutter_bloc/test/bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/bloc_provider_test.dart
@@ -7,16 +7,16 @@ import 'package:bloc/bloc.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 class MyApp extends StatelessWidget {
-  final CounterBloc Function(BuildContext context) _builder;
+  final CounterBloc Function(BuildContext context) _create;
   final CounterBloc _value;
   final Widget _child;
 
   const MyApp({
     Key key,
-    CounterBloc Function(BuildContext context) builder,
+    CounterBloc Function(BuildContext context) create,
     CounterBloc value,
     @required Widget child,
-  })  : _builder = builder,
+  })  : _create = create,
         _value = value,
         _child = child,
         super(key: key);
@@ -33,7 +33,7 @@ class MyApp extends StatelessWidget {
     }
     return MaterialApp(
       home: BlocProvider<CounterBloc>(
-        builder: _builder,
+        create: _create,
         child: _child,
       ),
     );
@@ -65,7 +65,7 @@ class _MyStatefulAppState extends State<MyStatefulApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       home: BlocProvider<CounterBloc>(
-        builder: (context) => bloc,
+        create: (context) => bloc,
         child: Scaffold(
           appBar: AppBar(
             title: Text('Counter'),
@@ -201,10 +201,10 @@ class CounterBloc extends Bloc<CounterEvent, int> {
 
 void main() {
   group('BlocProvider', () {
-    testWidgets('throws if initialized with no builder',
+    testWidgets('throws if initialized with no create',
         (WidgetTester tester) async {
       await tester.pumpWidget(MyApp(
-        builder: null,
+        create: null,
         child: CounterPage(),
       ));
       expect(tester.takeException(), isInstanceOf<AssertionError>());
@@ -213,17 +213,17 @@ void main() {
     testWidgets('throws if initialized with no child',
         (WidgetTester tester) async {
       await tester.pumpWidget(MyApp(
-        builder: (context) => CounterBloc(),
+        create: (context) => CounterBloc(),
         child: null,
       ));
       expect(tester.takeException(), isInstanceOf<AssertionError>());
     });
 
     testWidgets('passes bloc to children', (WidgetTester tester) async {
-      CounterBloc _builder(BuildContext context) => CounterBloc();
+      CounterBloc _create(BuildContext context) => CounterBloc();
       final _child = CounterPage();
       await tester.pumpWidget(MyApp(
-        builder: _builder,
+        create: _create,
         child: _child,
       ));
 
@@ -241,7 +241,7 @@ void main() {
           MaterialApp(
             home: Scaffold(
               body: BlocProvider(
-                builder: (context) => CounterBloc(),
+                create: (context) => CounterBloc(),
                 child: BlocBuilder<CounterBloc, int>(
                   builder: (context, state) => Text('state: $state'),
                 ),
@@ -256,14 +256,14 @@ void main() {
     testWidgets('calls close on bloc automatically',
         (WidgetTester tester) async {
       var closeCalled = false;
-      CounterBloc _builder(BuildContext context) => CounterBloc(
+      CounterBloc _create(BuildContext context) => CounterBloc(
             onClose: () {
               closeCalled = true;
             },
           );
       final Widget _child = RoutePage();
       await tester.pumpWidget(MyApp(
-        builder: _builder,
+        create: _create,
         child: _child,
       ));
 
@@ -317,8 +317,8 @@ void main() {
         1. The context you used comes from a widget above the BlocProvider.
         2. You used MultiBlocProvider and didn\'t explicity provide the BlocProvider types.
 
-        Good: BlocProvider<CounterBloc>(builder: (context) => CounterBloc())
-        Bad: BlocProvider(builder: (context) => CounterBloc()).
+        Good: BlocProvider<CounterBloc>(create: (context) => CounterBloc())
+        Bad: BlocProvider(create: (context) => CounterBloc()).
 
         The context used was: CounterPage(dirty)
 """;

--- a/packages/flutter_bloc/test/multi_bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/multi_bloc_provider_test.dart
@@ -44,7 +44,7 @@ class HomePage extends StatelessWidget {
       } else {
         providers.add(
           BlocProvider<CounterBloc>(
-            builder: (context) => CounterBloc(onClose: onCounterBlocClosed),
+            create: (context) => CounterBloc(onClose: onCounterBlocClosed),
           ),
         );
       }
@@ -58,7 +58,7 @@ class HomePage extends StatelessWidget {
       } else {
         providers.add(
           BlocProvider<ThemeBloc>(
-            builder: (context) => ThemeBloc(onClose: onThemeBlocClosed),
+            create: (context) => ThemeBloc(onClose: onThemeBlocClosed),
           ),
         );
       }
@@ -223,8 +223,8 @@ void main() {
       await tester.pumpWidget(
         MultiBlocProvider(
           providers: [
-            BlocProvider<CounterBloc>(builder: (context) => CounterBloc()),
-            BlocProvider<ThemeBloc>(builder: (context) => ThemeBloc())
+            BlocProvider<CounterBloc>(create: (context) => CounterBloc()),
+            BlocProvider<ThemeBloc>(create: (context) => ThemeBloc())
           ],
           child: MyApp(),
         ),

--- a/packages/flutter_bloc/test/multi_repository_provider_test.dart
+++ b/packages/flutter_bloc/test/multi_repository_provider_test.dart
@@ -100,9 +100,11 @@ void main() {
         MultiRepositoryProvider(
           providers: [
             RepositoryProvider<RepositoryA>(
-                builder: (context) => RepositoryA(0)),
+              create: (context) => RepositoryA(0),
+            ),
             RepositoryProvider<RepositoryB>(
-                builder: (context) => RepositoryB(1)),
+              create: (context) => RepositoryB(1),
+            ),
           ],
           child: MyApp(),
         ),

--- a/packages/flutter_bloc/test/repository_provider_test.dart
+++ b/packages/flutter_bloc/test/repository_provider_test.dart
@@ -29,7 +29,7 @@ class MyApp extends StatelessWidget {
     }
     return MaterialApp(
       home: RepositoryProvider<Repository>(
-        builder: (context) => _repository,
+        create: (context) => _repository,
         child: _child,
       ),
     );
@@ -61,7 +61,7 @@ class _MyStatefulAppState extends State<MyStatefulApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       home: RepositoryProvider<Repository>(
-        builder: (context) => _repository,
+        create: (context) => _repository,
         child: Scaffold(
           appBar: AppBar(
             title: Text('Counter'),
@@ -217,8 +217,8 @@ void main() {
         1. The context you used comes from a widget above the RepositoryProvider.
         2. You used MultiRepositoryProvider and didn\'t explicity provide the RepositoryProvider types.
 
-        Good: RepositoryProvider<Repository>(builder: (context) => Repository())
-        Bad: RepositoryProvider(builder: (context) => Repository()).
+        Good: RepositoryProvider<Repository>(create: (context) => Repository())
+        Bad: RepositoryProvider(create: (context) => Repository()).
 
         The context used was: CounterPage(dirty)
 """;


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Deprecate `builder` in favor of `create` for `BlocProvider` and `RepositoryProvider` to align with the [provider](https://github.com/rrousselGit/provider/issues/259) API. 

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
- Deprecation of `builder` which will be introduced in `flutter_bloc` v2.1.0
- `builder` will be removed in `flutter_bloc` v3.0.0