### PR TITLE
Add optional dispose callback to RepositoryProvider

### DIFF
--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -256,6 +256,18 @@ context.repository<RepositoryA>();
 RepositoryProvider.of<RepositoryA>(context)
 ```
 
+The repository can be optionally disposed via the `dispose` callback. `dispose` will be called when `RepositoryProvider` is unmounted from the widget tree.
+
+```dart
+RepositoryProvider(
+  create: (context) => RepositoryA(),
+  dispose: (context, repository) {
+    // dispose logic goes here
+  }
+  child: ChildA(),
+);
+```
+
 ### MultiRepositoryProvider
 
 **MultiRepositoryProvider** is a Flutter widget that merges multiple `RepositoryProvider` widgets into one.

--- a/packages/flutter_bloc/CHANGELOG.md
+++ b/packages/flutter_bloc/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.3.0
+
+- Add optional `dispose` callback to `RepositoryProvider` ([#952](https://github.com/felangel/bloc/issues/952))
+
 # 3.2.0
 
 - Fix type inference for: `MultiBlocProvider`, `MultiRepositoryProvider`, `MultiBlocListener` ([#773](https://github.com/felangel/bloc/pull/773))

--- a/packages/flutter_bloc/README.md
+++ b/packages/flutter_bloc/README.md
@@ -257,6 +257,18 @@ context.repository<RepositoryA>();
 RepositoryProvider.of<RepositoryA>(context)
 ```
 
+The repository can be optionally disposed via the `dispose` callback. `dispose` will be called when `RepositoryProvider` is unmounted from the widget tree.
+
+```dart
+RepositoryProvider(
+  create: (context) => RepositoryA(),
+  dispose: (context, repository) {
+    // dispose logic goes here
+  }
+  child: ChildA(),
+);
+```
+
 **MultiRepositoryProvider** is a Flutter widget that merges multiple `RepositoryProvider` widgets into one.
 `MultiRepositoryProvider` improves the readability and eliminates the need to nest multiple `RepositoryProvider`.
 By using `MultiRepositoryProvider` we can go from:

--- a/packages/flutter_bloc/lib/src/repository_provider.dart
+++ b/packages/flutter_bloc/lib/src/repository_provider.dart
@@ -21,6 +21,20 @@ mixin RepositoryProviderSingleChildWidget on SingleChildWidget {}
 ///   child: ChildA(),
 /// );
 /// ```
+///
+/// The repository can be optionally disposed via the [dispose] callback.
+/// [dispose] will be called when [RepositoryProvider]
+/// is unmounted from the widget tree.
+///
+/// ```dart
+/// RepositoryProvider(
+///   create: (context) => RepositoryA(),
+///   dispose: (context, repository) {
+///     // dispose logic goes here
+///   }
+///   child: ChildA(),
+/// );
+/// ```
 /// {@endtemplate}
 class RepositoryProvider<T> extends Provider<T>
     with RepositoryProviderSingleChildWidget {
@@ -28,12 +42,13 @@ class RepositoryProvider<T> extends Provider<T>
   RepositoryProvider({
     Key key,
     @required Create<T> create,
+    Dispose<T> dispose,
     Widget child,
     bool lazy,
   }) : super(
           key: key,
           create: create,
-          dispose: (_, __) {},
+          dispose: dispose,
           child: child,
           lazy: lazy,
         );

--- a/packages/flutter_bloc/test/repository_provider_test.dart
+++ b/packages/flutter_bloc/test/repository_provider_test.dart
@@ -133,7 +133,9 @@ class RoutePage extends StatelessWidget {
         key: Key('route_button'),
         onPressed: () {
           Navigator.of(context).pushReplacement(
-            MaterialPageRoute<Widget>(builder: (context) => Container()),
+            MaterialPageRoute<Widget>(
+              builder: (context) => Container(),
+            ),
           );
         },
       ),
@@ -192,6 +194,26 @@ void main() {
         ),
       );
       expect(createCalled, isTrue);
+    });
+
+    testWidgets('can override dispose', (tester) async {
+      var disposeCalled = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RepositoryProvider(
+            create: (_) => Repository(0),
+            lazy: false,
+            dispose: (context, repository) {
+              disposeCalled = true;
+            },
+            child: RoutePage(),
+          ),
+        ),
+      );
+      expect(disposeCalled, isFalse);
+      await tester.tap(find.byKey(Key('route_button')));
+      await tester.pumpAndSettle();
+      expect(disposeCalled, isTrue);
     });
 
     testWidgets('passes value to children via builder', (tester) async {


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Add optional `dispose` callback to `RepositoryProvider`
- Closes #952 

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
New feature which will be included in `flutter_bloc v3.3.0`