### PR TITLE
bloc_test v4.0.0

### DIFF
--- a/examples/flutter_login/test/unit/authentication/authentication_bloc_test.dart
+++ b/examples/flutter_login/test/unit/authentication/authentication_bloc_test.dart
@@ -42,27 +42,25 @@ void main() {
 
   group('AppStarted', () {
     blocTest(
-      'emits [uninitialized, unauthenticated] for invalid token',
-      build: () {
+      'emits [unauthenticated] for invalid token',
+      build: () async {
         when(userRepository.hasToken()).thenAnswer((_) => Future.value(false));
         return authenticationBloc;
       },
       act: (bloc) => bloc.add(AppStarted()),
       expect: [
-        AuthenticationUninitialized(),
         AuthenticationUnauthenticated(),
       ],
     );
 
     blocTest(
-      'emits [uninitialized, authenticated] for valid token',
-      build: () {
+      'emits [authenticated] for valid token',
+      build: () async {
         when(userRepository.hasToken()).thenAnswer((_) => Future.value(true));
         return authenticationBloc;
       },
       act: (bloc) => bloc.add(AppStarted()),
       expect: [
-        AuthenticationUninitialized(),
         AuthenticationAuthenticated(),
       ],
     );
@@ -70,11 +68,10 @@ void main() {
 
   group('LoggedIn', () {
     blocTest(
-      'emits [uninitialized, loading, authenticated] when token is persisted',
-      build: () => authenticationBloc,
+      'emits [loading, authenticated] when token is persisted',
+      build: () async => authenticationBloc,
       act: (bloc) => bloc.add(LoggedIn(token: 'instance.token')),
       expect: [
-        AuthenticationUninitialized(),
         AuthenticationLoading(),
         AuthenticationAuthenticated(),
       ],
@@ -83,11 +80,10 @@ void main() {
 
   group('LoggedOut', () {
     blocTest(
-      'emits [uninitialized, loading, unauthenticated] when token is deleted',
-      build: () => authenticationBloc,
+      'emits [loading, unauthenticated] when token is deleted',
+      build: () async => authenticationBloc,
       act: (bloc) => bloc.add(LoggedOut()),
       expect: [
-        AuthenticationUninitialized(),
         AuthenticationLoading(),
         AuthenticationUnauthenticated(),
       ],

--- a/examples/flutter_login/test/unit/login/login_bloc_test.dart
+++ b/examples/flutter_login/test/unit/login/login_bloc_test.dart
@@ -64,8 +64,8 @@ void main() {
 
   group('LoginButtonPressed', () {
     blocTest(
-      'emits [LoginInitial, LoginLoading, LoginInitial] and token on success',
-      build: () {
+      'emits [LoginLoading, LoginInitial] and token on success',
+      build: () async {
         when(userRepository.authenticate(
           username: 'valid.username',
           password: 'valid.password',
@@ -79,18 +79,17 @@ void main() {
         ),
       ),
       expect: [
-        LoginInitial(),
         LoginLoading(),
         LoginInitial(),
       ],
-      verify: () async {
+      verify: (_) async {
         verify(authenticationBloc.add(LoggedIn(token: 'token'))).called(1);
       },
     );
 
     blocTest(
-      'emits [LoginInitial, LoginLoading, LoginFailure] on failure',
-      build: () {
+      'emits [LoginLoading, LoginFailure] on failure',
+      build: () async {
         when(userRepository.authenticate(
           username: 'valid.username',
           password: 'valid.password',
@@ -104,11 +103,10 @@ void main() {
         ),
       ),
       expect: [
-        LoginInitial(),
         LoginLoading(),
         LoginFailure(error: 'Exception: login-error'),
       ],
-      verify: () async {
+      verify: (_) async {
         verifyNever(authenticationBloc.add(any));
       },
     );

--- a/examples/flutter_weather/test/blocs/weather_bloc_test.dart
+++ b/examples/flutter_weather/test/blocs/weather_bloc_test.dart
@@ -42,8 +42,8 @@ main() {
 
     group('FetchWeather', () {
       blocTest(
-        'emits [WeatherEmpty, WeatherLoading, WeatherLoaded] when weather repository returns weather',
-        build: () {
+        'emits [WeatherLoading, WeatherLoaded] when weather repository returns weather',
+        build: () async {
           when(weatherRepository.getWeather('chicago')).thenAnswer(
             (_) => Future.value(weather),
           );
@@ -51,22 +51,20 @@ main() {
         },
         act: (bloc) => bloc.add(FetchWeather(city: 'chicago')),
         expect: [
-          WeatherEmpty(),
           WeatherLoading(),
           WeatherLoaded(weather: weather),
         ],
       );
 
       blocTest(
-        'emits [WeatherEmpty, WeatherLoading, WeatherError] when weather repository throws error',
-        build: () {
+        'emits [WeatherLoading, WeatherError] when weather repository throws error',
+        build: () async {
           when(weatherRepository.getWeather('chicago'))
               .thenThrow('Weather Error');
           return weatherBloc;
         },
         act: (bloc) => bloc.add(FetchWeather(city: 'chicago')),
         expect: [
-          WeatherEmpty(),
           WeatherLoading(),
           WeatherError(),
         ],
@@ -75,8 +73,8 @@ main() {
 
     group('RefreshWeather', () {
       blocTest(
-        'emits [WeatherEmpty, WeatherLoaded] when weather repository returns weather',
-        build: () {
+        'emits [WeatherLoaded] when weather repository returns weather',
+        build: () async {
           when(weatherRepository.getWeather('chicago')).thenAnswer(
             (_) => Future.value(weather),
           );
@@ -84,22 +82,19 @@ main() {
         },
         act: (bloc) => bloc.add(RefreshWeather(city: 'chicago')),
         expect: [
-          WeatherEmpty(),
           WeatherLoaded(weather: weather),
         ],
       );
 
       blocTest(
-        'emits [WeatherEmpty] when weather repository throws error',
-        build: () {
+        'emits [] when weather repository throws error',
+        build: () async {
           when(weatherRepository.getWeather('chicago'))
               .thenThrow('Weather Error');
           return weatherBloc;
         },
         act: (bloc) => bloc.add(RefreshWeather(city: 'chicago')),
-        expect: [
-          WeatherEmpty(),
-        ],
+        expect: [],
       );
     });
   });

--- a/packages/bloc_test/CHANGELOG.md
+++ b/packages/bloc_test/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 4.0.0
+
+- `blocTest` and `emitsExactly` skip `initialState` by default and expose optional `skip` ([#910](https://github.com/felangel/bloc/issues/910))
+- `blocTest` async `build` ([#910](https://github.com/felangel/bloc/issues/910))
+- `blocTest` `expect` is optional ([#910](https://github.com/felangel/bloc/issues/910))
+- `blocTest` `verify` includes the built bloc ([#910](https://github.com/felangel/bloc/issues/910))
+
 # 3.1.0
 
 - Add `verify` to `blocTest` ([#781](https://github.com/felangel/bloc/issues/781))

--- a/packages/bloc_test/README.md
+++ b/packages/bloc_test/README.md
@@ -122,7 +122,7 @@ blocTest(
 
 ## Assert with Confidence using emitsExactly
 
-**emitsExactly** is similar to `emitsInOrder` but asserts that the provided `bloc` emits **only** the `expected` states in the **exact** order in which they were provided. The `initialState` of the bloc is not included in the assertion and should be unit tested indepedently.
+**emitsExactly** is similar to `emitsInOrder` but asserts that the provided `bloc` emits **only** the `expected` states in the **exact** order in which they were provided.
 
 ```dart
 group('CounterBloc', () {

--- a/packages/bloc_test/README.md
+++ b/packages/bloc_test/README.md
@@ -42,44 +42,44 @@ expectLater(counterBloc, emitsInOrder(<int>[0, 1, 2, 3])))
 
 **blocTest** creates a new `bloc`-specific test case with the given `description`. `blocTest` will handle asserting that the `bloc` emits the `expect`ed states (in order) after `act` is executed. `blocTest` also handles ensuring that no additional states are emitted by closing the `bloc` stream before evaluating the `expect`ation.
 
-`build` should be used for all `bloc` initialization and preparation and must return the `bloc` under test.
+`build` should be used for all `bloc` initialization and preparation and must return the `bloc` under test as a `Future`.
 
 `act` is an optional callback which will be invoked with the `bloc` under test and should be used to `add` events to the `bloc`.
+
+`skip` is an optional `int` which can be used to skip any number of states. The default value is 1 which skips the `initialState` of the bloc. `skip` can be overridden to include the `initialState` by setting skip to 0.
 
 `wait` is an optional `Duration` which can be used to wait for async operations within the `bloc` under test such as `debounceTime`.
 
 `expect` is an `Iterable<State>` which the `bloc` under test is expected to emit after `act` is executed.
 
-`verify` is an optional callback which is invoked after `expect` and can be used for additional non-bloc related assertions.
+`verify` is an optional callback which is invoked after `expect` and can be used for additional verification/assertions. `verify` is called with the `bloc` returned by `build`.
 
 ```dart
 group('CounterBloc', () {
   blocTest(
-    'emits [0] when nothing is added',
-    build: () => CounterBloc(),
-    expect: [0],
+    'emits [] when nothing is added',
+    build: () async => CounterBloc(),
+    expect: [],
   );
 
   blocTest(
-    'emits [0, 1] when CounterEvent.increment is added',
-    build: () => CounterBloc(),
+    'emits [1] when CounterEvent.increment is added',
+    build: () async => CounterBloc(),
     act: (bloc) => bloc.add(CounterEvent.increment),
-    expect: [0, 1],
+    expect: [1],
   );
 });
 ```
 
-`blocTest` can also be used to `verify` internal bloc functionality.
+`blocTest` can also be used to `skip` any number of emitted states before asserting against the expected states. The default value is 1 which skips the `initialState` of the bloc. `skip` can be overridden to include the `initialState` by setting skip to 0.
 
 ```dart
 blocTest(
   'CounterBloc emits [0, 1] when CounterEvent.increment is added',
-  build: () => CounterBloc(),
+  build: () async => CounterBloc(),
   act: (bloc) => bloc.add(CounterEvent.increment),
+  skip: 0,
   expect: [0, 1],
-  verify: () async {
-    verify(repository.someMethod(any)).called(1);
-  }
 );
 ```
 
@@ -87,11 +87,25 @@ blocTest(
 
 ```dart
 blocTest(
-  'CounterBloc emits [0, 1] when CounterEvent.increment is added',
-  build: () => CounterBloc(),
+  'CounterBloc emits [1] when CounterEvent.increment is added',
+  build: () async => CounterBloc(),
   act: (bloc) => bloc.add(CounterEvent.increment),
   wait: const Duration(milliseconds: 300),
-  expect: [0, 1],
+  expect: [1],
+);
+```
+
+`blocTest` can also be used to `verify` internal bloc functionality.
+
+```dart
+blocTest(
+  'CounterBloc emits [1] when CounterEvent.increment is added',
+  build: () async => CounterBloc(),
+  act: (bloc) => bloc.add(CounterEvent.increment),
+  expect: [1],
+  verify: () async {
+    verify(repository.someMethod(any)).called(1);
+  }
 );
 ```
 
@@ -99,28 +113,28 @@ blocTest(
 
 ```dart
 blocTest(
-  'emits [StateA, StateB] when MyEvent is added',
-  build: () => MyBloc(),
+  'emits [StateB] when MyEvent is added',
+  build: () async => MyBloc(),
   act: (bloc) => bloc.add(MyEvent()),
-  expect: [isA<StateA>(), isA<StateB>()],
+  expect: [isA<StateB>()],
 );
 ```
 
 ## Assert with Confidence using emitsExactly
 
-**emitsExactly** is similar to `emitsInOrder` but asserts that the provided `bloc` emits **only** the `expected` states in the **exact** order in which they were provided.
+**emitsExactly** is similar to `emitsInOrder` but asserts that the provided `bloc` emits **only** the `expected` states in the **exact** order in which they were provided. The `initialState` of the bloc is not included in the assertion and should be unit tested indepedently.
 
 ```dart
 group('CounterBloc', () {
-  test('emits [0] when nothing is added', () async {
+  test('emits [] when nothing is added', () async {
     final bloc = CounterBloc();
-    await emitsExactly(bloc, [0]);
+    await emitsExactly(bloc, []);
   });
 
-  test('emits [0, 1] when CounterEvent.increment is added', () async {
+  test('emits [1] when CounterEvent.increment is added', () async {
     final bloc = CounterBloc();
     bloc.add(CounterEvent.increment);
-    await emitsExactly(bloc, [0, 1]);
+    await emitsExactly(bloc, [1]);
   });
 });
 ```
@@ -128,20 +142,30 @@ group('CounterBloc', () {
 `emitsExactly` also supports `Matchers` for states which don't override `==` and `hashCode`.
 
 ```dart
-test('emits [StateA, StateB] when EventB is added', () async {
+test('emits [StateB] when EventB is added', () async {
   final bloc = MyBloc();
   bloc.add(EventB());
-  await emitsExactly(bloc, [isA<StateA>(), isA<StateB>()]);
+  await emitsExactly(bloc, [isA<StateB>()]);
+});
+```
+
+`skip` is an optional `int` which defaults to 1 and can be used to skip any number of states. The default behavior skips the `initialState` of the bloc but can be overridden to include the `initialState` by setting skip to 0.
+
+```dart
+test('emits [0, 1] when CounterEvent.increment is added', () async {
+  final bloc = CounterBloc();
+  bloc.add(CounterEvent.increment);
+  await emitsExactly(bloc, [0, 1], skip: 0);
 });
 ```
 
 `emitsExactly` also takes an optional `duration` which is useful in cases where the `bloc` is using `debounceTime` or other similar operators.
 
 ```dart
-test('emits [0, 1] when CounterEvent.increment is added', () async {
+test('emits [1] when CounterEvent.increment is added', () async {
   final bloc = CounterBloc();
   bloc.add(CounterEvent.increment);
-  await emitsExactly(bloc, [0, 1], duration: const Duration(milliseconds: 300));
+  await emitsExactly(bloc, [1], duration: const Duration(milliseconds: 300));
 });
 ```
 

--- a/packages/bloc_test/example/main.dart
+++ b/packages/bloc_test/example/main.dart
@@ -42,30 +42,30 @@ void main() {
   });
 
   group('emitsExactly', () {
-    test('emits [0] when nothing is added', () async {
+    test('emits [] when nothing is added', () async {
       final bloc = CounterBloc();
-      await emitsExactly(bloc, [0]);
+      await emitsExactly(bloc, []);
     });
 
-    test('emits [0, 1] when CounterEvent.increment is added', () async {
+    test('emits [1] when CounterEvent.increment is added', () async {
       final bloc = CounterBloc();
       bloc.add(CounterEvent.increment);
-      await emitsExactly(bloc, [0, 1]);
+      await emitsExactly(bloc, [1]);
     });
   });
 
   group('blocTest', () {
     blocTest(
-      'emits [0] when nothing is added',
-      build: () => CounterBloc(),
-      expect: [0],
+      'emits [] when nothing is added',
+      build: () async => CounterBloc(),
+      expect: [],
     );
 
     blocTest(
-      'emits [0, 1] when CounterEvent.increment is added',
-      build: () => CounterBloc(),
+      'emits [1] when CounterEvent.increment is added',
+      build: () async => CounterBloc(),
       act: (bloc) => bloc.add(CounterEvent.increment),
-      expect: [0, 1],
+      expect: [1],
     );
   });
 }

--- a/packages/bloc_test/lib/src/bloc_test.dart
+++ b/packages/bloc_test/lib/src/bloc_test.dart
@@ -121,7 +121,7 @@ void blocTest<B extends Bloc<Event, State>, Event, State>(
     await act?.call(bloc);
     if (wait != null) await Future.delayed(wait);
     await bloc.close();
-    test.expect(states, expect);
+    if (expect != null) test.expect(states, expect);
     await subscription.cancel();
     await verify?.call(bloc);
   });

--- a/packages/bloc_test/lib/src/bloc_test.dart
+++ b/packages/bloc_test/lib/src/bloc_test.dart
@@ -11,10 +11,14 @@ import 'package:test/test.dart' as test;
 /// by closing the [bloc] stream before evaluating the [expect]ation.
 ///
 /// [build] should be used for all [bloc] initialization and preparation
-/// and must return the [bloc] under test.
+/// and must return the [bloc] under test as a `Future`.
 ///
 /// [act] is an optional callback which will be invoked with the [bloc] under
 /// test and should be used to `add` events to the [bloc].
+///
+/// [skip] is an optional `int` which can be used to skip any number of states.
+/// The default value is 1 which skips the `initialState` of the bloc.
+/// [skip] can be overridden to include the `initialState` by setting it to 0.
 ///
 /// [wait] is an optional `Duration` which can be used to wait for
 /// async operations within the [bloc] under test such as `debounceTime`.
@@ -23,14 +27,15 @@ import 'package:test/test.dart' as test;
 /// under test is expected to emit after [act] is executed.
 ///
 /// [verify] is an optional callback which is invoked after [expect]
-/// and can be used for additional non-bloc related assertions.
+/// and can be used for additional verification/assertions.
+/// [verify] is called with the [bloc] returned by [build].
 ///
 /// ```dart
 /// blocTest(
-///   'CounterBloc emits [0, 1] when CounterEvent.increment is added',
-///   build: () => CounterBloc(),
+///   'CounterBloc emits [1] when CounterEvent.increment is added',
+///   build: () async => CounterBloc(),
 ///   act: (bloc) => bloc.add(CounterEvent.increment),
-///   expect: [0, 1],
+///   expect: [1],
 /// );
 /// ```
 ///
@@ -39,23 +44,24 @@ import 'package:test/test.dart' as test;
 ///
 /// ```dart
 /// blocTest(
-///   'CounterBloc emits [0] when nothing is added',
-///   build: () => CounterBloc(),
-///   expect: [0],
+///   'CounterBloc emits [] when nothing is added',
+///   build: () async => CounterBloc(),
+///   expect: [],
 /// );
 /// ```
 ///
-/// [blocTest] can also be used to [verify] internal bloc functionality.
+/// [blocTest] can also be used to [skip] any number of emitted states
+/// before asserting against the expected states.
+/// The default value is 1 which skips the `initialState` of the bloc.
+/// [skip] can be overridden to include the `initialState` by setting it to 0.
 ///
 /// ```dart
 /// blocTest(
 ///   'CounterBloc emits [0, 1] when CounterEvent.increment is added',
-///   build: () => CounterBloc(),
+///   build: () async => CounterBloc(),
 ///   act: (bloc) => bloc.add(CounterEvent.increment),
+///   skip: 0,
 ///   expect: [0, 1],
-///   verify: () async {
-///     verify(repository.someMethod(any)).called(1);
-///   }
 /// );
 /// ```
 ///
@@ -64,11 +70,25 @@ import 'package:test/test.dart' as test;
 ///
 /// ```dart
 /// blocTest(
-///   'CounterBloc emits [0, 1] when CounterEvent.increment is added',
-///   build: () => CounterBloc(),
+///   'CounterBloc emits [1] when CounterEvent.increment is added',
+///   build: () async => CounterBloc(),
 ///   act: (bloc) => bloc.add(CounterEvent.increment),
 ///   wait: const Duration(milliseconds: 300),
-///   expect: [0, 1],
+///   expect: [1],
+/// );
+/// ```
+///
+/// [blocTest] can also be used to [verify] internal bloc functionality.
+///
+/// ```dart
+/// blocTest(
+///   'CounterBloc emits [1] when CounterEvent.increment is added',
+///   build: () async => CounterBloc(),
+///   act: (bloc) => bloc.add(CounterEvent.increment),
+///   expect: [1],
+///   verify: (_) async {
+///     verify(repository.someMethod(any)).called(1);
+///   }
 /// );
 /// ```
 ///
@@ -78,30 +98,31 @@ import 'package:test/test.dart' as test;
 ///
 /// ```dart
 /// blocTest(
-///  'emits [StateA, StateB] when MyEvent is added',
-///  build: () => MyBloc(),
+///  'emits [StateB] when MyEvent is added',
+///  build: () async => MyBloc(),
 ///  act: (bloc) => bloc.add(MyEvent()),
-///  expect: [isA<StateA>(), isA<StateB>()],
+///  expect: [isA<StateB>()],
 /// );
 /// ```
 @isTest
 void blocTest<B extends Bloc<Event, State>, Event, State>(
   String description, {
-  @required B Function() build,
-  @required Iterable expect,
+  @required Future<B> Function() build,
   Future<void> Function(B bloc) act,
   Duration wait,
-  Future<void> Function() verify,
+  int skip = 1,
+  Iterable expect,
+  Future<void> Function(B bloc) verify,
 }) {
   test.test(description, () async {
-    final bloc = build();
+    final bloc = await build();
     final states = <State>[];
-    final subscription = bloc.listen(states.add);
+    final subscription = bloc.skip(skip).listen(states.add);
     await act?.call(bloc);
     if (wait != null) await Future.delayed(wait);
     await bloc.close();
     test.expect(states, expect);
     await subscription.cancel();
-    await verify?.call();
+    await verify?.call(bloc);
   });
 }

--- a/packages/bloc_test/lib/src/emits_exactly.dart
+++ b/packages/bloc_test/lib/src/emits_exactly.dart
@@ -8,10 +8,10 @@ import 'package:test/test.dart';
 /// they were provided.
 ///
 /// ```dart
-/// test('emits [0, 1] when CounterEvent.increment is added', () async {
+/// test('emits [1] when CounterEvent.increment is added', () async {
 ///   final bloc = CounterBloc();
 ///   bloc.add(CounterEvent.increment);
-///   await emitsExactly(bloc, [0, 1]);
+///   await emitsExactly(bloc, [1]);
 /// });
 /// ```
 ///
@@ -19,10 +19,22 @@ import 'package:test/test.dart';
 /// which don't override `==` and `hashCode`.
 ///
 /// ```dart
-/// test('emits [StateA, StateB] when EventB is added', () async {
+/// test('emits [StateB] when EventB is added', () async {
 ///   final bloc = MyBloc();
 ///   bloc.add(EventB());
-///   await emitsExactly(bloc, [isA<StateA>(), isA<StateB>()]);
+///   await emitsExactly(bloc, [isA<StateB>()]);
+/// });
+/// ```
+///
+/// [skip] is an optional `int` which defaults to 1 and can be used to skip any
+/// number of states. The default behavior skips the `initialState` of the bloc
+/// but can be overridden to include the `initialState` by setting it to 0.
+///
+/// ```dart
+/// test('emits [0, 1] when CounterEvent.increment is added', () async {
+///   final bloc = CounterBloc();
+///   bloc.add(CounterEvent.increment);
+///   await emitsExactly(bloc, [0, 1], skip: 0);
 /// });
 /// ```
 ///
@@ -30,12 +42,12 @@ import 'package:test/test.dart';
 /// where the [bloc] is using `debounceTime` or other similar operators.
 ///
 /// ```dart
-/// test('emits [0, 1] when CounterEvent.increment is added', () async {
+/// test('emits [1] when CounterEvent.increment is added', () async {
 ///   final bloc = CounterBloc();
 ///   bloc.add(CounterEvent.increment);
 ///   await emitsExactly(
 ///     bloc,
-///     [0, 1],
+///     [1],
 ///     duration: const Duration(milliseconds: 300),
 ///   );
 /// });
@@ -44,10 +56,11 @@ Future<void> emitsExactly<B extends Bloc<dynamic, State>, State>(
   B bloc,
   Iterable expected, {
   Duration duration,
+  int skip = 1,
 }) async {
   assert(bloc != null);
   final states = <State>[];
-  final subscription = bloc.listen(states.add);
+  final subscription = bloc.skip(skip).listen(states.add);
   if (duration != null) await Future.delayed(duration);
   await bloc.close();
   expect(states, expected);

--- a/packages/bloc_test/test/bloc_test_test.dart
+++ b/packages/bloc_test/test/bloc_test_test.dart
@@ -196,6 +196,15 @@ void main() {
           verify(repository.sideEffect()).called(1);
         },
       );
+
+      blocTest(
+        'does not require an expect',
+        build: () async => SideEffectCounterBloc(repository),
+        act: (bloc) => bloc.add(SideEffectCounterEvent.increment),
+        verify: (_) async {
+          verify(repository.sideEffect()).called(1);
+        },
+      );
     });
   });
 }

--- a/packages/bloc_test/test/bloc_test_test.dart
+++ b/packages/bloc_test/test/bloc_test_test.dart
@@ -12,123 +12,158 @@ void main() {
   group('blocTest', () {
     group('CounterBloc', () {
       blocTest(
-        'emits [0] when nothing is added',
-        build: () => CounterBloc(),
+        'emits [] when nothing is added',
+        build: () async => CounterBloc(),
+        expect: [],
+      );
+
+      blocTest(
+        'emits [0] when nothing is added and skip: 0',
+        build: () async => CounterBloc(),
+        skip: 0,
         expect: [0],
       );
 
       blocTest(
-        'emits [0, 1] when CounterEvent.increment is added',
-        build: () => CounterBloc(),
+        'emits [1] when CounterEvent.increment is added',
+        build: () async => CounterBloc(),
         act: (bloc) => bloc.add(CounterEvent.increment),
-        expect: [0, 1],
+        expect: [1],
       );
 
       blocTest(
-        'emits [0, 1] when CounterEvent.increment is added with async act',
-        build: () => CounterBloc(),
+        'emits [1] when CounterEvent.increment is added with async act',
+        build: () async => CounterBloc(),
         act: (bloc) async {
           await Future.delayed(Duration(seconds: 1));
           bloc.add(CounterEvent.increment);
         },
-        expect: [0, 1],
+        expect: [1],
       );
 
       blocTest(
-        'emits [0, 1, 2] when CounterEvent.increment is called multiple times'
+        'emits [1, 2] when CounterEvent.increment is called multiple times'
         'with async act',
-        build: () => CounterBloc(),
+        build: () async => CounterBloc(),
         act: (bloc) async {
           bloc.add(CounterEvent.increment);
           await Future.delayed(Duration(milliseconds: 10));
           bloc.add(CounterEvent.increment);
         },
-        expect: [0, 1, 2],
+        expect: [1, 2],
       );
     });
 
     group('AsyncCounterBloc', () {
       blocTest(
-        'emits [0] when nothing is added',
-        build: () => AsyncCounterBloc(),
+        'emits [] when nothing is added',
+        build: () async => AsyncCounterBloc(),
+        expect: [],
+      );
+
+      blocTest(
+        'emits [0] when nothing is added and skip: 0',
+        build: () async => AsyncCounterBloc(),
+        skip: 0,
         expect: [0],
       );
 
       blocTest(
-        'emits [0, 1] when AsyncCounterEvent.increment is added',
-        build: () => AsyncCounterBloc(),
+        'emits [1] when AsyncCounterEvent.increment is added',
+        build: () async => AsyncCounterBloc(),
         act: (bloc) => bloc.add(AsyncCounterEvent.increment),
-        expect: [0, 1],
+        expect: [1],
       );
 
       blocTest(
-        'emits [0, 1, 2] when AsyncCounterEvent.increment is called multiple'
+        'emits [1, 2] when AsyncCounterEvent.increment is called multiple'
         'times with async act',
-        build: () => AsyncCounterBloc(),
+        build: () async => AsyncCounterBloc(),
         act: (bloc) async {
           bloc.add(AsyncCounterEvent.increment);
           await Future.delayed(Duration(milliseconds: 10));
           bloc.add(AsyncCounterEvent.increment);
         },
-        expect: [0, 1, 2],
+        expect: [1, 2],
       );
     });
 
     group('DebounceCounterBloc', () {
       blocTest(
-        'emits [0] when nothing is added',
-        build: () => DebounceCounterBloc(),
+        'emits [] when nothing is added',
+        build: () async => DebounceCounterBloc(),
+        expect: [],
+      );
+
+      blocTest(
+        'emits [0] when nothing is added and skip: 0',
+        build: () async => DebounceCounterBloc(),
+        skip: 0,
         expect: [0],
       );
 
       blocTest(
-        'emits [0, 1] when DebounceCounterEvent.increment is added',
-        build: () => DebounceCounterBloc(),
+        'emits [1] when DebounceCounterEvent.increment is added',
+        build: () async => DebounceCounterBloc(),
         act: (bloc) => bloc.add(DebounceCounterEvent.increment),
         wait: const Duration(milliseconds: 300),
-        expect: [0, 1],
+        expect: [1],
       );
     });
 
     group('MultiCounterBloc', () {
       blocTest(
-        'emits [0] when nothing is added',
-        build: () => MultiCounterBloc(),
+        'emits [] when nothing is added',
+        build: () async => MultiCounterBloc(),
+        expect: [],
+      );
+
+      blocTest(
+        'emits [0] when nothing is added and skip: 0',
+        build: () async => MultiCounterBloc(),
+        skip: 0,
         expect: [0],
       );
 
       blocTest(
-        'emits [0, 1, 2] when MultiCounterEvent.increment is added',
-        build: () => MultiCounterBloc(),
+        'emits [1, 2] when MultiCounterEvent.increment is added',
+        build: () async => MultiCounterBloc(),
         act: (bloc) => bloc.add(MultiCounterEvent.increment),
-        expect: [0, 1, 2],
+        expect: [1, 2],
       );
 
       blocTest(
-        'emits [0, 1, 2, 3, 4] when MultiCounterEvent.increment is called'
+        'emits [1, 2, 3, 4] when MultiCounterEvent.increment is called'
         'multiple times with async act',
-        build: () => MultiCounterBloc(),
+        build: () async => MultiCounterBloc(),
         act: (bloc) async {
           bloc.add(MultiCounterEvent.increment);
           await Future.delayed(Duration(milliseconds: 10));
           bloc.add(MultiCounterEvent.increment);
         },
-        expect: [0, 1, 2, 3, 4],
+        expect: [1, 2, 3, 4],
       );
     });
 
     group('ComplexBloc', () {
       blocTest(
-        'emits [ComplexStateA] when nothing is added',
-        build: () => ComplexBloc(),
+        'emits [] when nothing is added',
+        build: () async => ComplexBloc(),
+        expect: [],
+      );
+
+      blocTest(
+        'emits [ComplexStateA] when nothing is added and skip: 0',
+        build: () async => ComplexBloc(),
+        skip: 0,
         expect: [isA<ComplexStateA>()],
       );
 
       blocTest(
-        'emits [ComplexStateA, ComplexStateB] when ComplexEventB is added',
-        build: () => ComplexBloc(),
+        'emits [ComplexStateB] when ComplexEventB is added',
+        build: () async => ComplexBloc(),
         act: (bloc) => bloc.add(ComplexEventB()),
-        expect: [isA<ComplexStateA>(), isA<ComplexStateB>()],
+        expect: [isA<ComplexStateB>()],
       );
     });
 
@@ -140,17 +175,24 @@ void main() {
       });
 
       blocTest(
-        'emits [0] when nothing is added',
-        build: () => SideEffectCounterBloc(repository),
+        'emits [] when nothing is added',
+        build: () async => SideEffectCounterBloc(repository),
+        expect: [],
+      );
+
+      blocTest(
+        'emits [0] when nothing is added and skip: 0',
+        build: () async => SideEffectCounterBloc(repository),
+        skip: 0,
         expect: [0],
       );
 
       blocTest(
-        'emits [0, 1] when SideEffectCounterEvent.increment is added',
-        build: () => SideEffectCounterBloc(repository),
+        'emits [1] when SideEffectCounterEvent.increment is added',
+        build: () async => SideEffectCounterBloc(repository),
         act: (bloc) => bloc.add(SideEffectCounterEvent.increment),
-        expect: [0, 1],
-        verify: () async {
+        expect: [1],
+        verify: (_) async {
           verify(repository.sideEffect()).called(1);
         },
       );

--- a/packages/bloc_test/test/emits_exactly_test.dart
+++ b/packages/bloc_test/test/emits_exactly_test.dart
@@ -14,22 +14,29 @@ void main() {
     });
 
     group('CounterBloc', () {
-      test('emits [0, 1] when CounterEvent.increment is added', () async {
+      test('emits [1] when CounterEvent.increment is added', () async {
         final bloc = CounterBloc();
         bloc.add(CounterEvent.increment);
-        await emitsExactly(bloc, [0, 1]);
+        await emitsExactly(bloc, [1]);
+      });
+
+      test('emits [0, 1] when CounterEvent.increment is added and skip: 0',
+          () async {
+        final bloc = CounterBloc();
+        bloc.add(CounterEvent.increment);
+        await emitsExactly(bloc, [0, 1], skip: 0);
       });
 
       test('fails if bloc does not emit all states', () async {
         try {
-          await emitsExactly(CounterBloc(), [0, 1]);
+          await emitsExactly(CounterBloc(), [1]);
           fail('should throw');
         } on TestFailure catch (error) {
           expect(
               error.message,
-              'Expected: [0, 1]\n'
-              '  Actual: [0]\n'
-              '   Which: shorter than expected at location [1]\n'
+              'Expected: [1]\n'
+              '  Actual: []\n'
+              '   Which: shorter than expected at location [0]\n'
               '');
         }
       });
@@ -38,14 +45,14 @@ void main() {
         try {
           final bloc = CounterBloc();
           bloc.add(CounterEvent.increment);
-          await emitsExactly(bloc, [0, 2]);
+          await emitsExactly(bloc, [2]);
           fail('should throw');
         } on TestFailure catch (error) {
           expect(
             error.message,
-            'Expected: [0, 2]\n'
-            '  Actual: [0, 1]\n'
-            '   Which: was <1> instead of <2> at location [1]\n'
+            'Expected: [2]\n'
+            '  Actual: [1]\n'
+            '   Which: was <1> instead of <2> at location [0]\n'
             '',
           );
         }
@@ -55,14 +62,14 @@ void main() {
         try {
           final bloc = CounterBloc();
           bloc.add(CounterEvent.increment);
-          await emitsExactly(bloc, [0, 1, 2]);
+          await emitsExactly(bloc, [1, 2]);
           fail('should throw');
         } on TestFailure catch (error) {
           expect(
             error.message,
-            'Expected: [0, 1, 2]\n'
-            '  Actual: [0, 1]\n'
-            '   Which: shorter than expected at location [2]\n'
+            'Expected: [1, 2]\n'
+            '  Actual: [1]\n'
+            '   Which: shorter than expected at location [1]\n'
             '',
           );
         }
@@ -70,22 +77,29 @@ void main() {
     });
 
     group('AsyncCounterBloc', () {
-      test('emits [0, 1] when CounterEvent.increment is added', () async {
+      test('emits [1] when CounterEvent.increment is added', () async {
         final bloc = AsyncCounterBloc();
         bloc.add(AsyncCounterEvent.increment);
-        await emitsExactly(bloc, [0, 1]);
+        await emitsExactly(bloc, [1]);
+      });
+
+      test('emits [0, 1] when CounterEvent.increment is added and skip: 0',
+          () async {
+        final bloc = AsyncCounterBloc();
+        bloc.add(AsyncCounterEvent.increment);
+        await emitsExactly(bloc, [0, 1], skip: 0);
       });
 
       test('fails if bloc does not emit all states', () async {
         try {
-          await emitsExactly(AsyncCounterBloc(), [0, 1]);
+          await emitsExactly(AsyncCounterBloc(), [1]);
           fail('should throw');
         } on TestFailure catch (error) {
           expect(
               error.message,
-              'Expected: [0, 1]\n'
-              '  Actual: [0]\n'
-              '   Which: shorter than expected at location [1]\n'
+              'Expected: [1]\n'
+              '  Actual: []\n'
+              '   Which: shorter than expected at location [0]\n'
               '');
         }
       });
@@ -94,14 +108,14 @@ void main() {
         try {
           final bloc = AsyncCounterBloc();
           bloc.add(AsyncCounterEvent.increment);
-          await emitsExactly(bloc, [0, 2]);
+          await emitsExactly(bloc, [2]);
           fail('should throw');
         } on TestFailure catch (error) {
           expect(
             error.message,
-            'Expected: [0, 2]\n'
-            '  Actual: [0, 1]\n'
-            '   Which: was <1> instead of <2> at location [1]\n'
+            'Expected: [2]\n'
+            '  Actual: [1]\n'
+            '   Which: was <1> instead of <2> at location [0]\n'
             '',
           );
         }
@@ -111,14 +125,14 @@ void main() {
         try {
           final bloc = AsyncCounterBloc();
           bloc.add(AsyncCounterEvent.increment);
-          await emitsExactly(bloc, [0, 1, 2]);
+          await emitsExactly(bloc, [1, 2]);
           fail('should throw');
         } on TestFailure catch (error) {
           expect(
             error.message,
-            'Expected: [0, 1, 2]\n'
-            '  Actual: [0, 1]\n'
-            '   Which: shorter than expected at location [2]\n'
+            'Expected: [1, 2]\n'
+            '  Actual: [1]\n'
+            '   Which: shorter than expected at location [1]\n'
             '',
           );
         }
@@ -126,23 +140,35 @@ void main() {
     });
 
     group('DebounceCounterBloc', () {
-      test('emits [0, 1] when CounterEvent.increment is added', () async {
+      test('emits [1] when CounterEvent.increment is added', () async {
         final bloc = DebounceCounterBloc();
         bloc.add(DebounceCounterEvent.increment);
-        await emitsExactly(bloc, [0, 1],
+        await emitsExactly(bloc, [1],
             duration: const Duration(milliseconds: 305));
+      });
+
+      test('emits [0, 1] when CounterEvent.increment is added and skip: 0',
+          () async {
+        final bloc = DebounceCounterBloc();
+        bloc.add(DebounceCounterEvent.increment);
+        await emitsExactly(
+          bloc,
+          [0, 1],
+          duration: const Duration(milliseconds: 305),
+          skip: 0,
+        );
       });
 
       test('fails if bloc does not emit all states', () async {
         try {
-          await emitsExactly(DebounceCounterBloc(), [0, 1]);
+          await emitsExactly(DebounceCounterBloc(), [1]);
           fail('should throw');
         } on TestFailure catch (error) {
           expect(
               error.message,
-              'Expected: [0, 1]\n'
-              '  Actual: [0]\n'
-              '   Which: shorter than expected at location [1]\n'
+              'Expected: [1]\n'
+              '  Actual: []\n'
+              '   Which: shorter than expected at location [0]\n'
               '');
         }
       });
@@ -151,15 +177,15 @@ void main() {
         try {
           final bloc = DebounceCounterBloc();
           bloc.add(DebounceCounterEvent.increment);
-          await emitsExactly(bloc, [0, 2],
+          await emitsExactly(bloc, [2],
               duration: const Duration(milliseconds: 305));
           fail('should throw');
         } on TestFailure catch (error) {
           expect(
             error.message,
-            'Expected: [0, 2]\n'
-            '  Actual: [0, 1]\n'
-            '   Which: was <1> instead of <2> at location [1]\n'
+            'Expected: [2]\n'
+            '  Actual: [1]\n'
+            '   Which: was <1> instead of <2> at location [0]\n'
             '',
           );
         }
@@ -171,16 +197,16 @@ void main() {
           bloc.add(DebounceCounterEvent.increment);
           await emitsExactly(
             bloc,
-            [0, 1, 2],
+            [1, 2],
             duration: const Duration(milliseconds: 305),
           );
           fail('should throw');
         } on TestFailure catch (error) {
           expect(
             error.message,
-            'Expected: [0, 1, 2]\n'
-            '  Actual: [0, 1]\n'
-            '   Which: shorter than expected at location [2]\n'
+            'Expected: [1, 2]\n'
+            '  Actual: [1]\n'
+            '   Which: shorter than expected at location [1]\n'
             '',
           );
         }
@@ -188,22 +214,29 @@ void main() {
     });
 
     group('MultiCounterBloc', () {
-      test('emits [0, 1, 2] when CounterEvent.increment is added', () async {
+      test('emits [1, 2] when CounterEvent.increment is added', () async {
         final bloc = MultiCounterBloc();
         bloc.add(MultiCounterEvent.increment);
-        await emitsExactly(bloc, [0, 1, 2]);
+        await emitsExactly(bloc, [1, 2]);
+      });
+
+      test('emits [0, 1, 2] when CounterEvent.increment is added and skip: 0',
+          () async {
+        final bloc = MultiCounterBloc();
+        bloc.add(MultiCounterEvent.increment);
+        await emitsExactly(bloc, [0, 1, 2], skip: 0);
       });
 
       test('fails if bloc does not emit all states', () async {
         try {
-          await emitsExactly(MultiCounterBloc(), [0, 1]);
+          await emitsExactly(MultiCounterBloc(), [1]);
           fail('should throw');
         } on TestFailure catch (error) {
           expect(
               error.message,
-              'Expected: [0, 1]\n'
-              '  Actual: [0]\n'
-              '   Which: shorter than expected at location [1]\n'
+              'Expected: [1]\n'
+              '  Actual: []\n'
+              '   Which: shorter than expected at location [0]\n'
               '');
         }
       });
@@ -212,14 +245,14 @@ void main() {
         try {
           final bloc = MultiCounterBloc();
           bloc.add(MultiCounterEvent.increment);
-          await emitsExactly(bloc, [0, 2]);
+          await emitsExactly(bloc, [2]);
           fail('should throw');
         } on TestFailure catch (error) {
           expect(
             error.message,
-            'Expected: [0, 2]\n'
-            '  Actual: [0, 1, 2]\n'
-            '   Which: was <1> instead of <2> at location [1]\n'
+            'Expected: [2]\n'
+            '  Actual: [1, 2]\n'
+            '   Which: was <1> instead of <2> at location [0]\n'
             '',
           );
         }
@@ -229,14 +262,14 @@ void main() {
         try {
           final bloc = MultiCounterBloc();
           bloc.add(MultiCounterEvent.increment);
-          await emitsExactly(bloc, [0, 1, 2, 3]);
+          await emitsExactly(bloc, [1, 2, 3]);
           fail('should throw');
         } on TestFailure catch (error) {
           expect(
             error.message,
-            'Expected: [0, 1, 2, 3]\n'
-            '  Actual: [0, 1, 2]\n'
-            '   Which: shorter than expected at location [3]\n'
+            'Expected: [1, 2, 3]\n'
+            '  Actual: [1, 2]\n'
+            '   Which: shorter than expected at location [2]\n'
             '',
           );
         }
@@ -244,25 +277,35 @@ void main() {
     });
 
     group('ComplexBloc', () {
-      test('emits [ComplexStateA, ComplexStateB] when ComplexEventB is added',
-          () async {
+      test('emits [ComplexStateB] when ComplexEventB is added', () async {
         final bloc = ComplexBloc();
         bloc.add(ComplexEventB());
-        await emitsExactly(bloc, [isA<ComplexStateA>(), isA<ComplexStateB>()]);
+        await emitsExactly(bloc, [isA<ComplexStateB>()]);
+      });
+
+      test(
+          'emits [ComplexStateA, ComplexStateB] when ComplexEventB '
+          'is added and skip: 0', () async {
+        final bloc = ComplexBloc();
+        bloc.add(ComplexEventB());
+        await emitsExactly(
+          bloc,
+          [isA<ComplexStateA>(), isA<ComplexStateB>()],
+          skip: 0,
+        );
       });
 
       test('fails if bloc does not emit all states', () async {
         try {
-          await emitsExactly(
-              ComplexBloc(), [isA<ComplexStateA>(), isA<ComplexStateB>()]);
+          await emitsExactly(ComplexBloc(), [isA<ComplexStateB>()]);
           fail('should throw');
         } on TestFailure catch (error) {
           expect(
               error.message,
               // ignore: lines_longer_than_80_chars
-              'Expected: [<<Instance of \'ComplexStateA\'>>, <<Instance of \'ComplexStateB\'>>]\n'
-              '  Actual: [Instance of \'ComplexStateA\']\n'
-              '   Which: shorter than expected at location [1]\n'
+              'Expected: [<<Instance of \'ComplexStateB\'>>]\n'
+              '  Actual: []\n'
+              '   Which: shorter than expected at location [0]\n'
               '');
         }
       });
@@ -273,18 +316,18 @@ void main() {
           bloc.add(ComplexEventA());
           await emitsExactly(
             bloc,
-            [isA<ComplexStateA>(), isA<ComplexStateB>()],
+            [isA<ComplexStateB>()],
           );
           fail('should throw');
         } on TestFailure catch (error) {
           expect(
               error.message,
               // ignore: lines_longer_than_80_chars
-              'Expected: [<<Instance of \'ComplexStateA\'>>, <<Instance of \'ComplexStateB\'>>]\n'
+              'Expected: [<<Instance of \'ComplexStateB\'>>]\n'
               // ignore: lines_longer_than_80_chars
-              '  Actual: [Instance of \'ComplexStateA\', Instance of \'ComplexStateA\']\n'
+              '  Actual: [Instance of \'ComplexStateA\']\n'
               // ignore: lines_longer_than_80_chars
-              '   Which: does not match <Instance of \'ComplexStateB\'> at location [1]\n'
+              '   Which: does not match <Instance of \'ComplexStateB\'> at location [0]\n'
               '');
         }
       });
@@ -295,20 +338,17 @@ void main() {
           bloc.add(ComplexEventB());
           await emitsExactly(
             bloc,
-            [isA<ComplexStateA>(), isA<ComplexStateB>(), isA<ComplexStateA>()],
+            [isA<ComplexStateB>(), isA<ComplexStateA>()],
           );
           fail('should throw');
         } on TestFailure catch (error) {
           expect(
               error.message,
-              'Expected: [\n'
-              '            <<Instance of \'ComplexStateA\'>>,\n'
-              '            <<Instance of \'ComplexStateB\'>>,\n'
-              '            <<Instance of \'ComplexStateA\'>>\n'
-              '          ]\n'
               // ignore: lines_longer_than_80_chars
-              '  Actual: [Instance of \'ComplexStateA\', Instance of \'ComplexStateB\']\n'
-              '   Which: shorter than expected at location [2]\n'
+              'Expected: [<<Instance of \'ComplexStateB\'>>, <<Instance of \'ComplexStateA\'>>]\n'
+              // ignore: lines_longer_than_80_chars
+              '  Actual: [Instance of \'ComplexStateB\']\n'
+              '   Which: shorter than expected at location [1]\n'
               '');
         }
       });

--- a/packages/bloc_test/test/emits_exactly_test.dart
+++ b/packages/bloc_test/test/emits_exactly_test.dart
@@ -302,7 +302,6 @@ void main() {
         } on TestFailure catch (error) {
           expect(
               error.message,
-              // ignore: lines_longer_than_80_chars
               'Expected: [<<Instance of \'ComplexStateB\'>>]\n'
               '  Actual: []\n'
               '   Which: shorter than expected at location [0]\n'
@@ -322,9 +321,7 @@ void main() {
         } on TestFailure catch (error) {
           expect(
               error.message,
-              // ignore: lines_longer_than_80_chars
               'Expected: [<<Instance of \'ComplexStateB\'>>]\n'
-              // ignore: lines_longer_than_80_chars
               '  Actual: [Instance of \'ComplexStateA\']\n'
               // ignore: lines_longer_than_80_chars
               '   Which: does not match <Instance of \'ComplexStateB\'> at location [0]\n'
@@ -346,7 +343,6 @@ void main() {
               error.message,
               // ignore: lines_longer_than_80_chars
               'Expected: [<<Instance of \'ComplexStateB\'>>, <<Instance of \'ComplexStateA\'>>]\n'
-              // ignore: lines_longer_than_80_chars
               '  Actual: [Instance of \'ComplexStateB\']\n'
               '   Which: shorter than expected at location [1]\n'
               '');


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
YES

## Description
Closes #910

### blocTest

#### Async Build

**Before:**
```dart
blocTest(
  '...',
  build: () => MyBloc(),
  ...
);
```

**After:**
```dart
blocTest(
  '...',
  build: () async => MyBloc(),
  ...
);
```

#### Skip InitialState by Default

**Before:**
```dart
blocTest(
  build: () async => CounterBloc(),
  act: (bloc) => bloc.add(CounterEvent.increment),
  expect: [0, 1],
);
```

**After:**
```dart
blocTest(
  build: () async => CounterBloc(),
  act: (bloc) => bloc.add(CounterEvent.increment),
  expect: [1],
);
```

#### Optional Skip (defaults to 1)
```dart
blocTest(
  build: () async => CounterBloc(),
  act: (bloc) => bloc.add(CounterEvent.increment),
  skip: 0,
  expect: [0, 1],
);
```

#### Verify Accepts Bloc as Parameter

**Before:**
```dart
blocTest(
  ...
  verify: () async { ... }
);
```

**After:**
```dart
blocTest(
  ...
  verify: (bloc) async { ... }
);
```

### emitsExactly

#### Skip InitialState by Default

**Before:**
```dart
test('emits [0, 1] when CounterEvent.increment is added', () async {
  final bloc = CounterBloc();
  bloc.add(CounterEvent.increment);
  await emitsExactly(bloc, [0, 1]);
});
```

**After:**
```dart
test('emits [1] when CounterEvent.increment is added', () async {
  final bloc = CounterBloc();
  bloc.add(CounterEvent.increment);
  await emitsExactly(bloc, [1]);
});
```

#### Optional Skip (defaults to 1)
```dart
test('emits [0, 1] when CounterEvent.increment is added', () async {
  final bloc = CounterBloc();
  bloc.add(CounterEvent.increment);
  await emitsExactly(bloc, [0, 1], skip: 0);
});
```

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
- Breaking changes to `blocTest` which will be included in v4.0.0.