### PR TITLE
Upgrade to effective_dart 1.2.0

### DIFF
--- a/packages/angular_bloc/analysis_options.yaml
+++ b/packages/angular_bloc/analysis_options.yaml
@@ -1,4 +1,5 @@
-include: package:effective_dart/analysis_options.1.1.0.yaml
+include: package:effective_dart/analysis_options.1.2.0.yaml
+
 analyzer:
   exclude: [build/**]
   errors:

--- a/packages/angular_bloc/lib/src/pipes/bloc_pipe.dart
+++ b/packages/angular_bloc/lib/src/pipes/bloc_pipe.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:angular/core.dart'
     show ChangeDetectorRef, OnDestroy, Pipe, PipeTransform;
-
 import 'package:bloc/bloc.dart';
 
 /// {@template blocpipe}
@@ -48,8 +47,9 @@ class BlocPipe implements OnDestroy, PipeTransform {
   void _subscribe(Bloc bloc) {
     _bloc = bloc;
     _subscription = bloc.listen(
-        (Object value) => _updateLatestValue(bloc, value),
-        onError: (dynamic e) => throw e);
+      (value) => _updateLatestValue(bloc, value),
+      onError: (dynamic e) => throw e,
+    );
   }
 
   void _updateLatestValue(dynamic async, Object value) {

--- a/packages/angular_bloc/pubspec.yaml
+++ b/packages/angular_bloc/pubspec.yaml
@@ -20,4 +20,4 @@ dev_dependencies:
   pedantic: ^1.8.0
   test: ^1.6.0
   mockito: ^4.0.0
-  effective_dart: ^1.1.1
+  effective_dart: ^1.2.0

--- a/packages/bloc/analysis_options.yaml
+++ b/packages/bloc/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:effective_dart/analysis_options.1.1.0.yaml
+include: package:effective_dart/analysis_options.1.2.0.yaml

--- a/packages/bloc/example/main.dart
+++ b/packages/bloc/example/main.dart
@@ -62,7 +62,8 @@ void main() {
 
   counterBloc.add(null); // Triggers Exception
 
-  // The exception triggers `SimpleBlocDelegate.onError` but does not impact bloc functionality.
+  // The exception triggers `SimpleBlocDelegate.onError`
+  // but does not impact bloc functionality.
   counterBloc.add(CounterEvent.increment);
   counterBloc.add(CounterEvent.decrement);
 }

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -31,8 +31,9 @@ abstract class Bloc<Event, State> extends Stream<State> implements Sink<Event> {
   }
 
   /// Adds a subscription to the `Stream<State>`.
-  /// Returns a [StreamSubscription] which handles events from the `Stream<State>`
-  /// using the provided [onData], [onError] and [onDone] handlers.
+  /// Returns a [StreamSubscription] which handles events from
+  /// the `Stream<State>` using the provided [onData], [onError] and [onDone]
+  /// handlers.
   @override
   StreamSubscription<State> listen(
     void Function(State) onData, {
@@ -53,14 +54,17 @@ abstract class Bloc<Event, State> extends Stream<State> implements Sink<Event> {
   void onEvent(Event event) => null;
 
   /// Called whenever a [transition] occurs with the given [transition].
-  /// A [transition] occurs when a new `event` is [add]ed and [mapEventToState] executed.
+  /// A [transition] occurs when a new `event` is [add]ed and [mapEventToState]
+  /// executed.
   /// [onTransition] is called before a [bloc]'s [state] has been updated.
   /// A great spot to add logging/analytics at the individual [bloc] level.
   void onTransition(Transition<Event, State> transition) => null;
 
   /// Called whenever an [error] is thrown within [mapEventToState].
-  /// By default all [error]s will be ignored and [bloc] functionality will be unaffected.
-  /// The [stacktrace] argument may be `null` if the [state] stream received an error without a [stacktrace].
+  /// By default all [error]s will be ignored and [bloc] functionality will be
+  /// unaffected.
+  /// The [stacktrace] argument may be `null` if the [state] stream received
+  /// an error without a [stacktrace].
   /// A great spot to handle errors at the individual [Bloc] level.
   void onError(Object error, StackTrace stacktrace) => null;
 
@@ -83,7 +87,8 @@ abstract class Bloc<Event, State> extends Stream<State> implements Sink<Event> {
   /// This method should be called when a [bloc] is no longer needed.
   /// Once [close] is called, `events` that are [add]ed will not be
   /// processed and will result in an error being passed to [onError].
-  /// In addition, if [close] is called while `events` are still being processed,
+  /// In addition, if [close] is called while `events` are still being
+  /// processed,
   /// the [bloc] will continue to process the pending `events` to completion.
   @override
   @mustCallSuper
@@ -92,22 +97,26 @@ abstract class Bloc<Event, State> extends Stream<State> implements Sink<Event> {
     await _stateSubject.close();
   }
 
-  /// Transforms the [events] stream along with a [next] function into a `Stream<State>`.
-  /// Events that should be processed by [mapEventToState] need to be passed to [next].
-  /// By default `asyncExpand` is used to ensure all [events] are processed in the order
-  /// in which they are received. You can override [transformEvents] for advanced usage
-  /// in order to manipulate the frequency and specificity with which [mapEventToState]
-  /// is called as well as which [events] are processed.
+  /// Transforms the [events] stream along with a [next] function into
+  /// a `Stream<State>`.
+  /// Events that should be processed by [mapEventToState] need to be passed to
+  /// [next].
+  /// By default `asyncExpand` is used to ensure all [events] are processed in
+  /// the order in which they are received.
+  /// You can override [transformEvents] for advanced usage in order to
+  /// manipulate the frequency and specificity with which [mapEventToState] is
+  /// called as well as which [events] are processed.
   ///
-  /// For example, if you only want [mapEventToState] to be called on the most recent
-  /// [event] you can use `switchMap` instead of `asyncExpand`.
+  /// For example, if you only want [mapEventToState] to be called on the most
+  /// recent [event] you can use `switchMap` instead of `asyncExpand`.
   ///
   /// ```dart
   /// @override
   /// Stream<State> transformEvents(events, next) => events.switchMap(next);
   /// ```
   ///
-  /// Alternatively, if you only want [mapEventToState] to be called for distinct [events]:
+  /// Alternatively, if you only want [mapEventToState] to be called for
+  /// distinct [events]:
   ///
   /// ```dart
   /// @override
@@ -134,9 +143,9 @@ abstract class Bloc<Event, State> extends Stream<State> implements Sink<Event> {
 
   /// Transforms the `Stream<State>` into a new `Stream<State>`.
   /// By default [transformStates] returns the incoming `Stream<State>`.
-  /// You can override [transformStates] for advanced usage
-  /// in order to manipulate the frequency and specificity at which `transitions` (state changes)
-  /// occur.
+  /// You can override [transformStates] for advanced usage in order to
+  /// manipulate the frequency and specificity at which `transitions`
+  /// (state changes) occur.
   ///
   /// For example, if you want to debounce outgoing [states]:
   ///

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
 
-import 'package:bloc/bloc.dart';
 import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
+
+import '../bloc.dart';
 
 /// {@template bloc}
 /// Takes a `Stream` of `Events` as input
@@ -150,11 +151,11 @@ abstract class Bloc<Event, State> extends Stream<State> implements Sink<Event> {
   void _bindStateSubject() {
     Event currentEvent;
 
-    transformStates(transformEvents(_eventSubject, (Event event) {
+    transformStates(transformEvents(_eventSubject, (event) {
       currentEvent = event;
       return mapEventToState(currentEvent).handleError(_handleError);
     })).forEach(
-      (State nextState) {
+      (nextState) {
         if (state == nextState || _stateSubject.isClosed) return;
         final transition = Transition(
           currentState: state,

--- a/packages/bloc/lib/src/bloc_delegate.dart
+++ b/packages/bloc/lib/src/bloc_delegate.dart
@@ -5,21 +5,25 @@ import '../bloc.dart';
 /// Handles `events` from all [bloc]s
 /// which are delegated by the [BlocSupervisor].
 class BlocDelegate {
-  /// Called whenever an [event] is `added` to any [bloc] with the given [bloc] and [event].
+  /// Called whenever an [event] is `added` to any [bloc] with the given [bloc]
+  /// and [event].
   /// A great spot to add universal logging/analytics.
   @mustCallSuper
   void onEvent(Bloc bloc, Object event) => null;
 
-  /// Called whenever a transition occurs in any [bloc] with the given [bloc] and [transition].
-  /// A [transition] occurs when a new `event` is `added` and `mapEventToState` executed.
+  /// Called whenever a transition occurs in any [bloc] with the given [bloc]
+  /// and [transition].
+  /// A [transition] occurs when a new `event` is `added` and `mapEventToState`
+  /// executed.
   /// [onTransition] is called before a [bloc]'s state has been updated.
   /// A great spot to add universal logging/analytics.
   @mustCallSuper
   void onTransition(Bloc bloc, Transition transition) => null;
 
-  /// Called whenever an [error] is thrown in any [bloc]
-  /// with the given [bloc], [error], and [stacktrace].
-  /// The [stacktrace] argument may be `null` if the state stream received an error without a [stacktrace].
+  /// Called whenever an [error] is thrown in any [bloc] with the given [bloc],
+  /// [error], and [stacktrace].
+  /// The [stacktrace] argument may be `null` if the state stream received
+  /// an error without a [stacktrace].
   /// A great spot to add universal error handling.
   @mustCallSuper
   void onError(Bloc bloc, Object error, StackTrace stacktrace) => null;

--- a/packages/bloc/lib/src/bloc_delegate.dart
+++ b/packages/bloc/lib/src/bloc_delegate.dart
@@ -1,5 +1,6 @@
-import 'package:bloc/bloc.dart';
 import 'package:meta/meta.dart';
+
+import '../bloc.dart';
 
 /// Handles `events` from all [bloc]s
 /// which are delegated by the [BlocSupervisor].

--- a/packages/bloc/lib/src/bloc_supervisor.dart
+++ b/packages/bloc/lib/src/bloc_supervisor.dart
@@ -1,4 +1,4 @@
-import 'package:bloc/bloc.dart';
+import '../bloc.dart';
 
 /// Oversees all [bloc]s and delegates responsibilities to the [BlocDelegate].
 class BlocSupervisor {
@@ -9,10 +9,12 @@ class BlocSupervisor {
 
   static final BlocSupervisor _instance = BlocSupervisor._();
 
-  /// [BlocDelegate] getter which returns the singleton [BlocSupervisor] instance's [BlocDelegate].
+  /// [BlocDelegate] getter which returns the singleton [BlocSupervisor]
+  /// instance's [BlocDelegate].
   static BlocDelegate get delegate => _instance._delegate;
 
-  /// [BlocDelegate] setter which sets the singleton [BlocSupervisor] instance's [BlocDelegate].
+  /// [BlocDelegate] setter which sets the singleton [BlocSupervisor]
+  /// instance's [BlocDelegate].
   static set delegate(BlocDelegate d) {
     _instance._delegate = d ?? BlocDelegate();
   }

--- a/packages/bloc/lib/src/transition.dart
+++ b/packages/bloc/lib/src/transition.dart
@@ -3,7 +3,8 @@ import 'package:meta/meta.dart';
 /// {@template transition}
 /// Occurs when an [event] is `added` after `mapEventToState` has been called
 /// but before the [bloc]'s `state` has been updated.
-/// A [Transition] consists of the [currentState], the [event] which was `added`, and the [nextState].
+/// A [Transition] consists of the [currentState], the [event] which was
+/// `added`, and the [nextState].
 /// {@endtemplate}
 class Transition<Event, State> {
   /// The current [State] of the [bloc] at the time of the [Transition].
@@ -39,5 +40,6 @@ class Transition<Event, State> {
 
   @override
   String toString() =>
-      'Transition { currentState: $currentState, event: $event, nextState: $nextState }';
+      'Transition { currentState: $currentState, event: $event, '
+      'nextState: $nextState }';
 }

--- a/packages/bloc/lib/src/transition.dart
+++ b/packages/bloc/lib/src/transition.dart
@@ -6,6 +6,7 @@ import 'package:meta/meta.dart';
 /// A [Transition] consists of the [currentState], the [event] which was
 /// `added`, and the [nextState].
 /// {@endtemplate}
+@immutable
 class Transition<Event, State> {
   /// The current [State] of the [bloc] at the time of the [Transition].
   final State currentState;

--- a/packages/bloc/pubspec.yaml
+++ b/packages/bloc/pubspec.yaml
@@ -16,4 +16,4 @@ dev_dependencies:
   test: ">=1.3.0 <2.0.0"
   test_coverage: ^0.2.0
   mockito: ^4.0.0
-  effective_dart: ^1.1.1
+  effective_dart: ^1.2.0

--- a/packages/bloc/test/bloc_delegate_test.dart
+++ b/packages/bloc/test/bloc_delegate_test.dart
@@ -2,7 +2,7 @@ import 'package:bloc/bloc.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
-import './helpers/helpers.dart';
+import 'helpers/helpers.dart';
 
 class MockBlocDelegate extends Mock implements BlocDelegate {}
 
@@ -215,7 +215,7 @@ void main() {
       final _bloc = CounterExceptionBloc();
       BlocSupervisor.delegate = delegate;
 
-      when(delegate.onError(any, any, any)).thenAnswer((Invocation invocation) {
+      when(delegate.onError(any, any, any)).thenAnswer((invocation) {
         blocWithError = invocation.positionalArguments[0] as Bloc;
         errorHandled = true;
       });

--- a/packages/bloc/test/bloc_supervisor_test.dart
+++ b/packages/bloc/test/bloc_supervisor_test.dart
@@ -11,16 +11,16 @@ void main() {
   });
 
   test(
-      'BlocSupervisor should have a correct BlocDelegate singleton when explicity set',
-      () {
+      'BlocSupervisor should have a correct BlocDelegate singleton '
+      'when explicity set', () {
     final delegate = MockBlocDelegate();
     BlocSupervisor.delegate = delegate;
     expect(BlocSupervisor.delegate, delegate);
   });
 
   test(
-      'BlocSupervisor should use default BlocDelegate singleton when explicity set to null',
-      () {
+      'BlocSupervisor should use default BlocDelegate singleton '
+      'when explicity set to null', () {
     BlocSupervisor.delegate = null;
     expect(BlocSupervisor.delegate, isNotNull);
   });

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -242,7 +242,8 @@ void main() {
       test('single Increment event updates state to 1', () {
         final expectedStates = [0, 1];
         final expectedTransitions = [
-          'Transition { currentState: 0, event: CounterEvent.increment, nextState: 1 }'
+          'Transition { currentState: 0, event: CounterEvent.increment, '
+              'nextState: 1 }'
         ];
 
         expectLater(
@@ -269,9 +270,12 @@ void main() {
       test('multiple Increment event updates state to 3', () {
         final expectedStates = [0, 1, 2, 3];
         final expectedTransitions = [
-          'Transition { currentState: 0, event: CounterEvent.increment, nextState: 1 }',
-          'Transition { currentState: 1, event: CounterEvent.increment, nextState: 2 }',
-          'Transition { currentState: 2, event: CounterEvent.increment, nextState: 3 }',
+          'Transition { currentState: 0, event: CounterEvent.increment, '
+              'nextState: 1 }',
+          'Transition { currentState: 1, event: CounterEvent.increment, '
+              'nextState: 2 }',
+          'Transition { currentState: 2, event: CounterEvent.increment, '
+              'nextState: 3 }',
         ];
 
         expectLater(
@@ -346,8 +350,8 @@ void main() {
       });
 
       test(
-          'close while events are pending finishes processing pending events and does not trigger onError',
-          () async {
+          'close while events are pending finishes processing pending events '
+          'and does not trigger onError', () async {
         final expectedStates = <AsyncState>[
           AsyncState.initial(),
           AsyncState.initial().copyWith(isLoading: true),

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -446,22 +446,6 @@ void main() {
       });
     });
 
-    group('== operator', () {
-      test('returns true for the same two CounterBlocs', () {
-        final blocA = CounterBloc();
-        final blocB = CounterBloc();
-
-        expect(blocA == blocB, true);
-      });
-
-      test('returns false for the two different Blocs', () {
-        final blocA = CounterBloc();
-        final blocB = ComplexBloc();
-
-        expect(blocA == blocB, false);
-      });
-    });
-
     group('Exception', () {
       test('does not break stream', () {
         final expected = [0, -1];

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -476,7 +476,7 @@ void main() {
 
         final bloc = OnExceptionBloc(
             exception: exception,
-            onErrorCallback: (Object error, StackTrace stacktrace) {
+            onErrorCallback: (error, stacktrace) {
               expectedError = error;
               expectedStacktrace = stacktrace;
             });
@@ -496,7 +496,7 @@ void main() {
         Object capturedError;
         StackTrace capturedStacktrace;
         final bloc = CounterBloc(
-          onErrorCallback: (Object error, StackTrace stacktrace) {
+          onErrorCallback: (error, stacktrace) {
             capturedError = error;
             capturedStacktrace = stacktrace;
           },
@@ -547,7 +547,7 @@ void main() {
 
         final bloc = OnErrorBloc(
           error: error,
-          onErrorCallback: (Object error, StackTrace stacktrace) {
+          onErrorCallback: (error, stacktrace) {
             expectedError = error;
             expectedStacktrace = stacktrace;
           },
@@ -571,7 +571,7 @@ void main() {
 
         final bloc = OnTransitionErrorBloc(
           error: error,
-          onErrorCallback: (Object error, StackTrace stacktrace) {
+          onErrorCallback: (error, stacktrace) {
             expectedError = error;
             expectedStacktrace = stacktrace;
           },

--- a/packages/bloc/test/helpers/async/async_event.dart
+++ b/packages/bloc/test/helpers/async/async_event.dart
@@ -1,3 +1,6 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class AsyncEvent {
   @override
   bool operator ==(

--- a/packages/bloc/test/helpers/async/async_state.dart
+++ b/packages/bloc/test/helpers/async/async_state.dart
@@ -1,3 +1,6 @@
+import 'package:meta/meta.dart';
+
+@immutable
 class AsyncState {
   final bool isLoading;
   final bool hasError;

--- a/packages/bloc/test/helpers/async/async_state.dart
+++ b/packages/bloc/test/helpers/async/async_state.dart
@@ -36,5 +36,6 @@ class AsyncState {
 
   @override
   String toString() =>
-      'AsyncState { isLoading: $isLoading, hasError: $hasError, isSuccess: $isSuccess }';
+      'AsyncState { isLoading: $isLoading, hasError: $hasError, '
+      'isSuccess: $isSuccess }';
 }

--- a/packages/bloc/test/helpers/complex/complex_bloc.dart
+++ b/packages/bloc/test/helpers/complex/complex_bloc.dart
@@ -35,17 +35,4 @@ class ComplexBloc extends Bloc<ComplexEvent, ComplexState> {
   Stream<ComplexState> transformStates(Stream<ComplexState> states) {
     return states.debounceTime(Duration(milliseconds: 50));
   }
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is ComplexBloc &&
-          runtimeType == other.runtimeType &&
-          initialState == other.initialState;
-
-  @override
-  int get hashCode =>
-      initialState.hashCode ^
-      mapEventToState.hashCode ^
-      transformEvents.hashCode;
 }

--- a/packages/bloc/test/helpers/complex/complex_event.dart
+++ b/packages/bloc/test/helpers/complex/complex_event.dart
@@ -1,3 +1,6 @@
+import 'package:meta/meta.dart';
+
+@immutable
 abstract class ComplexEvent {}
 
 class ComplexEventA extends ComplexEvent {

--- a/packages/bloc/test/helpers/complex/complex_state.dart
+++ b/packages/bloc/test/helpers/complex/complex_state.dart
@@ -1,3 +1,6 @@
+import 'package:meta/meta.dart';
+
+@immutable
 abstract class ComplexState {}
 
 class ComplexStateA extends ComplexState {

--- a/packages/bloc/test/helpers/counter/counter_bloc.dart
+++ b/packages/bloc/test/helpers/counter/counter_bloc.dart
@@ -47,17 +47,4 @@ class CounterBloc extends Bloc<CounterEvent, int> {
   void onError(Object error, StackTrace stacktrace) {
     onErrorCallback?.call(error, stacktrace);
   }
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is CounterBloc &&
-          runtimeType == other.runtimeType &&
-          initialState == other.initialState;
-
-  @override
-  int get hashCode =>
-      initialState.hashCode ^
-      mapEventToState.hashCode ^
-      transformEvents.hashCode;
 }

--- a/packages/bloc/test/transition_test.dart
+++ b/packages/bloc/test/transition_test.dart
@@ -1,8 +1,11 @@
+import 'package:meta/meta.dart';
 import 'package:test/test.dart';
 import 'package:bloc/bloc.dart';
 
+@immutable
 abstract class TransitionEvent {}
 
+@immutable
 abstract class TransitionState {}
 
 class SimpleTransitionEvent extends TransitionEvent {}

--- a/packages/bloc/test/transition_test.dart
+++ b/packages/bloc/test/transition_test.dart
@@ -43,8 +43,8 @@ void main() {
   group('Transition Tests', () {
     group('constructor', () {
       test(
-          'should throw assertion error when initialized with a null currentState',
-          () {
+          'should throw assertion error when initialized '
+          'with a null currentState', () {
         expect(
           () => Transition<TransitionEvent, TransitionState>(
             currentState: null,
@@ -87,8 +87,8 @@ void main() {
       });
 
       test(
-          'should not throw assertion error when initialized with with all required parameters',
-          () {
+          'should not throw assertion error when initialized with '
+          'all required parameters', () {
         try {
           Transition<TransitionEvent, TransitionState>(
             currentState: SimpleTransitionState(),
@@ -97,7 +97,8 @@ void main() {
           );
         } on dynamic catch (_) {
           fail(
-            'should not throw error when initialized with all required parameters',
+            'should not throw error when initialized '
+            'with all required parameters',
           );
         }
       });
@@ -159,8 +160,11 @@ void main() {
           nextState: CounterState(1),
         );
 
-        expect(transition.toString(),
-            'Transition { currentState: ${transition.currentState.toString()}, event: ${transition.event.toString()}, nextState: ${transition.nextState.toString()} }');
+        expect(
+            transition.toString(),
+            'Transition { currentState: ${transition.currentState.toString()}, '
+            'event: ${transition.event.toString()}, '
+            'nextState: ${transition.nextState.toString()} }');
       });
     });
   });

--- a/packages/bloc_test/analysis_options.yaml
+++ b/packages/bloc_test/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:effective_dart/analysis_options.1.1.0.yaml
+include: package:effective_dart/analysis_options.1.2.0.yaml

--- a/packages/bloc_test/example/main.dart
+++ b/packages/bloc_test/example/main.dart
@@ -35,7 +35,8 @@ void main() {
       // Stub the listen with a fake Stream
       whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
 
-      // Expect that the CounterBloc instance emitted the stubbed Stream of states
+      // Expect that the CounterBloc instance emitted the stubbed Stream of
+      // states
       expectLater(counterBloc, emitsInOrder(<int>[0, 1, 2, 3]));
     });
   });

--- a/packages/bloc_test/lib/src/bloc_test.dart
+++ b/packages/bloc_test/lib/src/bloc_test.dart
@@ -13,8 +13,8 @@ import 'package:test/test.dart' as test;
 /// [build] should be used for all [bloc] initialization and preparation
 /// and must return the [bloc] under test.
 ///
-/// [act] is an optional callback which will be invoked with the [bloc] under test
-/// and should be used to `add` events to the [bloc].
+/// [act] is an optional callback which will be invoked with the [bloc] under
+/// test and should be used to `add` events to the [bloc].
 ///
 /// [wait] is an optional `Duration` which can be used to wait for
 /// async operations within the [bloc] under test such as `debounceTime`.

--- a/packages/bloc_test/lib/src/emits_exactly.dart
+++ b/packages/bloc_test/lib/src/emits_exactly.dart
@@ -33,7 +33,11 @@ import 'package:test/test.dart';
 /// test('emits [0, 1] when CounterEvent.increment is added', () async {
 ///   final bloc = CounterBloc();
 ///   bloc.add(CounterEvent.increment);
-///   await emitsExactly(bloc, [0, 1], duration: const Duration(milliseconds: 300));
+///   await emitsExactly(
+///     bloc,
+///     [0, 1],
+///     duration: const Duration(milliseconds: 300),
+///   );
 /// });
 /// ```
 Future<void> emitsExactly<B extends Bloc<dynamic, State>, State>(

--- a/packages/bloc_test/lib/src/mock_bloc.dart
+++ b/packages/bloc_test/lib/src/mock_bloc.dart
@@ -6,11 +6,12 @@ import 'package:mockito/mockito.dart';
 /// Extend or mixin this class to mark the implementation as a [MockBloc].
 ///
 /// A mocked bloc implements all fields and methods with a default
-/// implementation that does not throw a [NoSuchMethodError], and may be further
-/// customized at runtime to define how it may behave using [when] and [whenListen].
+/// implementation that does not throw a [NoSuchMethodError],
+/// and may be further customized at runtime to define how it may behave using
+/// [when] and [whenListen].
 ///
-/// _**Note**: it is critical to explicitly provide the bloc event and state types_
-/// _when extending [MockBloc]_.
+/// _**Note**: it is critical to explicitly provide the bloc event and state
+/// types when extending [MockBloc]_.
 ///
 /// **GOOD**
 /// ```dart

--- a/packages/bloc_test/lib/src/when_listen.dart
+++ b/packages/bloc_test/lib/src/when_listen.dart
@@ -31,7 +31,7 @@ void whenListen<Event, State>(
 ) {
   final broadcastStream = stream.asBroadcastStream();
   when(bloc.skip(any)).thenAnswer(
-    (Invocation invocation) =>
+    (invocation) =>
         broadcastStream.skip(invocation.positionalArguments.first as int),
   );
 
@@ -40,7 +40,7 @@ void whenListen<Event, State>(
     onError: captureAnyNamed('onError'),
     onDone: captureAnyNamed('onDone'),
     cancelOnError: captureAnyNamed('cancelOnError'),
-  )).thenAnswer((Invocation invocation) {
+  )).thenAnswer((invocation) {
     return broadcastStream.listen(
       invocation.positionalArguments.first as Function(State),
       onError: invocation.namedArguments[Symbol('onError')] as Function,

--- a/packages/bloc_test/pubspec.yaml
+++ b/packages/bloc_test/pubspec.yaml
@@ -17,4 +17,4 @@ dependencies:
 
 dev_dependencies:
   test_coverage: ^0.2.0
-  effective_dart: ^1.1.1
+  effective_dart: ^1.2.0

--- a/packages/bloc_test/test/bloc_test_test.dart
+++ b/packages/bloc_test/test/bloc_test_test.dart
@@ -32,7 +32,8 @@ void main() {
       );
 
       blocTest(
-        'emits [0, 1, 2] when CounterEvent.increment is called multiple times with async act',
+        'emits [0, 1, 2] when CounterEvent.increment is called multiple times'
+        'with async act',
         build: () => CounterBloc(),
         act: (bloc) async {
           bloc.add(CounterEvent.increment);
@@ -58,7 +59,8 @@ void main() {
       );
 
       blocTest(
-        'emits [0, 1, 2] when AsyncCounterEvent.increment is called multiple times with async act',
+        'emits [0, 1, 2] when AsyncCounterEvent.increment is called multiple'
+        'times with async act',
         build: () => AsyncCounterBloc(),
         act: (bloc) async {
           bloc.add(AsyncCounterEvent.increment);
@@ -100,7 +102,8 @@ void main() {
       );
 
       blocTest(
-        'emits [0, 1, 2, 3, 4] when MultiCounterEvent.increment is called multiple times with async act',
+        'emits [0, 1, 2, 3, 4] when MultiCounterEvent.increment is called'
+        'multiple times with async act',
         build: () => MultiCounterBloc(),
         act: (bloc) async {
           bloc.add(MultiCounterEvent.increment);

--- a/packages/bloc_test/test/emits_exactly_test.dart
+++ b/packages/bloc_test/test/emits_exactly_test.dart
@@ -259,6 +259,7 @@ void main() {
         } on TestFailure catch (error) {
           expect(
               error.message,
+              // ignore: lines_longer_than_80_chars
               'Expected: [<<Instance of \'ComplexStateA\'>>, <<Instance of \'ComplexStateB\'>>]\n'
               '  Actual: [Instance of \'ComplexStateA\']\n'
               '   Which: shorter than expected at location [1]\n'
@@ -278,8 +279,11 @@ void main() {
         } on TestFailure catch (error) {
           expect(
               error.message,
+              // ignore: lines_longer_than_80_chars
               'Expected: [<<Instance of \'ComplexStateA\'>>, <<Instance of \'ComplexStateB\'>>]\n'
+              // ignore: lines_longer_than_80_chars
               '  Actual: [Instance of \'ComplexStateA\', Instance of \'ComplexStateA\']\n'
+              // ignore: lines_longer_than_80_chars
               '   Which: does not match <Instance of \'ComplexStateB\'> at location [1]\n'
               '');
         }
@@ -302,6 +306,7 @@ void main() {
               '            <<Instance of \'ComplexStateB\'>>,\n'
               '            <<Instance of \'ComplexStateA\'>>\n'
               '          ]\n'
+              // ignore: lines_longer_than_80_chars
               '  Actual: [Instance of \'ComplexStateA\', Instance of \'ComplexStateB\']\n'
               '   Which: shorter than expected at location [2]\n'
               '');

--- a/packages/flutter_bloc/analysis_options.yaml
+++ b/packages/flutter_bloc/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:effective_dart/analysis_options.1.1.0.yaml
+include: package:effective_dart/analysis_options.1.2.0.yaml

--- a/packages/flutter_bloc/lib/src/bloc_builder.dart
+++ b/packages/flutter_bloc/lib/src/bloc_builder.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 
+import 'package:bloc/bloc.dart';
 import 'package:flutter/widgets.dart';
 
-import 'package:bloc/bloc.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
+import '../flutter_bloc.dart';
 
 /// Signature for the [builder] function which takes the `BuildContext` and [state]
 /// and is responsible for returning a widget which is to be rendered.
@@ -163,7 +163,7 @@ class _BlocBuilderBaseState<B extends Bloc<dynamic, S>, S>
 
   void _subscribe() {
     if (_bloc != null) {
-      _subscription = _bloc.skip(1).listen((S state) {
+      _subscription = _bloc.skip(1).listen((state) {
         if (widget.condition?.call(_previousState, state) ?? true) {
           setState(() {
             _state = state;

--- a/packages/flutter_bloc/lib/src/bloc_builder.dart
+++ b/packages/flutter_bloc/lib/src/bloc_builder.dart
@@ -5,26 +5,27 @@ import 'package:flutter/widgets.dart';
 
 import '../flutter_bloc.dart';
 
-/// Signature for the [builder] function which takes the `BuildContext` and [state]
-/// and is responsible for returning a widget which is to be rendered.
+/// Signature for the [builder] function which takes the `BuildContext` and
+/// [state] and is responsible for returning a widget which is to be rendered.
 /// This is analogous to the [builder] function in [StreamBuilder].
 typedef BlocWidgetBuilder<S> = Widget Function(BuildContext context, S state);
 
-/// Signature for the condition function which takes the previous [state] and the current [state]
-/// and is responsible for returning a [bool] which determines whether or not to rebuild
-/// [BlocBuilder] with the current [state].
+/// Signature for the condition function which takes the previous [state] and
+/// the current [state] and is responsible for returning a [bool] which
+/// determines whether or not to rebuild [BlocBuilder] with the current [state].
 typedef BlocBuilderCondition<S> = bool Function(S previous, S current);
 
 /// {@template blocbuilder}
 /// [BlocBuilder] handles building a widget in response to new [states].
-/// [BlocBuilder] is analogous to [StreamBuilder] but has simplified API
-/// to reduce the amount of boilerplate code needed as well as [bloc]-specific performance improvements.
+/// [BlocBuilder] is analogous to [StreamBuilder] but has simplified API to
+/// reduce the amount of boilerplate code needed as well as [bloc]-specific
+/// performance improvements.
 
-/// Please refer to [BlocListener] if you want to "do" anything in response to [state] changes such as
-/// navigation, showing a dialog, etc...
+/// Please refer to [BlocListener] if you want to "do" anything in response to
+/// [state] changes such as navigation, showing a dialog, etc...
 ///
-/// If the [bloc] parameter is omitted, [BlocBuilder] will automatically perform a lookup using
-/// [BlocProvider] and the current `BuildContext`.
+/// If the [bloc] parameter is omitted, [BlocBuilder] will automatically
+/// perform a lookup using [BlocProvider] and the current `BuildContext`.
 ///
 /// ```dart
 /// BlocBuilder<BlocA, BlocAState>(
@@ -46,14 +47,16 @@ typedef BlocBuilderCondition<S> = bool Function(S previous, S current);
 /// )
 /// ```
 ///
-/// An optional [condition] can be implemented for more granular control
-/// over how often [BlocBuilder] rebuilds.
+/// An optional [condition] can be implemented for more granular control over
+/// how often [BlocBuilder] rebuilds.
 /// The [condition] function will be invoked on each [bloc] [state] change.
-/// The [condition] takes the previous [state] and current [state] and must return a [bool]
-/// which determines whether or not the [builder] function will be invoked.
-/// The previous [state] will be initialized to the [state] of the [bloc]
-/// when the [BlocBuilder] is initialized.
-/// [condition] is optional and if it isn't implemented, it will default to `true`.
+/// The [condition] takes the previous [state] and current [state] and must
+/// return a [bool] which determines whether or not the [builder] function will
+/// be invoked.
+/// The previous [state] will be initialized to the [state] of the [bloc] when
+/// the [BlocBuilder] is initialized.
+/// [condition] is optional and if it isn't implemented, it will default to
+/// `true`.
 ///
 /// ```dart
 /// BlocBuilder<BlocA, BlocAState>(
@@ -107,10 +110,13 @@ abstract class BlocBuilderBase<B extends Bloc<dynamic, S>, S>
 
   /// The [BlocBuilderCondition] that the [BlocBuilderBase] will invoke.
   /// The [condition] function will be invoked on each [bloc] [state] change.
-  /// The [condition] takes the previous [state] and current [state] and must return a [bool]
-  /// which determines whether or not the [builder] function will be invoked.
-  /// The previous [state] will be initialized to [state] when the [BlocBuilderBase] is initialized.
-  /// [condition] is optional and if it isn't implemented, it will default to `true`.
+  /// The [condition] takes the previous [state] and current [state] and must
+  /// return a [bool] which determines whether or not the [builder] function
+  /// will be invoked.
+  /// The previous [state] will be initialized to [state] when the
+  /// [BlocBuilderBase] is initialized.
+  /// [condition] is optional and if it isn't implemented, it will default to
+  /// `true`.
   final BlocBuilderCondition<S> condition;
 
   /// Returns a widget based on the `BuildContext` and current [state].

--- a/packages/flutter_bloc/lib/src/bloc_consumer.dart
+++ b/packages/flutter_bloc/lib/src/bloc_consumer.dart
@@ -1,6 +1,7 @@
 import 'package:bloc/bloc.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../flutter_bloc.dart';
 
 /// {@template blocconsumer}
 /// [BlocConsumer] exposes a [builder] and [listener] in order react to new states.

--- a/packages/flutter_bloc/lib/src/bloc_consumer.dart
+++ b/packages/flutter_bloc/lib/src/bloc_consumer.dart
@@ -4,17 +4,18 @@ import 'package:flutter/widgets.dart';
 import '../flutter_bloc.dart';
 
 /// {@template blocconsumer}
-/// [BlocConsumer] exposes a [builder] and [listener] in order react to new states.
+/// [BlocConsumer] exposes a [builder] and [listener] in order react to new
+/// states.
 /// [BlocConsumer] is analogous to a nested [BlocListener] and [BlocBuilder] but
 /// reduces the amount of boilerplate needed.
 /// [BlocConsumer] should only be used when it is necessary to both rebuild UI
 /// and execute other reactions to state changes in the [bloc].
 ///
-/// [BlocConsumer] takes a required [BlocWidgetBuilder] and [BlocWidgetListener] and an optional [bloc],
-/// [BlocBuilderCondition], and [BlocListenerCondition].
+/// [BlocConsumer] takes a required [BlocWidgetBuilder] and [BlocWidgetListener]
+/// and an optional [bloc], [BlocBuilderCondition], and [BlocListenerCondition].
 ///
-/// If the [bloc] parameter is omitted, [BlocConsumer] will automatically perform a lookup using
-/// [BlocProvider] and the current `BuildContext`.
+/// If the [bloc] parameter is omitted, [BlocConsumer] will automatically
+/// perform a lookup using [BlocProvider] and the current `BuildContext`.
 ///
 /// ```dart
 /// BlocConsumer<BlocA, BlocAState>(
@@ -27,14 +28,17 @@ import '../flutter_bloc.dart';
 /// )
 /// ```
 ///
-/// An optional [listenWhen] and [buildWhen] can be implemented for more granular control
-/// over when [listener] and [builder] are called.
-/// The [listenWhen] and [buildWhen] will be invoked on each [bloc] [state] change.
-/// They each take the previous [state] and current [state] and must return a [bool]
-/// which determines whether or not the [builder] and/or [listener] function will be invoked.
-/// The previous [state] will be initialized to the [state] of the [bloc]
-/// when the [BlocConsumer] is initialized.
-/// [listenWhen] and [buildWhen] are optional and if they aren't implemented, they will default to `true`.
+/// An optional [listenWhen] and [buildWhen] can be implemented for more
+/// granular control over when [listener] and [builder] are called.
+/// The [listenWhen] and [buildWhen] will be invoked on each [bloc] [state]
+/// change.
+/// They each take the previous [state] and current [state] and must return
+/// a [bool] which determines whether or not the [builder] and/or [listener]
+/// function will be invoked.
+/// The previous [state] will be initialized to the [state] of the [bloc] when
+/// the [BlocConsumer] is initialized.
+/// [listenWhen] and [buildWhen] are optional and if they aren't implemented,
+/// they will default to `true`.
 ///
 /// ```dart
 /// BlocConsumer<BlocA, BlocAState>(
@@ -71,14 +75,14 @@ class BlocConsumer<B extends Bloc<dynamic, S>, S> extends StatelessWidget {
   /// and is responsible for executing in response to [state] changes.
   final BlocWidgetListener<S> listener;
 
-  /// Takes the previous [state] and the current [state]
-  /// and is responsible for returning a [bool] which determines whether or not to trigger
+  /// Takes the previous [state] and the current [state] and is responsible for
+  /// returning a [bool] which determines whether or not to trigger
   /// [builder] with the current [state].
   final BlocBuilderCondition<S> buildWhen;
 
-  /// Takes the previous [state] and the current [state]
-  /// and is responsible for returning a [bool] which determines whether or not to call [listener]
-  /// of [BlocConsumer] with the current [state].
+  /// Takes the previous [state] and the current [state] and is responsible for
+  /// returning a [bool] which determines whether or not to call [listener] of
+  /// [BlocConsumer] with the current [state].
   final BlocListenerCondition<S> listenWhen;
 
   /// {@macro blocconsumer}

--- a/packages/flutter_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/bloc_listener.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
-import 'package:flutter/widgets.dart';
-
 import 'package:bloc/bloc.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter/widgets.dart';
 import 'package:provider/single_child_widget.dart';
+
+import '../flutter_bloc.dart';
 
 /// Signature for the [listener] function which takes the `BuildContext` along with the [bloc] [state]
 /// and is responsible for executing in response to [state] changes.
@@ -175,7 +175,7 @@ class _BlocListenerBaseState<B extends Bloc<dynamic, S>, S>
 
   void _subscribe() {
     if (_bloc != null) {
-      _subscription = _bloc.skip(1).listen((S state) {
+      _subscription = _bloc.skip(1).listen((state) {
         if (widget.condition?.call(_previousState, state) ?? true) {
           widget.listener(context, state);
         }

--- a/packages/flutter_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/bloc_listener.dart
@@ -6,25 +6,28 @@ import 'package:provider/single_child_widget.dart';
 
 import '../flutter_bloc.dart';
 
-/// Signature for the [listener] function which takes the `BuildContext` along with the [bloc] [state]
-/// and is responsible for executing in response to [state] changes.
+/// Signature for the [listener] function which takes the `BuildContext` along
+/// with the [bloc] [state] and is responsible for executing in response to
+/// [state] changes.
 typedef BlocWidgetListener<S> = void Function(BuildContext context, S state);
 
-/// Signature for the [condition] function which takes the previous [state] and the current [state]
-/// and is responsible for returning a [bool] which determines whether or not to call [BlocWidgetListener]
-/// of [BlocListener] with the current [state].
+/// Signature for the [condition] function which takes the previous [state]
+/// and the current [state] and is responsible for returning a [bool] which
+/// determines whether or not to call [BlocWidgetListener] of [BlocListener]
+/// with the current [state].
 typedef BlocListenerCondition<S> = bool Function(S previous, S current);
 
 /// {@template bloclistener}
-/// Takes a [BlocWidgetListener] and an optional [bloc]
-/// and invokes the [listener] in response to [state] changes in the [bloc].
-/// It should be used for functionality that needs to occur only in response to a [state] change
-/// such as navigation, showing a [SnackBar], showing a [Dialog], etc...
-/// The [listener] is guaranteed to only be called once for each [state] change unlike the
-/// [builder] in [BlocBuilder].
+/// Takes a [BlocWidgetListener] and an optional [bloc] and invokes
+/// the [listener] in response to [state] changes in the [bloc].
+/// It should be used for functionality that needs to occur only in response to
+/// a [state] change such as navigation, showing a [SnackBar], showing
+/// a [Dialog], etc...
+/// The [listener] is guaranteed to only be called once for each [state] change
+/// unlike the [builder] in [BlocBuilder].
 ///
-/// If the [bloc] parameter is omitted, [BlocListener] will automatically perform a lookup using
-/// [BlocProvider] and the current `BuildContext`.
+/// If the [bloc] parameter is omitted, [BlocListener] will automatically
+/// perform a lookup using [BlocProvider] and the current `BuildContext`.
 ///
 /// ```dart
 /// BlocListener<BlocA, BlocAState>(
@@ -50,11 +53,13 @@ typedef BlocListenerCondition<S> = bool Function(S previous, S current);
 /// An optional [condition] can be implemented for more granular control
 /// over when [listener] is called.
 /// The [condition] function will be invoked on each [bloc] [state] change.
-/// The [condition] takes the previous [state] and current [state] and must return a [bool]
-/// which determines whether or not the [listener] function will be invoked.
+/// The [condition] takes the previous [state] and current [state] and must
+/// return a [bool] which determines whether or not the [listener] function
+/// will be invoked.
 /// The previous [state] will be initialized to the [state] of the [bloc]
 /// when the [BlocListener] is initialized.
-/// [condition] is optional and if it isn't implemented, it will default to `true`.
+/// [condition] is optional and if it isn't implemented, it will default to
+/// `true`.
 ///
 /// ```dart
 /// BlocListener<BlocA, BlocAState>(
@@ -100,7 +105,8 @@ class BlocListener<B extends Bloc<dynamic, S>, S>
 /// {@endtemplate}
 abstract class BlocListenerBase<B extends Bloc<dynamic, S>, S>
     extends SingleChildStatefulWidget {
-  /// The widget which will be rendered as a descendant of the [BlocListenerBase].
+  /// The widget which will be rendered as a descendant of the
+  /// [BlocListenerBase].
   final Widget child;
 
   /// The [bloc] whose [state] will be listened to.
@@ -115,10 +121,13 @@ abstract class BlocListenerBase<B extends Bloc<dynamic, S>, S>
 
   /// The [BlocListenerCondition] that the [BlocListenerBase] will invoke.
   /// The [condition] function will be invoked on each [bloc] [state] change.
-  /// The [condition] takes the previous [state] and current [state] and must return a [bool]
-  /// which determines whether or not the [listener] function will be invoked.
-  /// The previous [state] will be initialized to [state] when the [BlocListenerBase] is initialized.
-  /// [condition] is optional and if it isn't implemented, it will default to `true`.
+  /// The [condition] takes the previous [state] and current [state] and must
+  /// return a [bool] which determines whether or not the [listener] function
+  /// will be invoked.
+  /// The previous [state] will be initialized to [state] when
+  /// the [BlocListenerBase] is initialized.
+  /// [condition] is optional and if it isn't implemented, it will default to
+  /// `true`.
   final BlocListenerCondition<S> condition;
 
   /// {@macro bloclistenerbase}

--- a/packages/flutter_bloc/lib/src/bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/bloc_provider.dart
@@ -5,13 +5,14 @@ import 'package:provider/single_child_widget.dart';
 import 'package:bloc/bloc.dart';
 
 /// {@template blocprovider}
-/// Takes a [ValueBuilder] that is responsible for
-/// creating the [bloc] and a [child] which will have access to the [bloc] via `BlocProvider.of(context)`.
-/// It is used as a dependency injection (DI) widget so that a single instance of a [bloc] can be provided
-/// to multiple widgets within a subtree.
+/// Takes a [ValueBuilder] that is responsible for creating the [bloc] and
+/// a [child] which will have access to the [bloc] via
+/// `BlocProvider.of(context)`.
+/// It is used as a dependency injection (DI) widget so that a single instance
+/// of a [bloc] can be provided to multiple widgets within a subtree.
 ///
-/// Automatically handles closing the [bloc] when used with [create]
-/// and lazily creates the provided [bloc] unless [lazy] is set to `false`.
+/// Automatically handles closing the [bloc] when used with [create] and lazily
+/// creates the provided [bloc] unless [lazy] is set to `false`.
 ///
 /// ```dart
 /// BlocProvider(
@@ -47,13 +48,16 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>>
           lazy: lazy,
         );
 
-  /// Takes a [bloc] and a [child] which will have access to the [bloc] via `BlocProvider.of(context)`.
-  /// When `BlocProvider.value` is used, the [bloc] will not be automatically closed.
-  /// As a result, `BlocProvider.value` should mainly be used for providing existing [bloc]s
-  /// to new routes.
+  /// Takes a [bloc] and a [child] which will have access to the [bloc] via
+  /// `BlocProvider.of(context)`.
+  /// When `BlocProvider.value` is used, the [bloc] will not be automatically
+  /// closed.
+  /// As a result, `BlocProvider.value` should mainly be used for providing
+  /// existing [bloc]s to new routes.
   ///
   /// A new [bloc] should not be created in `BlocProvider.value`.
-  /// [bloc]s should always be created using the default constructor within [create].
+  /// [bloc]s should always be created using the default constructor within
+  /// [create].
   ///
   /// ```dart
   /// BlocProvider.value(
@@ -82,11 +86,11 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>>
         _dispose = dispose,
         super(key: key, child: child);
 
-  /// Method that allows widgets to access a [bloc] instance as long as their `BuildContext`
-  /// contains a [BlocProvider] instance.
+  /// Method that allows widgets to access a [bloc] instance as long as their
+  /// `BuildContext` contains a [BlocProvider] instance.
   ///
-  /// If we want to access an instance of `BlocA` which was provided higher up in the widget tree
-  /// we can do so via:
+  /// If we want to access an instance of `BlocA` which was provided higher up
+  /// in the widget tree we can do so via:
   ///
   /// ```dart
   /// BlocProvider.of<BlocA>(context)

--- a/packages/flutter_bloc/lib/src/multi_bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/multi_bloc_listener.dart
@@ -43,19 +43,21 @@ import '../flutter_bloc.dart';
 /// )
 /// ```
 ///
-/// [MultiBlocListener] converts the [BlocListener] list
-/// into a tree of nested [BlocListener] widgets.
+/// [MultiBlocListener] converts the [BlocListener] list into a tree of nested
+/// [BlocListener] widgets.
 /// As a result, the only advantage of using [MultiBlocListener] is improved
 /// readability due to the reduction in nesting and boilerplate.
 /// {@endtemplate}
 class MultiBlocListener extends StatelessWidget {
-  /// The [BlocListener] list which is converted into a tree of [BlocListener] widgets.
-  /// The tree of [BlocListener] widgets is created in order meaning the first [BlocListener]
-  /// will be the top-most [BlocListener] and the last [BlocListener] will be a direct ancestor
-  /// of [child].
+  /// The [BlocListener] list which is converted into a tree of [BlocListener]
+  /// widgets.
+  /// The tree of [BlocListener] widgets is created in order meaning the first
+  /// [BlocListener] will be the top-most [BlocListener] and the last
+  /// [BlocListener] will be a direct ancestor of [child].
   final List<BlocListener> listeners;
 
-  /// The widget which will be a direct descendent of the last [BlocListener] in [listeners].
+  /// The widget which will be a direct descendent of the last [BlocListener]
+  /// in [listeners].
   final Widget child;
 
   /// {@macro multibloclistener}

--- a/packages/flutter_bloc/lib/src/multi_bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/multi_bloc_listener.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:provider/provider.dart';
+
+import '../flutter_bloc.dart';
 
 /// {@template multibloclistener}
 /// Merges multiple [BlocListener] widgets into one widget tree.

--- a/packages/flutter_bloc/lib/src/multi_bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/multi_bloc_provider.dart
@@ -43,20 +43,23 @@ import '../flutter_bloc.dart';
 /// )
 /// ```
 ///
-/// [MultiBlocProvider] converts the [BlocProvider] list
-/// into a tree of nested [BlocProvider] widgets.
+/// [MultiBlocProvider] converts the [BlocProvider] list into a tree of nested
+/// [BlocProvider] widgets.
 /// As a result, the only advantage of using [MultiBlocProvider] is improved
 /// readability due to the reduction in nesting and boilerplate.
 /// {@endtemplate}
 class MultiBlocProvider extends StatelessWidget {
-  /// The [BlocProvider] list which is converted into a tree of [BlocProvider] widgets.
-  /// The tree of [BlocProvider] widgets is created in order meaning the first [BlocProvider]
-  /// will be the top-most [BlocProvider] and the last [BlocProvider] will be a direct ancestor
-  /// of [child].
+  /// The [BlocProvider] list which is converted into a tree of [BlocProvider]
+  /// widgets.
+  /// The tree of [BlocProvider] widgets is created in order meaning the first
+  /// [BlocProvider] will be the top-most [BlocProvider] and the last
+  /// [BlocProvider] will be a direct ancestor of [child].
   final List<BlocProvider> providers;
 
-  /// The widget and its descendants which will have access to every [bloc] provided by [providers].
-  /// [child] will be a direct descendent of the last [BlocProvider] in [providers].
+  /// The widget and its descendants which will have access to every [bloc]
+  /// provided by [providers].
+  /// [child] will be a direct descendent of the last [BlocProvider] in
+  /// [providers].
   final Widget child;
 
   /// {@macro multiblocprovider}

--- a/packages/flutter_bloc/lib/src/multi_bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/multi_bloc_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:provider/provider.dart';
+
+import '../flutter_bloc.dart';
 
 /// {@template multiblocprovider}
 /// Merges multiple [BlocProvider] widgets into one widget tree.

--- a/packages/flutter_bloc/lib/src/multi_repository_provider.dart
+++ b/packages/flutter_bloc/lib/src/multi_repository_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:provider/provider.dart';
+
+import '../flutter_bloc.dart';
 
 /// {@template multirepositoryprovider}
 /// Merges multiple [RepositoryProvider] widgets into one widget tree.

--- a/packages/flutter_bloc/lib/src/multi_repository_provider.dart
+++ b/packages/flutter_bloc/lib/src/multi_repository_provider.dart
@@ -37,20 +37,23 @@ import '../flutter_bloc.dart';
 /// )
 /// ```
 ///
-/// [MultiRepositoryProvider] converts the [RepositoryProvider] list
-/// into a tree of nested [RepositoryProvider] widgets.
-/// As a result, the only advantage of using [MultiRepositoryProvider] is improved
-/// readability due to the reduction in nesting and boilerplate.
+/// [MultiRepositoryProvider] converts the [RepositoryProvider] list into a tree
+/// of nested [RepositoryProvider] widgets.
+/// As a result, the only advantage of using [MultiRepositoryProvider] is
+/// improved readability due to the reduction in nesting and boilerplate.
 /// {@endtemplate}
 class MultiRepositoryProvider extends StatelessWidget {
-  /// The [RepositoryProvider] list which is converted into a tree of [RepositoryProvider] widgets.
-  /// The tree of [RepositoryProvider] widgets is created in order meaning the first [RepositoryProvider]
-  /// will be the top-most [RepositoryProvider] and the last [RepositoryProvider] will be a direct ancestor
-  /// of [child].
+  /// The [RepositoryProvider] list which is converted into a tree of
+  /// [RepositoryProvider] widgets.
+  /// The tree of [RepositoryProvider] widgets is created in order meaning
+  /// the first [RepositoryProvider] will be the top-most [RepositoryProvider]
+  /// and the last [RepositoryProvider] will be a direct ancestor of [child].
   final List<RepositoryProvider> providers;
 
-  /// The widget and its descendants which will have access to every value provided by [providers].
-  /// [child] will be a direct descendent of the last [RepositoryProvider] in [providers].
+  /// The widget and its descendants which will have access to every value
+  /// provided by [providers].
+  /// [child] will be a direct descendent of the last [RepositoryProvider] in
+  /// [providers].
   final Widget child;
 
   /// {@macro multirepositoryprovider}

--- a/packages/flutter_bloc/lib/src/repository_provider.dart
+++ b/packages/flutter_bloc/lib/src/repository_provider.dart
@@ -2,10 +2,11 @@ import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 
 /// {@template repositoryprovider}
-/// Takes a `ValueBuilder` that is responsible for
-/// creating the repository and a [child] which will have access to the repository via `RepositoryProvider.of(context)`.
-/// It is used as a dependency injection (DI) widget so that a single instance of a repository can be provided
-/// to multiple widgets within a subtree.
+/// Takes a `ValueBuilder` that is responsible for creating the repository and
+/// a [child] which will have access to the repository via
+/// `RepositoryProvider.of(context)`.
+/// It is used as a dependency injection (DI) widget so that a single instance
+/// of a repository can be provided to multiple widgets within a subtree.
 ///
 /// Lazily creates the provided repository unless [lazy] is set to `false`.
 ///
@@ -33,7 +34,8 @@ class RepositoryProvider<T> extends Provider<T> {
 
   /// Takes a repository and a [child] which will have access to the repository.
   /// A new repository should not be created in `RepositoryProvider.value`.
-  /// Repositories should always be created using the default constructor within the [builder].
+  /// Repositories should always be created using the default constructor
+  /// within the [builder].
   RepositoryProvider.value({
     Key key,
     @required T value,
@@ -44,8 +46,8 @@ class RepositoryProvider<T> extends Provider<T> {
           child: child,
         );
 
-  /// Method that allows widgets to access a repository instance as long as their `BuildContext`
-  /// contains a [RepositoryProvider] instance.
+  /// Method that allows widgets to access a repository instance as long as
+  /// their `BuildContext` contains a [RepositoryProvider] instance.
   static T of<T>(BuildContext context) {
     try {
       return Provider.of<T>(context, listen: false);

--- a/packages/flutter_bloc/pubspec.yaml
+++ b/packages/flutter_bloc/pubspec.yaml
@@ -17,4 +17,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  effective_dart: ^1.1.1
+  effective_dart: ^1.2.0

--- a/packages/flutter_bloc/test/bloc_builder_test.dart
+++ b/packages/flutter_bloc/test/bloc_builder_test.dart
@@ -38,10 +38,7 @@ class MyThemeAppState extends State<MyThemeApp> {
   Widget build(BuildContext context) {
     return BlocBuilder(
       bloc: _themeBloc,
-      builder: ((
-        context,
-        theme,
-      ) {
+      builder: ((context, theme) {
         _onBuild();
         return MaterialApp(
           key: Key('material_app'),
@@ -294,8 +291,8 @@ void main() {
     });
 
     testWidgets(
-        'updates when the bloc is changed at runtime to a different bloc and unsubscribes from old bloc',
-        (tester) async {
+        'updates when the bloc is changed at runtime to a different bloc and'
+        'unsubscribes from old bloc', (tester) async {
       final _themeBloc = ThemeBloc();
       var numBuilds = 0;
       await tester.pumpWidget(
@@ -335,8 +332,8 @@ void main() {
     });
 
     testWidgets(
-        'does not update when the bloc is changed at runtime to same bloc and stays subscribed to current bloc',
-        (tester) async {
+        'does not update when the bloc is changed at runtime to same bloc '
+        'and stays subscribed to current bloc', (tester) async {
       final _themeBloc = DarkThemeBloc();
       var numBuilds = 0;
       await tester.pumpWidget(

--- a/packages/flutter_bloc/test/bloc_builder_test.dart
+++ b/packages/flutter_bloc/test/bloc_builder_test.dart
@@ -1,9 +1,8 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
-
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 class MyThemeApp extends StatefulWidget {
   final Bloc<ThemeEvent, ThemeData> _themeBloc;
@@ -40,8 +39,8 @@ class MyThemeAppState extends State<MyThemeApp> {
     return BlocBuilder(
       bloc: _themeBloc,
       builder: ((
-        BuildContext context,
-        ThemeData theme,
+        context,
+        theme,
       ) {
         _onBuild();
         return MaterialApp(
@@ -176,7 +175,7 @@ class CounterBloc extends Bloc<CounterEvent, int> {
 void main() {
   group('BlocBuilder', () {
     testWidgets('throws if initialized with null bloc and builder',
-        (WidgetTester tester) async {
+        (tester) async {
       try {
         await tester.pumpWidget(
           BlocBuilder<ThemeBloc, ThemeData>(
@@ -189,8 +188,7 @@ void main() {
       }
     });
 
-    testWidgets('throws if initialized with null builder',
-        (WidgetTester tester) async {
+    testWidgets('throws if initialized with null builder', (tester) async {
       try {
         await tester.pumpWidget(
           BlocBuilder<ThemeBloc, ThemeData>(
@@ -203,7 +201,7 @@ void main() {
       }
     });
 
-    testWidgets('passes initial state to widget', (WidgetTester tester) async {
+    testWidgets('passes initial state to widget', (tester) async {
       final _themeBloc = ThemeBloc();
       var numBuilds = 0;
       await tester.pumpWidget(
@@ -225,7 +223,7 @@ void main() {
     });
 
     testWidgets('receives events and sends state updates to widget',
-        (WidgetTester tester) async {
+        (tester) async {
       final _themeBloc = ThemeBloc();
       var numBuilds = 0;
       await tester.pumpWidget(
@@ -252,7 +250,7 @@ void main() {
     });
 
     testWidgets('infers the bloc from the context if the bloc is not provided',
-        (WidgetTester tester) async {
+        (tester) async {
       final themeBloc = ThemeBloc();
       var numBuilds = 0;
       await tester.pumpWidget(
@@ -260,8 +258,8 @@ void main() {
           value: themeBloc,
           child: BlocBuilder<ThemeBloc, ThemeData>(
             builder: (
-              BuildContext context,
-              ThemeData theme,
+              context,
+              theme,
             ) {
               numBuilds++;
               return MaterialApp(
@@ -297,7 +295,7 @@ void main() {
 
     testWidgets(
         'updates when the bloc is changed at runtime to a different bloc and unsubscribes from old bloc',
-        (WidgetTester tester) async {
+        (tester) async {
       final _themeBloc = ThemeBloc();
       var numBuilds = 0;
       await tester.pumpWidget(
@@ -338,7 +336,7 @@ void main() {
 
     testWidgets(
         'does not update when the bloc is changed at runtime to same bloc and stays subscribed to current bloc',
-        (WidgetTester tester) async {
+        (tester) async {
       final _themeBloc = DarkThemeBloc();
       var numBuilds = 0;
       await tester.pumpWidget(
@@ -377,8 +375,7 @@ void main() {
       expect(numBuilds, 3);
     });
 
-    testWidgets('shows latest state instead of initial state',
-        (WidgetTester tester) async {
+    testWidgets('shows latest state instead of initial state', (tester) async {
       final _themeBloc = ThemeBloc();
       _themeBloc.add(SetDarkTheme());
       await tester.pumpAndSettle();
@@ -406,7 +403,7 @@ void main() {
     });
 
     testWidgets('with condition only rebuilds when condition evaluates to true',
-        (WidgetTester tester) async {
+        (tester) async {
       await tester.pumpWidget(MyCounterApp());
       await tester.pumpAndSettle();
 

--- a/packages/flutter_bloc/test/bloc_consumer_test.dart
+++ b/packages/flutter_bloc/test/bloc_consumer_test.dart
@@ -24,8 +24,7 @@ class CounterBloc extends Bloc<CounterEvent, int> {
 
 void main() {
   group('BlocConsumer', () {
-    testWidgets('throws AssertionError if builder is null',
-        (WidgetTester tester) async {
+    testWidgets('throws AssertionError if builder is null', (tester) async {
       try {
         await tester.pumpWidget(
           BlocConsumer(
@@ -38,8 +37,7 @@ void main() {
       }
     });
 
-    testWidgets('throws AssertionError if listener is null',
-        (WidgetTester tester) async {
+    testWidgets('throws AssertionError if listener is null', (tester) async {
       try {
         await tester.pumpWidget(
           BlocConsumer(
@@ -54,7 +52,7 @@ void main() {
 
     testWidgets(
         'accesses the bloc directly and passes initial state to builder and nothing to listener',
-        (WidgetTester tester) async {
+        (tester) async {
       final counterBloc = CounterBloc();
       final listenerStates = <int>[];
       await tester.pumpWidget(
@@ -78,7 +76,7 @@ void main() {
 
     testWidgets(
         'accesses the bloc directly and passes multiple states to builder and listener',
-        (WidgetTester tester) async {
+        (tester) async {
       final counterBloc = CounterBloc();
       final listenerStates = <int>[];
       await tester.pumpWidget(
@@ -106,7 +104,7 @@ void main() {
 
     testWidgets(
         'accesses the bloc via context and passes initial state to builder',
-        (WidgetTester tester) async {
+        (tester) async {
       final counterBloc = CounterBloc();
       final listenerStates = <int>[];
       await tester.pumpWidget(
@@ -133,7 +131,7 @@ void main() {
 
     testWidgets(
         'accesses the bloc via context and passes multiple states to builder',
-        (WidgetTester tester) async {
+        (tester) async {
       final counterBloc = CounterBloc();
       final listenerStates = <int>[];
       await tester.pumpWidget(
@@ -160,7 +158,7 @@ void main() {
     });
 
     testWidgets('does not trigger rebuilds when buildWhen evaluates to false',
-        (WidgetTester tester) async {
+        (tester) async {
       final counterBloc = CounterBloc();
       final listenerStates = <int>[];
       final builderStates = <int>[];
@@ -201,7 +199,7 @@ void main() {
     });
 
     testWidgets('does not trigger listen when listenWhen evaluates to false',
-        (WidgetTester tester) async {
+        (tester) async {
       final counterBloc = CounterBloc();
       final listenerStates = <int>[];
       final builderStates = <int>[];

--- a/packages/flutter_bloc/test/bloc_consumer_test.dart
+++ b/packages/flutter_bloc/test/bloc_consumer_test.dart
@@ -51,8 +51,8 @@ void main() {
     });
 
     testWidgets(
-        'accesses the bloc directly and passes initial state to builder and nothing to listener',
-        (tester) async {
+        'accesses the bloc directly and passes initial state to builder and '
+        'nothing to listener', (tester) async {
       final counterBloc = CounterBloc();
       final listenerStates = <int>[];
       await tester.pumpWidget(
@@ -75,8 +75,8 @@ void main() {
     });
 
     testWidgets(
-        'accesses the bloc directly and passes multiple states to builder and listener',
-        (tester) async {
+        'accesses the bloc directly '
+        'and passes multiple states to builder and listener', (tester) async {
       final counterBloc = CounterBloc();
       final listenerStates = <int>[];
       await tester.pumpWidget(

--- a/packages/flutter_bloc/test/bloc_listener_test.dart
+++ b/packages/flutter_bloc/test/bloc_listener_test.dart
@@ -177,8 +177,8 @@ void main() {
     });
 
     testWidgets(
-        'updates when the bloc is changed at runtime to a different bloc and unsubscribes from old bloc',
-        (tester) async {
+        'updates when the bloc is changed at runtime to a different bloc '
+        'and unsubscribes from old bloc', (tester) async {
       var listenerCallCount = 0;
       int latestState;
       final incrementFinder = find.byKey(Key('bloc_listener_increment_button'));
@@ -209,8 +209,8 @@ void main() {
     });
 
     testWidgets(
-        'does not update when the bloc is changed at runtime to same bloc and stays subscribed to current bloc',
-        (tester) async {
+        'does not update when the bloc is changed at runtime to same bloc '
+        'and stays subscribed to current bloc', (tester) async {
       var listenerCallCount = 0;
       int latestState;
       final incrementFinder = find.byKey(Key('bloc_listener_increment_button'));
@@ -241,8 +241,8 @@ void main() {
     });
 
     testWidgets(
-        'calls condition on single state change with correct previous and current states',
-        (tester) async {
+        'calls condition on single state change with correct previous '
+        'and current states', (tester) async {
       int latestPreviousState;
       int latestState;
       var conditionCallCount = 0;
@@ -335,8 +335,8 @@ void main() {
     });
 
     testWidgets(
-        'calls condition on multiple state change with correct previous and current states',
-        (tester) async {
+        'calls condition on multiple state change with correct previous '
+        'and current states', (tester) async {
       int latestPreviousState;
       int latestState;
       var conditionCallCount = 0;
@@ -367,8 +367,8 @@ void main() {
     });
 
     testWidgets(
-        'does not call listener when condition returns false on single state change',
-        (tester) async {
+        'does not call listener when condition returns false on single state '
+        'change', (tester) async {
       var listenerCallCount = 0;
       final counterBloc = CounterBloc();
       final expectedStates = [0, 1];
@@ -411,8 +411,8 @@ void main() {
     });
 
     testWidgets(
-        'does not call listener when condition returns false on multiple state changes',
-        (tester) async {
+        'does not call listener when condition returns false on multiple state '
+        'changes', (tester) async {
       var listenerCallCount = 0;
       final counterBloc = CounterBloc();
       final expectedStates = [0, 1, 2, 3, 4];

--- a/packages/flutter_bloc/test/bloc_listener_test.dart
+++ b/packages/flutter_bloc/test/bloc_listener_test.dart
@@ -1,9 +1,8 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
-
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 enum CounterEvent { increment }
 
@@ -45,7 +44,7 @@ class _MyAppState extends State<MyApp> {
       home: Scaffold(
         body: BlocListener(
           bloc: _counterBloc,
-          listener: (BuildContext context, int state) {
+          listener: (context, state) {
             widget.onListenerCalled?.call(context, state);
           },
           child: Column(
@@ -87,7 +86,7 @@ class _MyAppState extends State<MyApp> {
 void main() {
   group('BlocListener', () {
     testWidgets('throws if initialized with null bloc, listener, and child',
-        (WidgetTester tester) async {
+        (tester) async {
       try {
         await tester.pumpWidget(
           BlocListener<Bloc, dynamic>(
@@ -103,7 +102,7 @@ void main() {
     });
 
     testWidgets('throws if initialized with null listener and child',
-        (WidgetTester tester) async {
+        (tester) async {
       try {
         await tester.pumpWidget(
           BlocListener<CounterBloc, int>(
@@ -118,12 +117,12 @@ void main() {
       }
     });
 
-    testWidgets('renders child properly', (WidgetTester tester) async {
+    testWidgets('renders child properly', (tester) async {
       final targetKey = Key('bloc_listener_container');
       await tester.pumpWidget(
         BlocListener(
           bloc: CounterBloc(),
-          listener: (BuildContext context, int state) {},
+          listener: (context, state) {},
           child: Container(
             key: targetKey,
           ),
@@ -132,8 +131,7 @@ void main() {
       expect(find.byKey(targetKey), findsOneWidget);
     });
 
-    testWidgets('calls listener on single state change',
-        (WidgetTester tester) async {
+    testWidgets('calls listener on single state change', (tester) async {
       int latestState;
       var listenerCallCount = 0;
       final counterBloc = CounterBloc();
@@ -141,7 +139,7 @@ void main() {
       await tester.pumpWidget(
         BlocListener(
           bloc: counterBloc,
-          listener: (BuildContext context, int state) {
+          listener: (context, state) {
             listenerCallCount++;
             latestState = state;
           },
@@ -155,8 +153,7 @@ void main() {
       });
     });
 
-    testWidgets('calls listener on multiple state change',
-        (WidgetTester tester) async {
+    testWidgets('calls listener on multiple state change', (tester) async {
       int latestState;
       var listenerCallCount = 0;
       final counterBloc = CounterBloc();
@@ -164,7 +161,7 @@ void main() {
       await tester.pumpWidget(
         BlocListener(
           bloc: counterBloc,
-          listener: (BuildContext context, int state) {
+          listener: (context, state) {
             listenerCallCount++;
             latestState = state;
           },
@@ -181,13 +178,13 @@ void main() {
 
     testWidgets(
         'updates when the bloc is changed at runtime to a different bloc and unsubscribes from old bloc',
-        (WidgetTester tester) async {
+        (tester) async {
       var listenerCallCount = 0;
       int latestState;
       final incrementFinder = find.byKey(Key('bloc_listener_increment_button'));
       final resetBlocFinder = find.byKey(Key('bloc_listener_reset_button'));
       await tester.pumpWidget(MyApp(
-        onListenerCalled: (BuildContext context, int state) {
+        onListenerCalled: (context, state) {
           listenerCallCount++;
           latestState = state;
         },
@@ -213,13 +210,13 @@ void main() {
 
     testWidgets(
         'does not update when the bloc is changed at runtime to same bloc and stays subscribed to current bloc',
-        (WidgetTester tester) async {
+        (tester) async {
       var listenerCallCount = 0;
       int latestState;
       final incrementFinder = find.byKey(Key('bloc_listener_increment_button'));
       final noopBlocFinder = find.byKey(Key('bloc_listener_noop_button'));
       await tester.pumpWidget(MyApp(
-        onListenerCalled: (BuildContext context, int state) {
+        onListenerCalled: (context, state) {
           listenerCallCount++;
           latestState = state;
         },
@@ -245,7 +242,7 @@ void main() {
 
     testWidgets(
         'calls condition on single state change with correct previous and current states',
-        (WidgetTester tester) async {
+        (tester) async {
       int latestPreviousState;
       int latestState;
       var conditionCallCount = 0;
@@ -254,13 +251,13 @@ void main() {
       await tester.pumpWidget(
         BlocListener(
           bloc: counterBloc,
-          condition: (int previous, int state) {
+          condition: (previous, state) {
             conditionCallCount++;
             latestPreviousState = previous;
             latestState = state;
             return true;
           },
-          listener: (BuildContext context, int state) {},
+          listener: (context, state) {},
           child: Container(),
         ),
       );
@@ -274,7 +271,7 @@ void main() {
 
     testWidgets(
         'calls condition with previous listener state and current bloc state',
-        (WidgetTester tester) async {
+        (tester) async {
       int latestPreviousState;
       int latestState;
       var conditionCallCount = 0;
@@ -283,7 +280,7 @@ void main() {
       await tester.pumpWidget(
         BlocListener(
           bloc: counterBloc,
-          condition: (int previous, int state) {
+          condition: (previous, state) {
             conditionCallCount++;
             if ((previous + state) % 3 == 0) {
               latestPreviousState = previous;
@@ -292,7 +289,7 @@ void main() {
             }
             return false;
           },
-          listener: (BuildContext context, int state) {},
+          listener: (context, state) {},
           child: Container(),
         ),
       );
@@ -307,7 +304,7 @@ void main() {
     });
 
     testWidgets('infers the bloc from the context if the bloc is not provided',
-        (WidgetTester tester) async {
+        (tester) async {
       int latestPreviousState;
       int latestState;
       var conditionCallCount = 0;
@@ -317,14 +314,14 @@ void main() {
         BlocProvider.value(
           value: counterBloc,
           child: BlocListener<CounterBloc, int>(
-            condition: (int previous, int state) {
+            condition: (previous, state) {
               conditionCallCount++;
               latestPreviousState = previous;
               latestState = state;
 
               return true;
             },
-            listener: (BuildContext context, int state) {},
+            listener: (context, state) {},
             child: Container(),
           ),
         ),
@@ -339,7 +336,7 @@ void main() {
 
     testWidgets(
         'calls condition on multiple state change with correct previous and current states',
-        (WidgetTester tester) async {
+        (tester) async {
       int latestPreviousState;
       int latestState;
       var conditionCallCount = 0;
@@ -348,14 +345,14 @@ void main() {
       await tester.pumpWidget(
         BlocListener(
           bloc: counterBloc,
-          condition: (int previous, int state) {
+          condition: (previous, state) {
             conditionCallCount++;
             latestPreviousState = previous;
             latestState = state;
 
             return true;
           },
-          listener: (BuildContext context, int state) {},
+          listener: (context, state) {},
           child: Container(),
         ),
       );
@@ -371,15 +368,15 @@ void main() {
 
     testWidgets(
         'does not call listener when condition returns false on single state change',
-        (WidgetTester tester) async {
+        (tester) async {
       var listenerCallCount = 0;
       final counterBloc = CounterBloc();
       final expectedStates = [0, 1];
       await tester.pumpWidget(
         BlocListener(
           bloc: counterBloc,
-          condition: (int previous, int state) => false,
-          listener: (BuildContext context, int state) {
+          condition: (previous, state) => false,
+          listener: (context, state) {
             listenerCallCount++;
           },
           child: Container(),
@@ -393,15 +390,15 @@ void main() {
 
     testWidgets(
         'calls listener when condition returns true on single state change',
-        (WidgetTester tester) async {
+        (tester) async {
       var listenerCallCount = 0;
       final counterBloc = CounterBloc();
       final expectedStates = [0, 1];
       await tester.pumpWidget(
         BlocListener(
           bloc: counterBloc,
-          condition: (int previous, int state) => true,
-          listener: (BuildContext context, int state) {
+          condition: (previous, state) => true,
+          listener: (context, state) {
             listenerCallCount++;
           },
           child: Container(),
@@ -415,15 +412,15 @@ void main() {
 
     testWidgets(
         'does not call listener when condition returns false on multiple state changes',
-        (WidgetTester tester) async {
+        (tester) async {
       var listenerCallCount = 0;
       final counterBloc = CounterBloc();
       final expectedStates = [0, 1, 2, 3, 4];
       await tester.pumpWidget(
         BlocListener(
           bloc: counterBloc,
-          condition: (int previous, int state) => false,
-          listener: (BuildContext context, int state) {
+          condition: (previous, state) => false,
+          listener: (context, state) {
             listenerCallCount++;
           },
           child: Container(),
@@ -440,15 +437,15 @@ void main() {
 
     testWidgets(
         'calls listener when condition returns true on multiple state change',
-        (WidgetTester tester) async {
+        (tester) async {
       var listenerCallCount = 0;
       final counterBloc = CounterBloc();
       final expectedStates = [0, 1, 2, 3, 4];
       await tester.pumpWidget(
         BlocListener(
           bloc: counterBloc,
-          condition: (int previous, int state) => true,
-          listener: (BuildContext context, int state) {
+          condition: (previous, state) => true,
+          listener: (context, state) {
             listenerCallCount++;
           },
           child: Container(),

--- a/packages/flutter_bloc/test/bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/bloc_provider_test.dart
@@ -125,7 +125,7 @@ class CounterPage extends StatelessWidget {
       appBar: AppBar(title: Text('Counter')),
       body: BlocBuilder<CounterBloc, int>(
         bloc: counterBloc,
-        builder: (BuildContext context, int count) {
+        builder: (context, count) {
           if (onBuild != null) {
             onBuild();
           }
@@ -211,7 +211,7 @@ class CounterBloc extends Bloc<CounterEvent, int> {
 void main() {
   group('BlocProvider', () {
     testWidgets('throws if initialized with no create',
-        (WidgetTester tester) async {
+        (tester) async {
       await tester.pumpWidget(MyApp(
         create: null,
         child: CounterPage(),
@@ -220,7 +220,7 @@ void main() {
     });
 
     testWidgets('throws if initialized with no child',
-        (WidgetTester tester) async {
+        (tester) async {
       await tester.pumpWidget(MyApp(
         create: (context) => CounterBloc(),
         child: null,
@@ -228,7 +228,7 @@ void main() {
       expect(tester.takeException(), isInstanceOf<AssertionError>());
     });
 
-    testWidgets('lazily loads blocs by default', (WidgetTester tester) async {
+    testWidgets('lazily loads blocs by default', (tester) async {
       var createCalled = false;
       await tester.pumpWidget(
         BlocProvider(
@@ -242,7 +242,7 @@ void main() {
       expect(createCalled, isFalse);
     });
 
-    testWidgets('can override lazy loading', (WidgetTester tester) async {
+    testWidgets('can override lazy loading', (tester) async {
       var createCalled = false;
       await tester.pumpWidget(
         BlocProvider(
@@ -257,7 +257,7 @@ void main() {
       expect(createCalled, isTrue);
     });
 
-    testWidgets('passes bloc to children', (WidgetTester tester) async {
+    testWidgets('passes bloc to children', (tester) async {
       CounterBloc _create(BuildContext context) => CounterBloc();
       final _child = CounterPage();
       await tester.pumpWidget(MyApp(
@@ -274,7 +274,7 @@ void main() {
 
     testWidgets(
       'passes bloc to children within same build',
-      (WidgetTester tester) async {
+      (tester) async {
         await tester.pumpWidget(
           MaterialApp(
             home: Scaffold(
@@ -293,7 +293,7 @@ void main() {
 
     testWidgets(
       'can access bloc directly within builder',
-      (WidgetTester tester) async {
+      (tester) async {
         await tester.pumpWidget(
           MaterialApp(
             home: Scaffold(
@@ -326,7 +326,7 @@ void main() {
     );
 
     testWidgets('does not call close on bloc if it was not loaded (lazily)',
-        (WidgetTester tester) async {
+        (tester) async {
       var closeCalled = false;
       CounterBloc _create(BuildContext context) => CounterBloc(
             onClose: () {
@@ -350,7 +350,7 @@ void main() {
     });
 
     testWidgets('calls close on bloc automatically when invoked (lazily)',
-        (WidgetTester tester) async {
+        (tester) async {
       var closeCalled = false;
       CounterBloc _create(BuildContext context) => CounterBloc(
             onClose: () {
@@ -376,7 +376,7 @@ void main() {
     });
 
     testWidgets('does not close when created using value',
-        (WidgetTester tester) async {
+        (tester) async {
       var closeCalled = false;
       final _value = CounterBloc(
         onClose: () {
@@ -401,7 +401,7 @@ void main() {
 
     testWidgets(
         'should throw FlutterError if BlocProvider is not found in current context',
-        (WidgetTester tester) async {
+        (tester) async {
       final Widget _child = CounterPage();
       await tester.pumpWidget(MyAppNoProvider(
         child: _child,
@@ -426,7 +426,7 @@ void main() {
 
     testWidgets(
         'should not rebuild widgets that inherited the bloc if the bloc is changed',
-        (WidgetTester tester) async {
+        (tester) async {
       var numBuilds = 0;
       final Widget _child = CounterPage(
         onBuild: () {

--- a/packages/flutter_bloc/test/bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/bloc_provider_test.dart
@@ -210,8 +210,7 @@ class CounterBloc extends Bloc<CounterEvent, int> {
 
 void main() {
   group('BlocProvider', () {
-    testWidgets('throws if initialized with no create',
-        (tester) async {
+    testWidgets('throws if initialized with no create', (tester) async {
       await tester.pumpWidget(MyApp(
         create: null,
         child: CounterPage(),
@@ -219,8 +218,7 @@ void main() {
       expect(tester.takeException(), isInstanceOf<AssertionError>());
     });
 
-    testWidgets('throws if initialized with no child',
-        (tester) async {
+    testWidgets('throws if initialized with no child', (tester) async {
       await tester.pumpWidget(MyApp(
         create: (context) => CounterBloc(),
         child: null,
@@ -375,8 +373,7 @@ void main() {
       expect(closeCalled, true);
     });
 
-    testWidgets('does not close when created using value',
-        (tester) async {
+    testWidgets('does not close when created using value', (tester) async {
       var closeCalled = false;
       final _value = CounterBloc(
         onClose: () {

--- a/packages/flutter_bloc/test/bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/bloc_provider_test.dart
@@ -189,19 +189,6 @@ class CounterBloc extends Bloc<CounterEvent, int> {
   }
 
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is CounterBloc &&
-          runtimeType == other.runtimeType &&
-          initialState == other.initialState;
-
-  @override
-  int get hashCode =>
-      initialState.hashCode ^
-      mapEventToState.hashCode ^
-      transformEvents.hashCode;
-
-  @override
   Future<void> close() {
     onClose?.call();
     return super.close();

--- a/packages/flutter_bloc/test/bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/bloc_provider_test.dart
@@ -397,8 +397,8 @@ void main() {
     });
 
     testWidgets(
-        'should throw FlutterError if BlocProvider is not found in current context',
-        (tester) async {
+        'should throw FlutterError if BlocProvider is not found in current '
+        'context', (tester) async {
       final Widget _child = CounterPage();
       await tester.pumpWidget(MyAppNoProvider(
         child: _child,
@@ -422,8 +422,8 @@ void main() {
     });
 
     testWidgets(
-        'should not rebuild widgets that inherited the bloc if the bloc is changed',
-        (tester) async {
+        'should not rebuild widgets that inherited the bloc if the bloc is '
+        'changed', (tester) async {
       var numBuilds = 0;
       final Widget _child = CounterPage(
         onBuild: () {

--- a/packages/flutter_bloc/test/multi_bloc_listener_test.dart
+++ b/packages/flutter_bloc/test/multi_bloc_listener_test.dart
@@ -23,7 +23,7 @@ class CounterBloc extends Bloc<CounterEvent, int> {
 void main() {
   group('MultiBlocListener', () {
     testWidgets('throws if initialized with no listeners and no child',
-        (WidgetTester tester) async {
+        (tester) async {
       try {
         await tester.pumpWidget(
           MultiBlocListener(
@@ -36,8 +36,7 @@ void main() {
       }
     });
 
-    testWidgets('throws if initialized with no listeners',
-        (WidgetTester tester) async {
+    testWidgets('throws if initialized with no listeners', (tester) async {
       try {
         await tester.pumpWidget(
           MultiBlocListener(
@@ -50,8 +49,7 @@ void main() {
       }
     });
 
-    testWidgets('throws if initialized with no child',
-        (WidgetTester tester) async {
+    testWidgets('throws if initialized with no child', (tester) async {
       try {
         await tester.pumpWidget(
           MultiBlocListener(
@@ -64,8 +62,7 @@ void main() {
       }
     });
 
-    testWidgets('calls listeners on state changes',
-        (WidgetTester tester) async {
+    testWidgets('calls listeners on state changes', (tester) async {
       int latestStateA;
       var listenerCallCountA = 0;
       final counterBlocA = CounterBloc();
@@ -81,14 +78,14 @@ void main() {
           listeners: [
             BlocListener<CounterBloc, int>(
               bloc: counterBlocA,
-              listener: (BuildContext context, int state) {
+              listener: (context, state) {
                 listenerCallCountA++;
                 latestStateA = state;
               },
             ),
             BlocListener<CounterBloc, int>(
               bloc: counterBlocB,
-              listener: (BuildContext context, int state) {
+              listener: (context, state) {
                 listenerCallCountB++;
                 latestStateB = state;
               },

--- a/packages/flutter_bloc/test/multi_bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/multi_bloc_provider_test.dart
@@ -1,9 +1,8 @@
 import 'dart:async';
 
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
-
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 class MyAppWithNavigation extends StatelessWidget {
   final Widget child;
@@ -106,7 +105,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder(
       bloc: BlocProvider.of<ThemeBloc>(context),
-      builder: (_, ThemeData theme) {
+      builder: (_, theme) {
         return MaterialApp(
           title: 'Flutter Demo',
           home: CounterPage(),
@@ -126,7 +125,7 @@ class CounterPage extends StatelessWidget {
       appBar: AppBar(title: Text('Counter')),
       body: BlocBuilder<CounterBloc, int>(
         bloc: counterBloc,
-        builder: (BuildContext context, int count) {
+        builder: (context, count) {
           return Center(
             child: Text(
               '$count',
@@ -213,8 +212,7 @@ class ThemeBloc extends Bloc<ThemeEvent, ThemeData> {
 
 void main() {
   group('MultiBlocProvider', () {
-    testWidgets('throws if initialized with no providers',
-        (WidgetTester tester) async {
+    testWidgets('throws if initialized with no providers', (tester) async {
       try {
         await tester.pumpWidget(
           MultiBlocProvider(
@@ -227,8 +225,7 @@ void main() {
       }
     });
 
-    testWidgets('throws if initialized with no child',
-        (WidgetTester tester) async {
+    testWidgets('throws if initialized with no child', (tester) async {
       try {
         await tester.pumpWidget(
           MultiBlocProvider(
@@ -241,7 +238,7 @@ void main() {
       }
     });
 
-    testWidgets('passes blocs to children', (WidgetTester tester) async {
+    testWidgets('passes blocs to children', (tester) async {
       await tester.pumpWidget(
         MultiBlocProvider(
           providers: [
@@ -263,7 +260,7 @@ void main() {
       expect(counterText.data, '0');
     });
 
-    testWidgets('adds event to each bloc', (WidgetTester tester) async {
+    testWidgets('adds event to each bloc', (tester) async {
       await tester.pumpWidget(
         MultiBlocProvider(
           providers: [
@@ -292,7 +289,7 @@ void main() {
     });
 
     testWidgets('close on counter bloc which was loaded (lazily)',
-        (WidgetTester tester) async {
+        (tester) async {
       var counterBlocClosed = false;
       var themeBlocClosed = false;
 
@@ -322,7 +319,7 @@ void main() {
     });
 
     testWidgets('close on theme bloc which was loaded (lazily)',
-        (WidgetTester tester) async {
+        (tester) async {
       var counterBlocClosed = false;
       var themeBlocClosed = false;
 
@@ -352,7 +349,7 @@ void main() {
     });
 
     testWidgets('close on all blocs which were loaded (lazily)',
-        (WidgetTester tester) async {
+        (tester) async {
       var counterBlocClosed = false;
       var themeBlocClosed = false;
 
@@ -383,7 +380,7 @@ void main() {
     });
 
     testWidgets('does not call close on blocs if they were not loaded (lazily)',
-        (WidgetTester tester) async {
+        (tester) async {
       var counterBlocClosed = false;
       var themeBlocClosed = false;
 
@@ -410,8 +407,7 @@ void main() {
       expect(themeBlocClosed, false);
     });
 
-    testWidgets('does not close when created using value',
-        (WidgetTester tester) async {
+    testWidgets('does not close when created using value', (tester) async {
       var counterBlocClosed = false;
       var themeBlocClosed = false;
 

--- a/packages/flutter_bloc/test/multi_repository_provider_test.dart
+++ b/packages/flutter_bloc/test/multi_repository_provider_test.dart
@@ -1,7 +1,6 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
-
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 class MyApp extends StatelessWidget {
   @override
@@ -55,7 +54,7 @@ void main() {
   group('MultiRepositoryProvider', () {
     testWidgets(
         'throws if initialized with no RepositoryProviders and no child',
-        (WidgetTester tester) async {
+        (tester) async {
       try {
         await tester.pumpWidget(
           MultiRepositoryProvider(
@@ -69,7 +68,7 @@ void main() {
     });
 
     testWidgets('throws if initialized with no RepositoryProviders',
-        (WidgetTester tester) async {
+        (tester) async {
       try {
         await tester.pumpWidget(
           MultiRepositoryProvider(
@@ -82,8 +81,7 @@ void main() {
       }
     });
 
-    testWidgets('throws if initialized with no child',
-        (WidgetTester tester) async {
+    testWidgets('throws if initialized with no child', (tester) async {
       try {
         await tester.pumpWidget(
           MultiRepositoryProvider(
@@ -96,7 +94,7 @@ void main() {
       }
     });
 
-    testWidgets('passes values to children', (WidgetTester tester) async {
+    testWidgets('passes values to children', (tester) async {
       await tester.pumpWidget(
         MultiRepositoryProvider(
           providers: [

--- a/packages/flutter_bloc/test/repository_provider_test.dart
+++ b/packages/flutter_bloc/test/repository_provider_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
-
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 class MyApp extends StatelessWidget {
   final Repository _repository;
@@ -150,8 +149,7 @@ class Repository {
 
 void main() {
   group('RepositoryProvider', () {
-    testWidgets('throws if initialized with no repository',
-        (WidgetTester tester) async {
+    testWidgets('throws if initialized with no repository', (tester) async {
       await tester.pumpWidget(MyApp(
         repository: null,
         child: CounterPage(),
@@ -159,8 +157,7 @@ void main() {
       expect(tester.takeException(), isInstanceOf<AssertionError>());
     });
 
-    testWidgets('throws if initialized with no child',
-        (WidgetTester tester) async {
+    testWidgets('throws if initialized with no child', (tester) async {
       await tester.pumpWidget(MyApp(
         repository: Repository(0),
         child: null,
@@ -168,8 +165,7 @@ void main() {
       expect(tester.takeException(), isInstanceOf<AssertionError>());
     });
 
-    testWidgets('lazily loads repositories by default',
-        (WidgetTester tester) async {
+    testWidgets('lazily loads repositories by default', (tester) async {
       var createCalled = false;
       await tester.pumpWidget(
         RepositoryProvider(
@@ -183,7 +179,7 @@ void main() {
       expect(createCalled, isFalse);
     });
 
-    testWidgets('can override lazy loading', (WidgetTester tester) async {
+    testWidgets('can override lazy loading', (tester) async {
       var createCalled = false;
       await tester.pumpWidget(
         RepositoryProvider(
@@ -198,8 +194,7 @@ void main() {
       expect(createCalled, isTrue);
     });
 
-    testWidgets('passes value to children via builder',
-        (WidgetTester tester) async {
+    testWidgets('passes value to children via builder', (tester) async {
       final repository = Repository(0);
       final _child = CounterPage();
       await tester.pumpWidget(MyApp(
@@ -214,8 +209,7 @@ void main() {
       expect(_counterText.data, '0');
     });
 
-    testWidgets('passes value to children via value',
-        (WidgetTester tester) async {
+    testWidgets('passes value to children via value', (tester) async {
       final repository = Repository(0);
       final _child = CounterPage();
       await tester.pumpWidget(MyApp(
@@ -233,7 +227,7 @@ void main() {
 
     testWidgets(
         'should throw FlutterError if RepositoryProvider is not found in current context',
-        (WidgetTester tester) async {
+        (tester) async {
       final Widget _child = CounterPage();
       await tester.pumpWidget(MyAppNoProvider(
         child: _child,
@@ -258,7 +252,7 @@ void main() {
 
     testWidgets(
         'should not rebuild widgets that inherited the value if the value is changed',
-        (WidgetTester tester) async {
+        (tester) async {
       var numBuilds = 0;
       final Widget _child = CounterPage(
         onBuild: () {

--- a/packages/flutter_bloc/test/repository_provider_test.dart
+++ b/packages/flutter_bloc/test/repository_provider_test.dart
@@ -226,8 +226,8 @@ void main() {
     });
 
     testWidgets(
-        'should throw FlutterError if RepositoryProvider is not found in current context',
-        (tester) async {
+        'should throw FlutterError if RepositoryProvider is not found in '
+        'current context', (tester) async {
       final Widget _child = CounterPage();
       await tester.pumpWidget(MyAppNoProvider(
         child: _child,
@@ -251,8 +251,8 @@ void main() {
     });
 
     testWidgets(
-        'should not rebuild widgets that inherited the value if the value is changed',
-        (tester) async {
+        'should not rebuild widgets that inherited the value if the value is '
+        'changed', (tester) async {
       var numBuilds = 0;
       final Widget _child = CounterPage(
         onBuild: () {

--- a/performance_tests/flutter_bloc/bloc_builder/test_driver/main.dart
+++ b/performance_tests/flutter_bloc/bloc_builder/test_driver/main.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: close_sinks
+
 import 'package:flutter/material.dart';
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';

--- a/performance_tests/flutter_bloc/bloc_provider/test_driver/main.dart
+++ b/performance_tests/flutter_bloc/bloc_provider/test_driver/main.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: close_sinks
+
 import 'package:flutter/material.dart';
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';


### PR DESCRIPTION
## Status
**DONE**

## Breaking Changes
NO

## Description

Hi, as we discussed in the chat, I have upgraded `package:effective_dart` to `1.2.0` in `packages/`. It turns out that the major updates needed are relative imports within your package, https://dart-lang.github.io/linter/lints/avoid_types_on_closure_parameters.html and 80 chars in line (but that mostly for comments).  

Also, see https://github.com/tenhobi/effective_dart/blob/master/CHANGELOG.md

I did updated everything except comments. Can you tell me how (in what way/style) should I update them? E.g. where to choose the breaks. :slight_smile: And also https://dart-lang.github.io/linter/lints/avoid_equals_and_hash_code_on_mutable_classes.html, because that requires maybe some more look. (it's avoid btw, so you can opt out it).

For example, should

```
/// Called whenever an [event] is `added` to any [bloc] with the given [bloc] and [event].
/// A great spot to add universal logging/analytics.
```

become

```
/// Called whenever an [event] is `added` to any [bloc]
/// with the given [bloc] and [event].
/// A great spot to add universal logging/analytics.
```

or

```
/// Called whenever an [event] is `added` to any [bloc]
/// with the given [bloc] and [event]. A great spot to
/// add universal logging/analytics.
```

---

Also, I probably need to play a bit also with analyzer, so it is cleer what is prefer/avoid (hint) and do/don't (warning). But for that I will need more help/know-how. Will take a look in weekend. :slight_smile:  


## Todos

- [x] info: AVOID lines longer than 80 characters. (lines_longer_than_80_chars)
- [x] info: AVOID overloading operator == and hashCode on classes not marked `@immutable`. (avoid_equals_and_hash_code_on_mutable_classes)