### PR TITLE
Expose lazy parameter on RepositoryProvider and BlocProvider

### DIFF
--- a/packages/flutter_bloc/lib/src/bloc_builder.dart
+++ b/packages/flutter_bloc/lib/src/bloc_builder.dart
@@ -57,7 +57,7 @@ typedef BlocBuilderCondition<S> = bool Function(S previous, S current);
 ///
 /// ```dart
 /// BlocBuilder<BlocA, BlocAState>(
-///   condition: (previousState, state) {
+///   condition: (previous, current) {
 ///     // return true/false to determine whether or not
 ///     // to rebuild the widget with state
 ///   },

--- a/packages/flutter_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/bloc_listener.dart
@@ -29,7 +29,7 @@ typedef BlocListenerCondition<S> = bool Function(S previous, S current);
 /// ```dart
 /// BlocListener<BlocA, BlocAState>(
 ///   listener: (context, state) {
-///     /// do stuff here based on BlocA's state
+///     // do stuff here based on BlocA's state
 ///   },
 ///   child: Container(),
 /// )
@@ -41,7 +41,7 @@ typedef BlocListenerCondition<S> = bool Function(S previous, S current);
 /// BlocListener<BlocA, BlocAState>(
 ///   bloc: blocA,
 ///   listener: (context, state) {
-///     /// do stuff here based on BlocA's state
+///     // do stuff here based on BlocA's state
 ///   },
 ///   child: Container(),
 /// )
@@ -58,7 +58,7 @@ typedef BlocListenerCondition<S> = bool Function(S previous, S current);
 ///
 /// ```dart
 /// BlocListener<BlocA, BlocAState>(
-///   condition: (previousState, state) {
+///   condition: (previous, current) {
 ///     // return true/false to determine whether or not
 ///     // to invoke listener with state
 ///   },

--- a/packages/flutter_bloc/lib/src/bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/bloc_provider.dart
@@ -10,7 +10,8 @@ import 'package:bloc/bloc.dart';
 /// It is used as a dependency injection (DI) widget so that a single instance of a [bloc] can be provided
 /// to multiple widgets within a subtree.
 ///
-/// Automatically handles closing the [bloc] when used with [create].
+/// Automatically handles closing the [bloc] when used with [create]
+/// and lazily creates the provided [bloc] unless [lazy] is set to `false`.
 ///
 /// ```dart
 /// BlocProvider(
@@ -24,6 +25,10 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>>
   /// [child] and its descendants which will have access to the [bloc].
   final Widget child;
 
+  /// Whether or not the [bloc] being provided should be lazily created.
+  /// Defaults to `true`.
+  final bool lazy;
+
   final Dispose<T> _dispose;
 
   final Create<T> _create;
@@ -33,11 +38,13 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>>
     Key key,
     @required Create<T> create,
     Widget child,
+    bool lazy,
   }) : this._(
           key: key,
           create: create,
           dispose: (_, bloc) => bloc?.close(),
           child: child,
+          lazy: lazy,
         );
 
   /// Takes a [bloc] and a [child] which will have access to the [bloc] via `BlocProvider.of(context)`.
@@ -70,6 +77,7 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>>
     @required Create<T> create,
     Dispose<T> dispose,
     this.child,
+    this.lazy,
   })  : _create = create,
         _dispose = dispose,
         super(key: key, child: child);
@@ -111,6 +119,7 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>>
       create: _create,
       dispose: _dispose,
       child: child,
+      lazy: lazy,
     );
   }
 }

--- a/packages/flutter_bloc/lib/src/repository_provider.dart
+++ b/packages/flutter_bloc/lib/src/repository_provider.dart
@@ -7,6 +7,8 @@ import 'package:provider/provider.dart';
 /// It is used as a dependency injection (DI) widget so that a single instance of a repository can be provided
 /// to multiple widgets within a subtree.
 ///
+/// Lazily creates the provided repository unless [lazy] is set to `false`.
+///
 /// ```dart
 /// RepositoryProvider(
 ///   create: (context) => RepositoryA(),
@@ -20,11 +22,13 @@ class RepositoryProvider<T> extends Provider<T> {
     Key key,
     @required Create<T> create,
     Widget child,
+    bool lazy,
   }) : super(
           key: key,
           create: create,
           dispose: (_, __) {},
           child: child,
+          lazy: lazy,
         );
 
   /// Takes a repository and a [child] which will have access to the repository.

--- a/packages/flutter_bloc/pubspec.yaml
+++ b/packages/flutter_bloc/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   bloc: ^3.0.0
-  provider: ^4.0.0
+  provider: ^4.0.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_bloc/test/bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/bloc_provider_test.dart
@@ -229,6 +229,35 @@ void main() {
       expect(tester.takeException(), isInstanceOf<AssertionError>());
     });
 
+    testWidgets('lazily loads blocs by default', (WidgetTester tester) async {
+      var createCalled = false;
+      await tester.pumpWidget(
+        BlocProvider(
+          create: (_) {
+            createCalled = true;
+            return CounterBloc();
+          },
+          child: Container(),
+        ),
+      );
+      expect(createCalled, isFalse);
+    });
+
+    testWidgets('can override lazy loading', (WidgetTester tester) async {
+      var createCalled = false;
+      await tester.pumpWidget(
+        BlocProvider(
+          lazy: false,
+          create: (_) {
+            createCalled = true;
+            return CounterBloc();
+          },
+          child: Container(),
+        ),
+      );
+      expect(createCalled, isTrue);
+    });
+
     testWidgets('passes bloc to children', (WidgetTester tester) async {
       CounterBloc _create(BuildContext context) => CounterBloc();
       final _child = CounterPage();

--- a/packages/flutter_bloc/test/multi_bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/multi_bloc_provider_test.dart
@@ -263,6 +263,34 @@ void main() {
       expect(counterText.data, '0');
     });
 
+    testWidgets('adds event to each bloc', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MultiBlocProvider(
+          providers: [
+            BlocProvider<CounterBloc>(
+              create: (context) => CounterBloc()..add(CounterEvent.decrement),
+            ),
+            BlocProvider<ThemeBloc>(
+              create: (context) => ThemeBloc()..add(ThemeEvent.toggle),
+            ),
+          ],
+          child: MyApp(),
+        ),
+      );
+
+      await tester.pump();
+
+      final materialApp =
+          tester.widget(find.byType(MaterialApp)) as MaterialApp;
+      expect(materialApp.theme, ThemeData.dark());
+
+      final counterFinder = find.byKey((Key('counter_text')));
+      expect(counterFinder, findsOneWidget);
+
+      final counterText = tester.widget(counterFinder) as Text;
+      expect(counterText.data, '-1');
+    });
+
     testWidgets('close on counter bloc which was loaded (lazily)',
         (WidgetTester tester) async {
       var counterBlocClosed = false;

--- a/packages/flutter_bloc/test/repository_provider_test.dart
+++ b/packages/flutter_bloc/test/repository_provider_test.dart
@@ -168,6 +168,36 @@ void main() {
       expect(tester.takeException(), isInstanceOf<AssertionError>());
     });
 
+    testWidgets('lazily loads repositories by default',
+        (WidgetTester tester) async {
+      var createCalled = false;
+      await tester.pumpWidget(
+        RepositoryProvider(
+          create: (_) {
+            createCalled = true;
+            return Repository(0);
+          },
+          child: Container(),
+        ),
+      );
+      expect(createCalled, isFalse);
+    });
+
+    testWidgets('can override lazy loading', (WidgetTester tester) async {
+      var createCalled = false;
+      await tester.pumpWidget(
+        RepositoryProvider(
+          create: (_) {
+            createCalled = true;
+            return Repository(0);
+          },
+          lazy: false,
+          child: Container(),
+        ),
+      );
+      expect(createCalled, isTrue);
+    });
+
     testWidgets('passes value to children via builder',
         (WidgetTester tester) async {
       final repository = Repository(0);


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Expose `lazy` property on `BlocProvider` and `RepositoryProvider`
- Bump `provider` version to `^4.0.1` ([#748](https://github.com/felangel/bloc/issues/748))

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
- Changes included in v3.1.0