### PR TITLE
Update flutterinfinitelisttutorial.md

### DIFF
--- a/docs/pt-br/flutterinfinitelisttutorial.md
+++ b/docs/pt-br/flutterinfinitelisttutorial.md
@@ -347,6 +347,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
 
   @override
   Stream<PostState> mapEventToState(event) async* {
+    final currentState = state;
     if (event is Fetch && !_hasReachedMax(currentState)) {
       try {
         if (currentState is PostUninitialized) {


### PR DESCRIPTION
Missing declaration of currentState added to finished version of PostEvent Class in pt-br language documentation.

## Status
**READY/IN DEVELOPMENT/HOLD**

## Breaking Changes
YES | NO

## Description
Missing declaration of currentState added to finished version of PostEvent Class.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Todos

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```
```

## Impact to Remaining Code Base
This PR will affect:

* 
