### PR TITLE
bloc_test v3.0.1

### DIFF
--- a/packages/bloc_test/CHANGELOG.md
+++ b/packages/bloc_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.0.1
+
+- Enable `blocTest` to add more than one asynchronous event at a time ([#724](https://github.com/felangel/bloc/issues/724))
+
 # 3.0.0
 
 - Update to `bloc: ^3.0.0`

--- a/packages/bloc_test/lib/src/bloc_test.dart
+++ b/packages/bloc_test/lib/src/bloc_test.dart
@@ -1,9 +1,8 @@
 import 'dart:async';
 
 import 'package:bloc/bloc.dart';
-import 'package:bloc_test/bloc_test.dart';
 import 'package:meta/meta.dart';
-import 'package:test/test.dart';
+import 'package:test/test.dart' as test;
 
 /// Creates a new [bloc]-specific test case with the given [description].
 /// [blocTest] will handle asserting that the [bloc] emits the [expect]ed
@@ -76,9 +75,14 @@ void blocTest<B extends Bloc<Event, State>, Event, State>(
   Future<void> Function(B bloc) act,
   Duration wait,
 }) {
-  test(description, () async {
+  test.test(description, () async {
     final bloc = build();
+    final states = <State>[];
+    final subscription = bloc.listen(states.add);
     await act?.call(bloc);
-    await emitsExactly(bloc, expect, duration: wait);
+    if (wait != null) await Future.delayed(wait);
+    await bloc.close();
+    test.expect(states, expect);
+    await subscription.cancel();
   });
 }

--- a/packages/bloc_test/pubspec.yaml
+++ b/packages/bloc_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc_test
 description: A testing library which makes it easy to test blocs. Built to be used with the bloc state management package.
-version: 3.0.0
+version: 3.0.1
 repository: https://github.com/felangel/bloc
 issue_tracker: https://github.com/felangel/bloc/issues
 homepage: https://bloclibrary.dev

--- a/packages/bloc_test/test/bloc_test_test.dart
+++ b/packages/bloc_test/test/bloc_test_test.dart
@@ -30,6 +30,17 @@ void main() {
         },
         expect: [0, 1],
       );
+
+      blocTest(
+        'emits [0, 1, 2] when CounterEvent.increment is called multiple times with async act',
+        build: () => CounterBloc(),
+        act: (bloc) async {
+          bloc.add(CounterEvent.increment);
+          await Future.delayed(Duration(milliseconds: 10));
+          bloc.add(CounterEvent.increment);
+        },
+        expect: [0, 1, 2],
+      );
     });
 
     group('AsyncCounterBloc', () {
@@ -44,6 +55,17 @@ void main() {
         build: () => AsyncCounterBloc(),
         act: (bloc) => bloc.add(AsyncCounterEvent.increment),
         expect: [0, 1],
+      );
+
+      blocTest(
+        'emits [0, 1, 2] when AsyncCounterEvent.increment is called multiple times with async act',
+        build: () => AsyncCounterBloc(),
+        act: (bloc) async {
+          bloc.add(AsyncCounterEvent.increment);
+          await Future.delayed(Duration(milliseconds: 10));
+          bloc.add(AsyncCounterEvent.increment);
+        },
+        expect: [0, 1, 2],
       );
     });
 
@@ -75,6 +97,17 @@ void main() {
         build: () => MultiCounterBloc(),
         act: (bloc) => bloc.add(MultiCounterEvent.increment),
         expect: [0, 1, 2],
+      );
+
+      blocTest(
+        'emits [0, 1, 2, 3, 4] when MultiCounterEvent.increment is called multiple times with async act',
+        build: () => MultiCounterBloc(),
+        act: (bloc) async {
+          bloc.add(MultiCounterEvent.increment);
+          await Future.delayed(Duration(milliseconds: 10));
+          bloc.add(MultiCounterEvent.increment);
+        },
+        expect: [0, 1, 2, 3, 4],
       );
     });
 


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Enable `blocTest` to add more than one asynchronous event at a time ([#724](https://github.com/felangel/bloc/issues/724))

## Related PRs
- https://github.com/felangel/bloc/pull/756

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
- Fix which will be included in v3.0.1