### PR TITLE
Add Docs workflow

### DIFF
--- a/.github/DOCS_ISSUE_TEMPLATE.md
+++ b/.github/DOCS_ISSUE_TEMPLATE.md
@@ -1,0 +1,10 @@
+---
+title: "[Translations] Update docs"
+assignees: tenhobi
+labels: documentation, translation
+---
+Update Translations to include changes from {{ sha }}.
+
+- [ ] cs (@tenhobi)
+- [ ] pt-br (@rodrigobastosv)
+- [ ] ru (@basilex)

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,23 @@
+name: docs
+
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - 'README.md'
+    - 'docs/*'
+
+jobs:
+  # Create an issue, when any changes to source docs were made.
+  create-issue:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: JasonEtco/create-an-issue@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/DOCS_ISSUE_TEMPLATE.md


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Breaking Changes
NO

## Description
This PR adds a new workflow, which adds automatically a new issue on every source docs update.

Multiple assignees seem to fail, so for now, only I am assigned and we can add other guys later. See https://github.com/JasonEtco/create-an-issue/issues/41
