### PR TITLE
update angular_bloc, bloc_test, and flutter_bloc to bloc v4.0.0-dev.2

### DIFF
--- a/packages/angular_bloc/CHANGELOG.md
+++ b/packages/angular_bloc/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.0-dev.2
+
+Updated to `bloc: ^4.0.0-dev.2`
+
 # 4.0.0-dev.1
 
 Updated to `bloc: ^4.0.0-dev.1`

--- a/packages/angular_bloc/pubspec.yaml
+++ b/packages/angular_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: angular_bloc
 description: Angular Components that make it easy to implement the BLoC (Business Logic Component) design pattern. Built to be used with the bloc state management package.
-version: 4.0.0-dev.1
+version: 4.0.0-dev.2
 repository: https://github.com/felangel/bloc/tree/master/packages/angular_bloc
 issue_tracker: https://github.com/felangel/bloc/issues
 homepage: https://bloclibrary.dev
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   angular: ^5.3.0
-  bloc: ^4.0.0-dev.1
+  bloc: ^4.0.0-dev.2
 
 dev_dependencies:
   angular_test: ^2.3.0

--- a/packages/bloc_test/CHANGELOG.md
+++ b/packages/bloc_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.0.0-dev.2
+
+- Update to `bloc: ^4.0.0-dev.2`
+
 # 5.0.0-dev.1
 
 - Update to `bloc: ^4.0.0-dev.1`

--- a/packages/bloc_test/pubspec.yaml
+++ b/packages/bloc_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc_test
 description: A testing library which makes it easy to test blocs. Built to be used with the bloc state management package.
-version: 5.0.0-dev.1
+version: 5.0.0-dev.2
 repository: https://github.com/felangel/bloc/tree/master/packages/bloc_test
 issue_tracker: https://github.com/felangel/bloc/issues
 homepage: https://bloclibrary.dev
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.6.0 <3.0.0"
 
 dependencies:
-  bloc: ^4.0.0-dev.1
+  bloc: ^4.0.0-dev.2
   mockito: ^4.0.0
   test: ^1.3.0
   meta: ^1.1.6

--- a/packages/flutter_bloc/CHANGELOG.md
+++ b/packages/flutter_bloc/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.0-dev.2
+
+Updated to `bloc: ^4.0.0-dev.2`
+
 # 4.0.0-dev.1
 
 - Updated to `bloc: ^4.0.0-dev.1`

--- a/packages/flutter_bloc/pubspec.yaml
+++ b/packages/flutter_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_bloc
 description: Flutter Widgets that make it easy to implement the BLoC (Business Logic Component) design pattern. Built to be used with the bloc state management package.
-version: 4.0.0-dev.1
+version: 4.0.0-dev.2
 repository: https://github.com/felangel/bloc/tree/master/packages/flutter_bloc
 issue_tracker: https://github.com/felangel/bloc/issues
 homepage: https://bloclibrary.dev
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  bloc: ^4.0.0-dev.1
+  bloc: ^4.0.0-dev.2
   provider: ^4.0.1
 
 dev_dependencies:


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Update to package:bloc v4.0.0-dev.2
  - package:angular_bloc
  - package:flutter_bloc
  - package:bloc_test

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
- Release candidate for `angular_bloc`, `bloc_test`, and `flutter_bloc` packages