### PR TITLE
revert condition to previous behavior

### DIFF
--- a/packages/flutter_bloc/lib/src/bloc_builder.dart
+++ b/packages/flutter_bloc/lib/src/bloc_builder.dart
@@ -49,9 +49,8 @@ typedef BlocBuilderCondition<S> = bool Function(S previous, S current);
 /// An optional [condition] can be implemented for more granular control
 /// over how often [BlocBuilder] rebuilds.
 /// The [condition] function will be invoked on each [bloc] [state] change.
-/// The [condition] takes the previous [state] built by [BlocBuilder] and
-/// the current [state] of the [bloc] and must return a [bool] which determines
-/// whether or not the [builder] function will be invoked.
+/// The [condition] takes the previous [state] and current [state] and must return a [bool]
+/// which determines whether or not the [builder] function will be invoked.
 /// The previous [state] will be initialized to the [state] of the [bloc]
 /// when the [BlocBuilder] is initialized.
 /// [condition] is optional and if it isn't implemented, it will default to `true`.
@@ -168,9 +167,9 @@ class _BlocBuilderBaseState<B extends Bloc<dynamic, S>, S>
         if (widget.condition?.call(_previousState, state) ?? true) {
           setState(() {
             _state = state;
-            _previousState = state;
           });
         }
+        _previousState = state;
       });
     }
   }

--- a/packages/flutter_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/bloc_listener.dart
@@ -50,9 +50,8 @@ typedef BlocListenerCondition<S> = bool Function(S previous, S current);
 /// An optional [condition] can be implemented for more granular control
 /// over when [listener] is called.
 /// The [condition] function will be invoked on each [bloc] [state] change.
-/// The [condition] takes the previous [state] handled by [BlocListener] and
-/// the current [state] of the [bloc] and must return a [bool] which determines
-/// whether or not the [listener] function will be invoked.
+/// The [condition] takes the previous [state] and current [state] and must return a [bool]
+/// which determines whether or not the [listener] function will be invoked.
 /// The previous [state] will be initialized to the [state] of the [bloc]
 /// when the [BlocListener] is initialized.
 /// [condition] is optional and if it isn't implemented, it will default to `true`.
@@ -191,8 +190,8 @@ class _BlocListenerBaseState<B extends Bloc<dynamic, S>, S>
       _subscription = _bloc.skip(1).listen((S state) {
         if (widget.condition?.call(_previousState, state) ?? true) {
           widget.listener(context, state);
-          _previousState = state;
         }
+        _previousState = state;
       });
     }
   }

--- a/packages/flutter_bloc/test/bloc_builder_test.dart
+++ b/packages/flutter_bloc/test/bloc_builder_test.dart
@@ -445,7 +445,7 @@ void main() {
 
       final conditionalCounterText3 =
           tester.widget(find.byKey(Key('myCounterAppTextCondition'))) as Text;
-      expect(conditionalCounterText3.data, '0');
+      expect(conditionalCounterText3.data, '2');
 
       await tester.tap(incrementButtonFinder);
       await tester.pumpAndSettle();
@@ -456,7 +456,7 @@ void main() {
 
       final conditionalCounterText4 =
           tester.widget(find.byKey(Key('myCounterAppTextCondition'))) as Text;
-      expect(conditionalCounterText4.data, '3');
+      expect(conditionalCounterText4.data, '2');
     });
   });
 }

--- a/packages/flutter_bloc/test/bloc_listener_test.dart
+++ b/packages/flutter_bloc/test/bloc_listener_test.dart
@@ -286,7 +286,7 @@ void main() {
           bloc: counterBloc,
           condition: (int previous, int state) {
             conditionCallCount++;
-            if (previous + state % 3 == 0) {
+            if ((previous + state) % 3 == 0) {
               latestPreviousState = previous;
               latestState = state;
               return true;
@@ -302,8 +302,8 @@ void main() {
       counterBloc.add(CounterEvent.increment);
       expectLater(counterBloc, emitsInOrder(expectedStates)).then((_) {
         expect(conditionCallCount, 3);
-        expect(latestPreviousState, 0);
-        expect(latestState, 3);
+        expect(latestPreviousState, 1);
+        expect(latestState, 2);
       });
     });
 


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
YES

## Description
- Revert `condition` behavior in `BlocBuilder` and `BlocListener` to use previous state of bloc rather than previously used state in UI (#709)
- Addresses #730 since code is no longer redundant

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
- Reverts #671 and #678; will be included in v3.0.0 
