### PR TITLE
Add mapState to bloc_test

### DIFF
--- a/packages/bloc_test/test/bloc_test_test.dart
+++ b/packages/bloc_test/test/bloc_test_test.dart
@@ -165,6 +165,19 @@ void main() {
         act: (bloc) => bloc.add(ComplexEventB()),
         expect: [isA<ComplexStateB>()],
       );
+
+      blocTest(
+        'emits [1, 2, 3] when three ComplexEventA are added',
+        build: () async => ComplexBloc(),
+        act: (bloc) async {
+          bloc
+            ..add(ComplexEventA(1))
+            ..add(ComplexEventA(2))
+            ..add(ComplexEventA(3));
+        },
+        mapState: (state) => state.id,
+        expect: [1, 2, 3],
+      );
     });
 
     group('SideEffectCounterBloc', () {

--- a/packages/bloc_test/test/helpers/complex_bloc.dart
+++ b/packages/bloc_test/test/helpers/complex_bloc.dart
@@ -4,13 +4,21 @@ import 'package:bloc/bloc.dart';
 
 abstract class ComplexEvent {}
 
-class ComplexEventA extends ComplexEvent {}
+class ComplexEventA extends ComplexEvent {
+  ComplexEventA([this.id = 0]);
+  final int id;
+}
 
 class ComplexEventB extends ComplexEvent {}
 
-abstract class ComplexState {}
+abstract class ComplexState {
+  ComplexState([this.id = 0]);
+  final int id;
+}
 
-class ComplexStateA extends ComplexState {}
+class ComplexStateA extends ComplexState {
+  ComplexStateA([int id = 0]) : super(id);
+}
 
 class ComplexStateB extends ComplexState {}
 
@@ -23,7 +31,7 @@ class ComplexBloc extends Bloc<ComplexEvent, ComplexState> {
     ComplexEvent event,
   ) async* {
     if (event is ComplexEventA) {
-      yield ComplexStateA();
+      yield ComplexStateA(event.id);
     } else if (event is ComplexEventB) {
       yield ComplexStateB();
     }


### PR DESCRIPTION
## Status
READY

## Breaking Changes
NO

## Description
Makes `blocTest` simpler by adding a new `mapState` field to it.
That change allow simpler error messages like:

```dart
  Expected: [1, 2, 33]
    Actual: [1, 2, 3]
     Which: was <3> instead of <33> at location [2]
```

Where we are comparing only the wanted part of the state.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------

## Todos
- [x] Tests
- [x] Documentation
- [x] Examples

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

- It adds `mapState` to `blocTest`.

```dart
      blocTest(
        'emits [1, 2, 3] when three ComplexEventA are added',
        build: () async => ComplexBloc(),
        act: (bloc) async {
          bloc
            ..add(ComplexEventA(1))
            ..add(ComplexEventA(2))
            ..add(ComplexEventA(3));
        },
        mapState: (state) => state.id,
        expect: [1, 2, 3],
      );
```

## Impact to Remaining Code Base
This PR will affect:

*  `blocTest` from `bloc_test`
