### PR TITLE
Fix MultiBlocProvider and MultiRepositoryProvider type inference

### DIFF
--- a/packages/flutter_bloc/lib/flutter_bloc.dart
+++ b/packages/flutter_bloc/lib/flutter_bloc.dart
@@ -4,9 +4,10 @@ export 'package:bloc/bloc.dart';
 
 export './src/bloc_builder.dart';
 export './src/bloc_consumer.dart';
-export './src/bloc_listener.dart';
-export './src/bloc_provider.dart';
+export './src/bloc_listener.dart' hide BlocListenerSingleChildWidget;
+export './src/bloc_provider.dart' hide BlocProviderSingleChildWidget;
 export './src/multi_bloc_listener.dart';
 export './src/multi_bloc_provider.dart';
 export './src/multi_repository_provider.dart';
-export './src/repository_provider.dart';
+export './src/repository_provider.dart'
+    hide RepositoryProviderSingleChildWidget;

--- a/packages/flutter_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/bloc_listener.dart
@@ -6,6 +6,10 @@ import 'package:provider/single_child_widget.dart';
 
 import '../flutter_bloc.dart';
 
+/// Mixin which allows `MultiBlocListener` to infer the types
+/// of multiple [BlocListener]s.
+mixin BlocListenerSingleChildWidget on SingleChildWidget {}
+
 /// Signature for the [listener] function which takes the `BuildContext` along
 /// with the [bloc] [state] and is responsible for executing in response to
 /// [state] changes.
@@ -74,8 +78,8 @@ typedef BlocListenerCondition<S> = bool Function(S previous, S current);
 /// )
 /// ```
 /// {@endtemplate}
-class BlocListener<B extends Bloc<dynamic, S>, S>
-    extends BlocListenerBase<B, S> {
+class BlocListener<B extends Bloc<dynamic, S>, S> extends BlocListenerBase<B, S>
+    with BlocListenerSingleChildWidget {
   /// The widget which will be rendered as a descendant of the [BlocListener].
   final Widget child;
 

--- a/packages/flutter_bloc/lib/src/bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/bloc_provider.dart
@@ -4,6 +4,10 @@ import 'package:provider/provider.dart';
 import 'package:provider/single_child_widget.dart';
 import 'package:bloc/bloc.dart';
 
+/// Mixin which allows `MultiBlocProvider` to infer the types
+/// of multiple [BlocProvider]s.
+mixin BlocProviderSingleChildWidget on SingleChildWidget {}
+
 /// {@template blocprovider}
 /// Takes a [ValueBuilder] that is responsible for creating the [bloc] and
 /// a [child] which will have access to the [bloc] via
@@ -22,7 +26,7 @@ import 'package:bloc/bloc.dart';
 /// ```
 /// {@endtemplate}
 class BlocProvider<T extends Bloc<dynamic, dynamic>>
-    extends SingleChildStatelessWidget {
+    extends SingleChildStatelessWidget with BlocProviderSingleChildWidget {
   /// [child] and its descendants which will have access to the [bloc].
   final Widget child;
 
@@ -104,12 +108,7 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>>
         BlocProvider.of() called with a context that does not contain a Bloc of type $T.
         No ancestor could be found starting from the context that was passed to BlocProvider.of<$T>().
 
-        This can happen if:
-        1. The context you used comes from a widget above the BlocProvider.
-        2. You used MultiBlocProvider and didn\'t explicity provide the BlocProvider types.
-
-        Good: BlocProvider<$T>(create: (context) => $T())
-        Bad: BlocProvider(create: (context) => $T()).
+        This can happen if the context you used comes from a widget above the BlocProvider.
 
         The context used was: $context
         """,

--- a/packages/flutter_bloc/lib/src/multi_bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/multi_bloc_listener.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 
-import '../flutter_bloc.dart';
+import 'bloc_listener.dart';
 
 /// {@template multibloclistener}
 /// Merges multiple [BlocListener] widgets into one widget tree.
@@ -54,7 +54,7 @@ class MultiBlocListener extends StatelessWidget {
   /// The tree of [BlocListener] widgets is created in order meaning the first
   /// [BlocListener] will be the top-most [BlocListener] and the last
   /// [BlocListener] will be a direct ancestor of [child].
-  final List<BlocListener> listeners;
+  final List<BlocListenerSingleChildWidget> listeners;
 
   /// The widget which will be a direct descendent of the last [BlocListener]
   /// in [listeners].

--- a/packages/flutter_bloc/lib/src/multi_bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/multi_bloc_provider.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 
-import '../flutter_bloc.dart';
+import 'bloc_provider.dart';
 
 /// {@template multiblocprovider}
 /// Merges multiple [BlocProvider] widgets into one widget tree.
@@ -54,7 +54,7 @@ class MultiBlocProvider extends StatelessWidget {
   /// The tree of [BlocProvider] widgets is created in order meaning the first
   /// [BlocProvider] will be the top-most [BlocProvider] and the last
   /// [BlocProvider] will be a direct ancestor of [child].
-  final List<BlocProvider> providers;
+  final List<BlocProviderSingleChildWidget> providers;
 
   /// The widget and its descendants which will have access to every [bloc]
   /// provided by [providers].

--- a/packages/flutter_bloc/lib/src/multi_repository_provider.dart
+++ b/packages/flutter_bloc/lib/src/multi_repository_provider.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 
-import '../flutter_bloc.dart';
+import 'repository_provider.dart';
 
 /// {@template multirepositoryprovider}
 /// Merges multiple [RepositoryProvider] widgets into one widget tree.
@@ -48,7 +48,7 @@ class MultiRepositoryProvider extends StatelessWidget {
   /// The tree of [RepositoryProvider] widgets is created in order meaning
   /// the first [RepositoryProvider] will be the top-most [RepositoryProvider]
   /// and the last [RepositoryProvider] will be a direct ancestor of [child].
-  final List<RepositoryProvider> providers;
+  final List<RepositoryProviderSingleChildWidget> providers;
 
   /// The widget and its descendants which will have access to every value
   /// provided by [providers].

--- a/packages/flutter_bloc/lib/src/repository_provider.dart
+++ b/packages/flutter_bloc/lib/src/repository_provider.dart
@@ -1,5 +1,10 @@
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
+import 'package:provider/single_child_widget.dart';
+
+/// Mixin which allows `MultiRepositoryProvider` to infer the types
+/// of multiple [RepositoryProvider]s.
+mixin RepositoryProviderSingleChildWidget on SingleChildWidget {}
 
 /// {@template repositoryprovider}
 /// Takes a `ValueBuilder` that is responsible for creating the repository and
@@ -17,7 +22,8 @@ import 'package:provider/provider.dart';
 /// );
 /// ```
 /// {@endtemplate}
-class RepositoryProvider<T> extends Provider<T> {
+class RepositoryProvider<T> extends Provider<T>
+    with RepositoryProviderSingleChildWidget {
   /// {@macro repositoryprovider}
   RepositoryProvider({
     Key key,
@@ -57,12 +63,7 @@ class RepositoryProvider<T> extends Provider<T> {
         RepositoryProvider.of() called with a context that does not contain a repository of type $T.
         No ancestor could be found starting from the context that was passed to RepositoryProvider.of<$T>().
 
-        This can happen if:
-        1. The context you used comes from a widget above the RepositoryProvider.
-        2. You used MultiRepositoryProvider and didn\'t explicity provide the RepositoryProvider types.
-
-        Good: RepositoryProvider<$T>(create: (context) => $T())
-        Bad: RepositoryProvider(create: (context) => $T()).
+        This can happen if the context you used comes from a widget above the RepositoryProvider.
 
         The context used was: $context
         """,

--- a/packages/flutter_bloc/test/bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/bloc_provider_test.dart
@@ -227,6 +227,20 @@ void main() {
       expect(createCalled, isFalse);
     });
 
+    testWidgets('lazily loads blocs by default', (tester) async {
+      var createCalled = false;
+      await tester.pumpWidget(
+        BlocProvider(
+          create: (_) {
+            createCalled = true;
+            return CounterBloc();
+          },
+          child: Container(),
+        ),
+      );
+      expect(createCalled, isFalse);
+    });
+
     testWidgets('can override lazy loading', (tester) async {
       var createCalled = false;
       await tester.pumpWidget(
@@ -240,6 +254,25 @@ void main() {
         ),
       );
       expect(createCalled, isTrue);
+    });
+
+    testWidgets('can be provided without an explicit type', (tester) async {
+      final key = Key('__text_count__');
+      await tester.pumpWidget(
+        MaterialApp(
+          home: BlocProvider(
+            create: (_) => CounterBloc(),
+            child: Builder(
+              builder: (context) => Text(
+                '${BlocProvider.of<CounterBloc>(context).state}',
+                key: key,
+              ),
+            ),
+          ),
+        ),
+      );
+      final text = tester.widget(find.byKey(key)) as Text;
+      expect(text.data, '0');
     });
 
     testWidgets('passes bloc to children', (tester) async {
@@ -395,12 +428,7 @@ void main() {
         BlocProvider.of() called with a context that does not contain a Bloc of type CounterBloc.
         No ancestor could be found starting from the context that was passed to BlocProvider.of<CounterBloc>().
 
-        This can happen if:
-        1. The context you used comes from a widget above the BlocProvider.
-        2. You used MultiBlocProvider and didn\'t explicity provide the BlocProvider types.
-
-        Good: BlocProvider<CounterBloc>(create: (context) => CounterBloc())
-        Bad: BlocProvider(create: (context) => CounterBloc()).
+        This can happen if the context you used comes from a widget above the BlocProvider.
 
         The context used was: CounterPage(dirty)
 """;

--- a/packages/flutter_bloc/test/multi_bloc_listener_test.dart
+++ b/packages/flutter_bloc/test/multi_bloc_listener_test.dart
@@ -112,5 +112,57 @@ void main() {
         expect(latestStateB, 1);
       });
     });
+
+    testWidgets('calls listeners on state changes without explicit types',
+        (tester) async {
+      int latestStateA;
+      var listenerCallCountA = 0;
+      final counterBlocA = CounterBloc();
+      final expectedStatesA = [0, 1, 2];
+
+      int latestStateB;
+      var listenerCallCountB = 0;
+      final counterBlocB = CounterBloc();
+      final expectedStatesB = [0, 1];
+
+      await tester.pumpWidget(
+        MultiBlocListener(
+          listeners: [
+            BlocListener(
+              bloc: counterBlocA,
+              listener: (context, state) {
+                listenerCallCountA++;
+                latestStateA = state;
+              },
+            ),
+            BlocListener(
+              bloc: counterBlocB,
+              listener: (context, state) {
+                listenerCallCountB++;
+                latestStateB = state;
+              },
+            ),
+          ],
+          child: Container(key: Key('multiBlocListener_child')),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(Key('multiBlocListener_child')), findsOneWidget);
+
+      counterBlocA.add(CounterEvent.increment);
+      counterBlocA.add(CounterEvent.increment);
+      counterBlocB.add(CounterEvent.increment);
+
+      expectLater(counterBlocA, emitsInOrder(expectedStatesA)).then((_) {
+        expect(listenerCallCountA, 2);
+        expect(latestStateA, 2);
+      });
+
+      expectLater(counterBlocB, emitsInOrder(expectedStatesB)).then((_) {
+        expect(listenerCallCountB, 1);
+        expect(latestStateB, 1);
+      });
+    });
   });
 }

--- a/packages/flutter_bloc/test/multi_bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/multi_bloc_provider_test.dart
@@ -260,6 +260,29 @@ void main() {
       expect(counterText.data, '0');
     });
 
+    testWidgets('passes blocs to children without explicit states',
+        (tester) async {
+      await tester.pumpWidget(
+        MultiBlocProvider(
+          providers: [
+            BlocProvider(create: (context) => CounterBloc()),
+            BlocProvider(create: (context) => ThemeBloc())
+          ],
+          child: MyApp(),
+        ),
+      );
+
+      final materialApp =
+          tester.widget(find.byType(MaterialApp)) as MaterialApp;
+      expect(materialApp.theme, ThemeData.light());
+
+      final counterFinder = find.byKey((Key('counter_text')));
+      expect(counterFinder, findsOneWidget);
+
+      final counterText = tester.widget(counterFinder) as Text;
+      expect(counterText.data, '0');
+    });
+
     testWidgets('adds event to each bloc', (tester) async {
       await tester.pumpWidget(
         MultiBlocProvider(

--- a/packages/flutter_bloc/test/multi_repository_provider_test.dart
+++ b/packages/flutter_bloc/test/multi_repository_provider_test.dart
@@ -121,5 +121,34 @@ void main() {
       final repositoryBText = tester.widget(repositoryBFinder) as Text;
       expect(repositoryBText.data, '1');
     });
+
+    testWidgets('passes values to children without explict types',
+        (tester) async {
+      await tester.pumpWidget(
+        MultiRepositoryProvider(
+          providers: [
+            RepositoryProvider(
+              create: (context) => RepositoryA(0),
+            ),
+            RepositoryProvider(
+              create: (context) => RepositoryB(1),
+            ),
+          ],
+          child: MyApp(),
+        ),
+      );
+
+      final repositoryAFinder = find.byKey((Key('RepositoryA_data')));
+      expect(repositoryAFinder, findsOneWidget);
+
+      final repositoryAText = tester.widget(repositoryAFinder) as Text;
+      expect(repositoryAText.data, '0');
+
+      final repositoryBFinder = find.byKey((Key('RepositoryB_data')));
+      expect(repositoryBFinder, findsOneWidget);
+
+      final repositoryBText = tester.widget(repositoryBFinder) as Text;
+      expect(repositoryBText.data, '1');
+    });
   });
 }

--- a/packages/flutter_bloc/test/repository_provider_test.dart
+++ b/packages/flutter_bloc/test/repository_provider_test.dart
@@ -237,12 +237,7 @@ void main() {
         RepositoryProvider.of() called with a context that does not contain a repository of type Repository.
         No ancestor could be found starting from the context that was passed to RepositoryProvider.of<Repository>().
 
-        This can happen if:
-        1. The context you used comes from a widget above the RepositoryProvider.
-        2. You used MultiRepositoryProvider and didn\'t explicity provide the RepositoryProvider types.
-
-        Good: RepositoryProvider<Repository>(create: (context) => Repository())
-        Bad: RepositoryProvider(create: (context) => Repository()).
+        This can happen if the context you used comes from a widget above the RepositoryProvider.
 
         The context used was: CounterPage(dirty)
 """;


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
As a developer, I shouldn't need to provider the Bloc/Repository type explicitly when using `MultiBlocProvider`, `MultiBlocListener`, or `MultiRepositoryProvider`.

```dart
MultiBlocProvider(
  providers: [
    BlocProvider<BlocA>(
      create: (_) => BlocA(),
    ),
    BlocProvider<BlocB>(
      create: (_) => BlocB(),
    ),
    child: MyChild(),
);
```

Instead, I should be able to omit the type and have it be correctly inferred:

```dart
MultiBlocProvider(
  providers: [
    BlocProvider(
      create: (_) => BlocA(),
    ),
    BlocProvider(
      create: (_) => BlocB(),
    ),
    child: MyChild(),
);
```

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
- Enhancement to be included in `flutter_bloc 3.2.0`