### PR TITLE
Fix syntax highlighting in bloc_provider.dart

### DIFF
--- a/packages/flutter_bloc/lib/src/bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/bloc_provider.dart
@@ -68,6 +68,7 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>>
   ///   value: BlocProvider.of<BlocA>(context),
   ///   child: ScreenA(),
   /// );
+  /// ```
   BlocProvider.value({
     Key key,
     @required T value,


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
Github's syntax highlighting is broken starting from [this line](https://github.com/felangel/bloc/blob/3112783f581b0e1966b544b31cd74f473ea96bf9/packages/flutter_bloc/lib/src/bloc_provider.dart#L70).