### PR TITLE
Add extensions to BlocProvider & RepositoryProvider + Fix Provider Error Handling

### DIFF
--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -71,7 +71,7 @@ then from either `ChildA`, or `ScreenA` we can retrieve `BlocA` with:
 
 ```dart
 // with extensions
-context.bloc<BlocA>(context);
+context.bloc<BlocA>();
 
 // without extensions
 BlocProvider.of<BlocA>(context)
@@ -250,7 +250,7 @@ then from `ChildA` we can retrieve the `Repository` instance with:
 
 ```dart
 // with extensions
-context.repository<RepositoryA>(context);
+context.repository<RepositoryA>();
 
 // without extensions
 RepositoryProvider.of<RepositoryA>(context)

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -70,6 +70,10 @@ BlocProvider.value(
 then from either `ChildA`, or `ScreenA` we can retrieve `BlocA` with:
 
 ```dart
+// with extensions
+context.bloc<BlocA>(context);
+
+// without extensions
 BlocProvider.of<BlocA>(context)
 ```
 
@@ -245,6 +249,10 @@ RepositoryProvider(
 then from `ChildA` we can retrieve the `Repository` instance with:
 
 ```dart
+// with extensions
+context.repository<RepositoryA>(context);
+
+// without extensions
 RepositoryProvider.of<RepositoryA>(context)
 ```
 

--- a/packages/flutter_bloc/CHANGELOG.md
+++ b/packages/flutter_bloc/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.2.0
+
+- Fix type inference for: `MultiBlocProvider`, `MultiRepositoryProvider`, `MultiBlocListener` ([#773](https://github.com/felangel/bloc/pull/773))
+- Fix swallowed exceptions within `BlocProvider` and `RepositoryProvider` ([#807](https://github.com/felangel/bloc/issues/807))
+- Add `BlocProviderExtension` and `RepositoryProviderExtension` on `BuildContext` ([#608](https://github.com/felangel/bloc/issues/608))
+
 # 3.1.0
 
 - Expose lazy parameter on `RepositoryProvider` and `BlocProvider` ([#749](https://github.com/felangel/bloc/pull/749))

--- a/packages/flutter_bloc/README.md
+++ b/packages/flutter_bloc/README.md
@@ -81,6 +81,10 @@ BlocProvider.value(
 then from either `ChildA`, or `ScreenA` we can retrieve `BlocA` with:
 
 ```dart
+// with extensions
+context.bloc<BlocA>(context);
+
+// without extensions
 BlocProvider.of<BlocA>(context)
 ```
 
@@ -246,6 +250,10 @@ RepositoryProvider(
 then from `ChildA` we can retrieve the `Repository` instance with:
 
 ```dart
+// with extensions
+context.repository<RepositoryA>(context);
+
+// without extensions
 RepositoryProvider.of<RepositoryA>(context)
 ```
 
@@ -318,7 +326,7 @@ class CounterBloc extends Bloc<CounterEvent, int> {
 class CounterPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final CounterBloc counterBloc = BlocProvider.of<CounterBloc>(context);
+    final CounterBloc counterBloc = context.bloc<CounterBloc>();
 
     return Scaffold(
       appBar: AppBar(title: Text('Counter')),

--- a/packages/flutter_bloc/README.md
+++ b/packages/flutter_bloc/README.md
@@ -82,7 +82,7 @@ then from either `ChildA`, or `ScreenA` we can retrieve `BlocA` with:
 
 ```dart
 // with extensions
-context.bloc<BlocA>(context);
+context.bloc<BlocA>();
 
 // without extensions
 BlocProvider.of<BlocA>(context)
@@ -251,7 +251,7 @@ then from `ChildA` we can retrieve the `Repository` instance with:
 
 ```dart
 // with extensions
-context.repository<RepositoryA>(context);
+context.repository<RepositoryA>();
 
 // without extensions
 RepositoryProvider.of<RepositoryA>(context)

--- a/packages/flutter_bloc/example/lib/main.dart
+++ b/packages/flutter_bloc/example/lib/main.dart
@@ -73,24 +73,23 @@ class CounterPage extends StatelessWidget {
             padding: EdgeInsets.symmetric(vertical: 5.0),
             child: FloatingActionButton(
               child: Icon(Icons.add),
-              onPressed: () => BlocProvider.of<CounterBloc>(context)
-                  .add(CounterEvent.increment),
+              onPressed: () =>
+                  context.bloc<CounterBloc>().add(CounterEvent.increment),
             ),
           ),
           Padding(
             padding: EdgeInsets.symmetric(vertical: 5.0),
             child: FloatingActionButton(
               child: Icon(Icons.remove),
-              onPressed: () => BlocProvider.of<CounterBloc>(context)
-                  .add(CounterEvent.decrement),
+              onPressed: () =>
+                  context.bloc<CounterBloc>().add(CounterEvent.decrement),
             ),
           ),
           Padding(
             padding: EdgeInsets.symmetric(vertical: 5.0),
             child: FloatingActionButton(
               child: Icon(Icons.update),
-              onPressed: () =>
-                  BlocProvider.of<ThemeBloc>(context).add(ThemeEvent.toggle),
+              onPressed: () => context.bloc<ThemeBloc>().add(ThemeEvent.toggle),
             ),
           ),
         ],

--- a/packages/flutter_bloc/lib/src/bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/bloc_provider.dart
@@ -102,7 +102,7 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>>
   static T of<T extends Bloc<dynamic, dynamic>>(BuildContext context) {
     try {
       return Provider.of<T>(context, listen: false);
-    } on dynamic catch (_) {
+    } on ProviderNotFoundException catch (_) {
       throw FlutterError(
         """
         BlocProvider.of() called with a context that does not contain a Bloc of type $T.
@@ -125,4 +125,18 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>>
       lazy: lazy,
     );
   }
+}
+
+/// Extends the `BuildContext` class with the ability
+/// to perform a lookup based on a `Bloc` type.
+extension BlocProviderExtension on BuildContext {
+  /// Performs a lookup using the `BuildContext` to obtain
+  /// the nearest ancestor `Bloc` of type [B].
+  ///
+  /// Calling this method is equivalent to calling:
+  ///
+  /// ```dart
+  /// BlocProvider.of<B>(context)
+  /// ```
+  B bloc<B extends Bloc>() => BlocProvider.of<B>(this);
 }

--- a/packages/flutter_bloc/lib/src/repository_provider.dart
+++ b/packages/flutter_bloc/lib/src/repository_provider.dart
@@ -57,7 +57,7 @@ class RepositoryProvider<T> extends Provider<T>
   static T of<T>(BuildContext context) {
     try {
       return Provider.of<T>(context, listen: false);
-    } on dynamic catch (_) {
+    } on ProviderNotFoundException catch (_) {
       throw FlutterError(
         """
         RepositoryProvider.of() called with a context that does not contain a repository of type $T.
@@ -70,4 +70,18 @@ class RepositoryProvider<T> extends Provider<T>
       );
     }
   }
+}
+
+/// Extends the `BuildContext` class with the ability
+/// to perform a lookup based on a repository type.
+extension RepositoryProviderExtension on BuildContext {
+  /// Performs a lookup using the `BuildContext` to obtain
+  /// the nearest ancestor repository of type [T].
+  ///
+  /// Calling this method is equivalent to calling:
+  ///
+  /// ```dart
+  /// RepositoryProvider.of<T>(context)
+  /// ```
+  T repository<T>() => RepositoryProvider.of<T>(this);
 }

--- a/packages/flutter_bloc/test/bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/bloc_provider_test.dart
@@ -437,6 +437,21 @@ void main() {
     });
 
     testWidgets(
+        'should not throw FlutterError if internal '
+        'exception is thrown', (tester) async {
+      final expectedException = Exception('oops');
+      await tester.pumpWidget(
+        BlocProvider<CounterBloc>(
+          lazy: false,
+          create: (_) => throw expectedException,
+          child: Container(),
+        ),
+      );
+      final dynamic exception = tester.takeException();
+      expect(exception, expectedException);
+    });
+
+    testWidgets(
         'should not rebuild widgets that inherited the bloc if the bloc is '
         'changed', (tester) async {
       var numBuilds = 0;
@@ -451,6 +466,35 @@ void main() {
       await tester.tap(find.byKey(Key('iconButtonKey')));
       await tester.pump();
       expect(numBuilds, 1);
+    });
+
+    testWidgets(
+        'should access bloc instance'
+        'via BlocProviderExtension', (tester) async {
+      await tester.pumpWidget(
+        BlocProvider(
+          create: (_) => CounterBloc(),
+          child: MaterialApp(
+            home: Scaffold(
+              appBar: AppBar(title: Text('Value')),
+              body: Center(
+                child: Builder(
+                  builder: (context) => Text(
+                    '${context.bloc<CounterBloc>().state}',
+                    key: Key('value_data'),
+                    style: TextStyle(fontSize: 24.0),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      final _counterFinder = find.byKey((Key('value_data')));
+      expect(_counterFinder, findsOneWidget);
+
+      final _counterText = _counterFinder.evaluate().first.widget as Text;
+      expect(_counterText.data, '0');
     });
   });
 }

--- a/packages/flutter_bloc/test/repository_provider_test.dart
+++ b/packages/flutter_bloc/test/repository_provider_test.dart
@@ -246,6 +246,21 @@ void main() {
     });
 
     testWidgets(
+        'should not throw FlutterError if internal '
+        'exception is thrown', (tester) async {
+      final expectedException = Exception('oops');
+      await tester.pumpWidget(
+        RepositoryProvider<Repository>(
+          lazy: false,
+          create: (_) => throw expectedException,
+          child: Container(),
+        ),
+      );
+      final dynamic exception = tester.takeException();
+      expect(exception, expectedException);
+    });
+
+    testWidgets(
         'should not rebuild widgets that inherited the value if the value is '
         'changed', (tester) async {
       var numBuilds = 0;
@@ -260,6 +275,35 @@ void main() {
       await tester.tap(find.byKey(Key('iconButtonKey')));
       await tester.pump();
       expect(numBuilds, 1);
+    });
+
+    testWidgets(
+        'should access repository instance'
+        'via RepositoryProviderExtension', (tester) async {
+      await tester.pumpWidget(
+        RepositoryProvider(
+          create: (_) => Repository(0),
+          child: MaterialApp(
+            home: Scaffold(
+              appBar: AppBar(title: Text('Value')),
+              body: Center(
+                child: Builder(
+                  builder: (context) => Text(
+                    '${context.repository<Repository>().data}',
+                    key: Key('value_data'),
+                    style: TextStyle(fontSize: 24.0),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      final _counterFinder = find.byKey((Key('value_data')));
+      expect(_counterFinder, findsOneWidget);
+
+      final _counterText = _counterFinder.evaluate().first.widget as Text;
+      expect(_counterText.data, '0');
     });
   });
 }


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Fix type inference for: `MultiBlocProvider`, `MultiRepositoryProvider`, `MultiBlocListener` (#773)

### Before
```dart
MultiBlocProvider(
  providers: [
    BlocProvider<BlocA>(create: (_) => BlocA()),
    BlocProvider<BlocB>(create: (_) => BlocB()),
  ],
)
```

### After

```dart
MultiBlocProvider(
  providers: [
    BlocProvider(create: (_) => BlocA()),
    BlocProvider(create: (_) => BlocB()),
  ],
)
```

- Fix swallowed exceptions within `BlocProvider` and `RepositoryProvider` (#807, #817)
- Add `BlocProviderExtension` and `RepositoryProviderExtension` on `BuildContext` (#608)

```dart
// with extension
final bloc = context.bloc<BlocA>();

// without extension
final bloc = BlocProvider.of<BlocA>();
```

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
- Non-Breaking Changes which will be included in `flutter_bloc v3.2.0`