### PR TITLE
allow blocTests to add more than one asynchronous event

### DIFF
--- a/packages/bloc_test/lib/src/bloc_test.dart
+++ b/packages/bloc_test/lib/src/bloc_test.dart
@@ -78,7 +78,6 @@ void blocTest<B extends Bloc<Event, State>, Event, State>(
 }) {
   test(description, () async {
     final bloc = build();
-    await act?.call(bloc);
-    await emitsExactly(bloc, expect, duration: wait);
+    await emitsExactly(bloc, expect, duration: wait, act: act);
   });
 }

--- a/packages/bloc_test/lib/src/bloc_test.dart
+++ b/packages/bloc_test/lib/src/bloc_test.dart
@@ -43,6 +43,22 @@ import 'package:test/test.dart';
 /// );
 /// ```
 ///
+/// [blocTest] can also be used when you need to add multiple events in sequence
+/// asynchronously by adding delays in the [act] function.
+///
+/// ```dart
+/// blocTest(
+///  'emits [0, 1, 2] when CounterEvent.increment is called multiple times with async act',
+///  build: () => CounterBloc(),
+///  act: (bloc) async {
+///    bloc.add(CounterEvent.increment);
+///    await Future.delayed(Duration(milliseconds: 10));
+///    bloc.add(CounterEvent.increment);
+///  },
+///  expect: [0, 1, 2],
+///);
+/// ```
+///
 /// [blocTest] can also be used to wait for async operations like `debounceTime`
 /// by optionally providing a `Duration` to [wait].
 ///

--- a/packages/bloc_test/lib/src/emits_exactly.dart
+++ b/packages/bloc_test/lib/src/emits_exactly.dart
@@ -40,10 +40,12 @@ Future<void> emitsExactly<B extends Bloc<dynamic, State>, State>(
   B bloc,
   Iterable expected, {
   Duration duration,
+  Future<void> Function(B bloc) act,
 }) async {
   assert(bloc != null);
   final states = <State>[];
   final subscription = bloc.listen(states.add);
+  await act?.call(bloc);
   if (duration != null) await Future.delayed(duration);
   await bloc.close();
   expect(states, expected);

--- a/packages/bloc_test/test/bloc_test_test.dart
+++ b/packages/bloc_test/test/bloc_test_test.dart
@@ -30,6 +30,17 @@ void main() {
         },
         expect: [0, 1],
       );
+
+      blocTest(
+        'emits [0, 1, 2] when CounterEvent.increment is called multiple times with async act',
+        build: () => CounterBloc(),
+        act: (bloc) async {
+          bloc.add(CounterEvent.increment);
+          await Future.delayed(Duration(milliseconds: 10));
+          bloc.add(CounterEvent.increment);
+        },
+        expect: [0, 1, 2],
+      );
     });
 
     group('AsyncCounterBloc', () {


### PR DESCRIPTION


## Status
READY

## Breaking Changes
NO

## Description
allow blocTests to add more than one asynchronous event

The issue was that emitsExactly was listening to events too late. Since
Bloc uses a BehaviorSubject, if there is a delay between events the
listener would miss states emitted before the listener attaches. The
listener should start listening before any events are added so that all
states get recorded. I suspect this was the underlying problem with
[#724].
## Todos
- [x] Tests
- [x] Documentation
- [x] Examples

## Steps to Test or Reproduce
The included test outlines the existing problem. If there is an asynchronous situation and the test requires multiple events in sequence, the current implementation will yield a false negative as it may not capture all the bloc's states. The reason is that act is called before the emitExactly function listens to the bloc. The behaviorSubject in the bloc starts with the last state given which may exclude earlier states in some situations. By listening to the bloc stream before we act, this should solve the problem.

## Impact to Remaining Code Base
This PR will affect: nothing else as far as I can tell. all the bloc_test tests pass with this change.