### PR TITLE
Remove try catch block in Auth Bloc in Firebase Login example

### DIFF
--- a/examples/flutter_firebase_login/lib/authentication_bloc/authentication_bloc.dart
+++ b/examples/flutter_firebase_login/lib/authentication_bloc/authentication_bloc.dart
@@ -32,7 +32,6 @@ class AuthenticationBloc
   }
 
   Stream<AuthenticationState> _mapAppStartedToState() async* {
- 
       final isSignedIn = await _userRepository.isSignedIn();
       if (isSignedIn) {
         final name = await _userRepository.getUser();
@@ -40,7 +39,6 @@ class AuthenticationBloc
       } else {
         yield Unauthenticated();
       }
-    
   }
 
   Stream<AuthenticationState> _mapLoggedInToState() async* {

--- a/examples/flutter_firebase_login/lib/authentication_bloc/authentication_bloc.dart
+++ b/examples/flutter_firebase_login/lib/authentication_bloc/authentication_bloc.dart
@@ -32,13 +32,13 @@ class AuthenticationBloc
   }
 
   Stream<AuthenticationState> _mapAppStartedToState() async* {
-      final isSignedIn = await _userRepository.isSignedIn();
-      if (isSignedIn) {
-        final name = await _userRepository.getUser();
-        yield Authenticated(name);
-      } else {
-        yield Unauthenticated();
-      }
+    final isSignedIn = await _userRepository.isSignedIn();
+    if (isSignedIn) {
+      final name = await _userRepository.getUser();
+      yield Authenticated(name);
+    } else {
+      yield Unauthenticated();
+    }
   }
 
   Stream<AuthenticationState> _mapLoggedInToState() async* {

--- a/examples/flutter_firebase_login/lib/authentication_bloc/authentication_bloc.dart
+++ b/examples/flutter_firebase_login/lib/authentication_bloc/authentication_bloc.dart
@@ -32,7 +32,7 @@ class AuthenticationBloc
   }
 
   Stream<AuthenticationState> _mapAppStartedToState() async* {
-    try {
+ 
       final isSignedIn = await _userRepository.isSignedIn();
       if (isSignedIn) {
         final name = await _userRepository.getUser();
@@ -40,9 +40,7 @@ class AuthenticationBloc
       } else {
         yield Unauthenticated();
       }
-    } catch (_) {
-      yield Unauthenticated();
-    }
+    
   }
 
   Stream<AuthenticationState> _mapLoggedInToState() async* {


### PR DESCRIPTION
I noticed that in the for state mapping for AppStarted event, the Try Catch block wraps the  _userRepository.isSignedIn(); 

This seems unnecessary since that repository just calls firebase.instance.currentUser() under the hood. The method only returns a Firebase User or a null value.

## Status
**READY**

## Breaking Changes
NO

## Description
Remove unnecessary try catch block in firebase login example


## Todos
Nill

## Steps to Test or Reproduce
Nill

## Impact to Remaining Code Base
This PR will affect:

* simplify firebase login example
