### PR TITLE
Update templates to follow initial state naming convention

### DIFF
--- a/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/with_equatable/bloc.dart.template
+++ b/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/with_equatable/bloc.dart.template
@@ -4,7 +4,7 @@ import './bloc.dart';
 
 class ${bloc_pascal_case}Bloc extends Bloc<${bloc_pascal_case}Event, ${bloc_pascal_case}State> {
   @override
-  ${bloc_pascal_case}State get initialState => Initial${bloc_pascal_case}State();
+  ${bloc_pascal_case}State get initialState => ${bloc_pascal_case}Initial();
 
   @override
   Stream<${bloc_pascal_case}State> mapEventToState(

--- a/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/with_equatable/bloc_state.dart.template
+++ b/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/with_equatable/bloc_state.dart.template
@@ -4,7 +4,7 @@ abstract class ${bloc_pascal_case}State extends Equatable {
   const ${bloc_pascal_case}State();
 }
 
-class Initial${bloc_pascal_case}State extends ${bloc_pascal_case}State {
+class ${bloc_pascal_case}Initial extends ${bloc_pascal_case}State {
   @override
   List<Object> get props => [];
 }

--- a/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/without_equatable/bloc.dart.template
+++ b/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/without_equatable/bloc.dart.template
@@ -4,7 +4,7 @@ import './bloc.dart';
 
 class ${bloc_pascal_case}Bloc extends Bloc<${bloc_pascal_case}Event, ${bloc_pascal_case}State> {
   @override
-  ${bloc_pascal_case}State get initialState => Initial${bloc_pascal_case}State();
+  ${bloc_pascal_case}State get initialState => ${bloc_pascal_case}Initial();
 
   @override
   Stream<${bloc_pascal_case}State> mapEventToState(

--- a/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/without_equatable/bloc_state.dart.template
+++ b/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/without_equatable/bloc_state.dart.template
@@ -3,4 +3,4 @@ import 'package:meta/meta.dart';
 @immutable
 abstract class ${bloc_pascal_case}State {}
 
-class Initial${bloc_pascal_case}State extends ${bloc_pascal_case}State {}
+class ${bloc_pascal_case}Initial extends ${bloc_pascal_case}State {}

--- a/extensions/vscode/src/templates/bloc-state.template.ts
+++ b/extensions/vscode/src/templates/bloc-state.template.ts
@@ -17,7 +17,7 @@ abstract class ${pascalCaseBlocName}State extends Equatable {
   const ${pascalCaseBlocName}State();
 }
 
-class Initial${pascalCaseBlocName}State extends ${pascalCaseBlocName}State {
+class ${pascalCaseBlocName}Initial extends ${pascalCaseBlocName}State {
   @override
   List<Object> get props => [];
 }
@@ -30,7 +30,7 @@ function getDefaultBlocStateTemplate(blocName: string): string {
 
 @immutable
 abstract class ${pascalCaseBlocName}State {}
-  
-class Initial${pascalCaseBlocName}State extends ${pascalCaseBlocName}State {}
+
+class ${pascalCaseBlocName}Initial extends ${pascalCaseBlocName}State {}
 `;
 }

--- a/extensions/vscode/src/templates/bloc.template.ts
+++ b/extensions/vscode/src/templates/bloc.template.ts
@@ -10,7 +10,7 @@ import './bloc.dart';
 
 class ${pascalCaseBlocName}Bloc extends Bloc<${blocEvent}, ${blocState}> {
   @override
-  ${blocState} get initialState => Initial${blocState}();
+  ${blocState} get initialState => ${pascalCaseBlocName}Initial();
 
   @override
   Stream<${blocState}> mapEventToState(


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
Currently, the extension templates don't follow the recently added naming conventions. This PR fixes initial state naming.
