### PR TITLE
add wait to blocTest and duration to emitsExactly

### DIFF
--- a/packages/bloc_test/CHANGELOG.md
+++ b/packages/bloc_test/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.0.0
+
+- `emitsExactly` supports optional `duration` for async operators like `debounceTime`.
+- `blocTest` supports optional `wait` for async operators like `debounceTime`.
+
 # 3.0.0-dev.1
 
 - Updated to `bloc: ^3.0.0-dev.1`

--- a/packages/bloc_test/README.md
+++ b/packages/bloc_test/README.md
@@ -44,7 +44,9 @@ expectLater(counterBloc, emitsInOrder(<int>[0, 1, 2, 3])))
 
 `build` should be used for all `bloc` initialization and preparation and must return the `bloc` under test.
 
-`act` is an optional callback which will be invoked with the `bloc` under test and should be used to `add` events to the bloc.
+`act` is an optional callback which will be invoked with the `bloc` under test and should be used to `add` events to the `bloc`.
+
+`wait` is an optional `Duration` which can be used to wait for async operations within the `bloc` under test such as `debounceTime`.
 
 `expect` is an `Iterable<State>` which the `bloc` under test is expected to emit after `act` is executed.
 
@@ -63,6 +65,18 @@ group('CounterBloc', () {
     expect: [0, 1],
   );
 });
+```
+
+`blocTest` can also be used to wait for async operations like `debounceTime` by providing a `Duration` to `wait`.
+
+```dart
+blocTest(
+  'CounterBloc emits [0, 1] when CounterEvent.increment is added',
+  build: () => CounterBloc(),
+  act: (bloc) => bloc.add(CounterEvent.increment),
+  wait: const Duration(milliseconds: 300),
+  expect: [0, 1],
+);
 ```
 
 **Note:** when using `blocTest` with state classes which don't override `==` and `hashCode` you can provide an `Iterable` of matchers instead of explicit state instances.
@@ -102,6 +116,16 @@ test('emits [StateA, StateB] when EventB is added', () async {
   final bloc = MyBloc();
   bloc.add(EventB());
   await emitsExactly(bloc, [isA<StateA>(), isA<StateB>()]);
+});
+```
+
+`emitsExactly` also takes an optional `duration` which is useful in cases where the `bloc` is using `debounceTime` or other similar operators.
+
+```dart
+test('emits [0, 1] when CounterEvent.increment is added', () async {
+  final bloc = CounterBloc();
+  bloc.add(CounterEvent.increment);
+  await emitsExactly(bloc, [0, 1], duration: const Duration(milliseconds: 300));
 });
 ```
 

--- a/packages/bloc_test/lib/src/bloc_test.dart
+++ b/packages/bloc_test/lib/src/bloc_test.dart
@@ -15,7 +15,10 @@ import 'package:test/test.dart';
 /// and must return the [bloc] under test.
 ///
 /// [act] is an optional callback which will be invoked with the [bloc] under test
-/// and should be used to `add` events to the bloc.
+/// and should be used to `add` events to the [bloc].
+///
+/// [wait] is an optional `Duration` which can be used to wait for
+/// async operations within the [bloc] under test such as `debounceTime`.
 ///
 /// [expect] is an `Iterable` of matchers which the [bloc]
 /// under test is expected to emit after [act] is executed.
@@ -40,6 +43,19 @@ import 'package:test/test.dart';
 /// );
 /// ```
 ///
+/// [blocTest] can also be used to wait for async operations like `debounceTime`
+/// by optionally providing a `Duration` to [wait].
+///
+/// ```dart
+/// blocTest(
+///   'CounterBloc emits [0, 1] when CounterEvent.increment is added',
+///   build: () => CounterBloc(),
+///   act: (bloc) => bloc.add(CounterEvent.increment),
+///   wait: const Duration(milliseconds: 300),
+///   expect: [0, 1],
+/// );
+/// ```
+///
 /// **Note:** when using [blocTest] with state classes which don't override
 /// `==` and `hashCode` you can provide an `Iterable` of matchers instead of
 /// explicit state instances.
@@ -58,10 +74,11 @@ void blocTest<B extends Bloc<Event, State>, Event, State>(
   @required B build(),
   @required Iterable expect,
   Future<void> Function(B bloc) act,
+  Duration wait,
 }) {
   test(description, () async {
     final bloc = build();
     await act?.call(bloc);
-    await emitsExactly(bloc, expect);
+    await emitsExactly(bloc, expect, duration: wait);
   });
 }

--- a/packages/bloc_test/lib/src/emits_exactly.dart
+++ b/packages/bloc_test/lib/src/emits_exactly.dart
@@ -25,13 +25,26 @@ import 'package:test/test.dart';
 ///   await emitsExactly(bloc, [isA<StateA>(), isA<StateB>()]);
 /// });
 /// ```
+///
+/// [emitsExactly] also takes an optional [duration] which is useful in cases
+/// where the [bloc] is using `debounceTime` or other similar operators.
+///
+/// ```dart
+/// test('emits [0, 1] when CounterEvent.increment is added', () async {
+///   final bloc = CounterBloc();
+///   bloc.add(CounterEvent.increment);
+///   await emitsExactly(bloc, [0, 1], duration: const Duration(milliseconds: 300));
+/// });
+/// ```
 Future<void> emitsExactly<B extends Bloc<dynamic, State>, State>(
   B bloc,
-  Iterable expected,
-) async {
+  Iterable expected, {
+  Duration duration,
+}) async {
   assert(bloc != null);
   final states = <State>[];
   final subscription = bloc.listen(states.add);
+  if (duration != null) await Future.delayed(duration);
   await bloc.close();
   expect(states, expected);
   await subscription.cancel();

--- a/packages/bloc_test/test/bloc_test_test.dart
+++ b/packages/bloc_test/test/bloc_test_test.dart
@@ -47,6 +47,22 @@ void main() {
       );
     });
 
+    group('DebounceCounterBloc', () {
+      blocTest(
+        'emits [0] when nothing is added',
+        build: () => DebounceCounterBloc(),
+        expect: [0],
+      );
+
+      blocTest(
+        'emits [0, 1] when DebounceCounterEvent.increment is added',
+        build: () => DebounceCounterBloc(),
+        act: (bloc) => bloc.add(DebounceCounterEvent.increment),
+        wait: const Duration(milliseconds: 300),
+        expect: [0, 1],
+      );
+    });
+
     group('MultiCounterBloc', () {
       blocTest(
         'emits [0] when nothing is added',

--- a/packages/bloc_test/test/emits_exactly_test.dart
+++ b/packages/bloc_test/test/emits_exactly_test.dart
@@ -125,6 +125,68 @@ void main() {
       });
     });
 
+    group('DebounceCounterBloc', () {
+      test('emits [0, 1] when CounterEvent.increment is added', () async {
+        final bloc = DebounceCounterBloc();
+        bloc.add(DebounceCounterEvent.increment);
+        await emitsExactly(bloc, [0, 1],
+            duration: const Duration(milliseconds: 305));
+      });
+
+      test('fails if bloc does not emit all states', () async {
+        try {
+          await emitsExactly(DebounceCounterBloc(), [0, 1]);
+          fail('should throw');
+        } on TestFailure catch (error) {
+          expect(
+              error.message,
+              'Expected: [0, 1]\n'
+              '  Actual: [0]\n'
+              '   Which: shorter than expected at location [1]\n'
+              '');
+        }
+      });
+
+      test('fails if bloc does not emit correct states', () async {
+        try {
+          final bloc = DebounceCounterBloc();
+          bloc.add(DebounceCounterEvent.increment);
+          await emitsExactly(bloc, [0, 2],
+              duration: const Duration(milliseconds: 305));
+          fail('should throw');
+        } on TestFailure catch (error) {
+          expect(
+            error.message,
+            'Expected: [0, 2]\n'
+            '  Actual: [0, 1]\n'
+            '   Which: was <1> instead of <2> at location [1]\n'
+            '',
+          );
+        }
+      });
+
+      test('fails if expecting extra states', () async {
+        try {
+          final bloc = DebounceCounterBloc();
+          bloc.add(DebounceCounterEvent.increment);
+          await emitsExactly(
+            bloc,
+            [0, 1, 2],
+            duration: const Duration(milliseconds: 305),
+          );
+          fail('should throw');
+        } on TestFailure catch (error) {
+          expect(
+            error.message,
+            'Expected: [0, 1, 2]\n'
+            '  Actual: [0, 1]\n'
+            '   Which: shorter than expected at location [2]\n'
+            '',
+          );
+        }
+      });
+    });
+
     group('MultiCounterBloc', () {
       test('emits [0, 1, 2] when CounterEvent.increment is added', () async {
         final bloc = MultiCounterBloc();

--- a/packages/bloc_test/test/helpers/debounce_counter_bloc.dart
+++ b/packages/bloc_test/test/helpers/debounce_counter_bloc.dart
@@ -1,0 +1,32 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:rxdart/rxdart.dart';
+
+enum DebounceCounterEvent { increment }
+
+class DebounceCounterBloc extends Bloc<DebounceCounterEvent, int> {
+  @override
+  int get initialState => 0;
+
+  @override
+  Stream<int> transformEvents(
+    Stream<DebounceCounterEvent> events,
+    Stream<int> Function(DebounceCounterEvent event) next,
+  ) {
+    return events
+        .debounceTime(const Duration(milliseconds: 300))
+        .switchMap(next);
+  }
+
+  @override
+  Stream<int> mapEventToState(
+    DebounceCounterEvent event,
+  ) async* {
+    switch (event) {
+      case DebounceCounterEvent.increment:
+        yield state + 1;
+        break;
+    }
+  }
+}

--- a/packages/bloc_test/test/helpers/helpers.dart
+++ b/packages/bloc_test/test/helpers/helpers.dart
@@ -1,5 +1,6 @@
 export 'async_counter_bloc.dart';
 export 'complex_bloc.dart';
 export 'counter_bloc.dart';
+export 'debounce_counter_bloc.dart';
 export 'multi_counter_bloc.dart';
 export 'sum_bloc.dart';


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Add `duration` to `emitsExactly` (https://github.com/felangel/bloc/issues/726)
- Add `wait` to `blocTest` (https://github.com/felangel/bloc/issues/726)

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
None