### PR TITLE
Fix stacktrace of onError methods

### DIFF
--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -81,7 +81,7 @@ abstract class Bloc<Event, State> extends Stream<State> implements Sink<Event> {
 
   /// Notifies the [bloc] of a new [event] which triggers [mapEventToState].
   /// If [close] has already been called, any subsequent calls to [add] will
-  /// be delegated to the [onError] method which can be overriden at the [bloc]
+  /// be delegated to the [onError] method which can be overridden at the [bloc]
   /// as well as the [BlocDelegate] level.
   @override
   void add(Event event) {

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -89,8 +89,8 @@ abstract class Bloc<Event, State> extends Stream<State> implements Sink<Event> {
       BlocSupervisor.delegate.onEvent(this, event);
       onEvent(event);
       _eventController.add(event);
-    } on dynamic catch (error) {
-      _handleError(error);
+    } on dynamic catch (error, stacktrace) {
+      _handleError(error, stacktrace);
     }
   }
 
@@ -199,8 +199,8 @@ abstract class Bloc<Event, State> extends Stream<State> implements Sink<Event> {
           onTransition(transition);
           _state = transition.nextState;
           _stateController.add(transition.nextState);
-        } on dynamic catch (error) {
-          _handleError(error);
+        } on dynamic catch (error, stacktrace) {
+          _handleError(error, stacktrace);
         }
       },
       onError: _handleError,

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -601,7 +601,7 @@ void main() {
             (capturedError as StateError).message,
             'Cannot add new events after calling close',
           );
-          expect(capturedStacktrace, isNull);
+          expect(capturedStacktrace, isNotNull);
         });
 
         bloc.close();
@@ -669,7 +669,7 @@ void main() {
           emitsInOrder(<int>[0]),
         ).then((_) {
           expect(expectedError, error);
-          expect(expectedStacktrace, isNull);
+          expect(expectedStacktrace, isNotNull);
           expect(bloc.state, 0);
         });
         bloc.add(CounterEvent.increment);


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
The `stacktrace` was always `null` in `onError` methods, I have fixed it and also fixed the tests since they failed after the change.