### PR TITLE
Decouple Bloc from RxDart

### DIFF
--- a/packages/bloc/pubspec.yaml
+++ b/packages/bloc/pubspec.yaml
@@ -17,4 +17,3 @@ dev_dependencies:
   mockito: ^4.0.0
   effective_dart: ^1.2.0
   rxdart: ^0.23.0
-

--- a/packages/bloc/test/helpers/complex/complex_bloc.dart
+++ b/packages/bloc/test/helpers/complex/complex_bloc.dart
@@ -9,11 +9,11 @@ class ComplexBloc extends Bloc<ComplexEvent, ComplexState> {
   ComplexState get initialState => ComplexStateA();
 
   @override
-  Stream<ComplexState> transformEvents(
+  Stream<Transition<ComplexEvent, ComplexState>> transformEvents(
     Stream<ComplexEvent> events,
-    Function(ComplexEvent) next,
+    TransitionFunction<ComplexEvent, ComplexState> transitionFn,
   ) {
-    return events.switchMap(next);
+    return events.switchMap(transitionFn);
   }
 
   @override
@@ -32,7 +32,9 @@ class ComplexBloc extends Bloc<ComplexEvent, ComplexState> {
   }
 
   @override
-  Stream<ComplexState> transformStates(Stream<ComplexState> states) {
-    return states.debounceTime(Duration(milliseconds: 50));
+  Stream<Transition<ComplexEvent, ComplexState>> transformTransitions(
+    Stream<Transition<ComplexEvent, ComplexState>> transitions,
+  ) {
+    return transitions.debounceTime(Duration(milliseconds: 50));
   }
 }


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Breaking Changes
YES

## Description
- Remove `rxdart` as a dependency from `bloc` (related to #821)
- Refactor to use `_TransitionStreamTransformer` object which encapsulates the current transition in order to ensure that transitions occur for the respective event/state pair.(https://github.com/felangel/bloc/pull/839#discussion_r373839896)
- Rename `transformStates` to `transformTransitions`
- `transformEvents` signature change to take a `TransitionFunction`

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
- Breaking changes
  - `transformStates` -> `transformTransitions`
  - Function signature changes to `transformEvents`