### PR TITLE
add mustCallSuper to onEvent, onTransition, and onError

### DIFF
--- a/packages/bloc/CHANGELOG.md
+++ b/packages/bloc/CHANGELOG.md
@@ -1,6 +1,10 @@
+# 4.0.0-dev.3
+
+- Add `mustCallSuper` to `onEvent`, `onTransition`, and `onError`
+
 # 4.0.0-dev.2
 
-- Bugfix: Do not emit duplicate terminating state
+- Fix: remove duplicate terminating state
 
 # 4.0.0-dev.1
 

--- a/packages/bloc/pubspec.yaml
+++ b/packages/bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc
 description: A predictable state management library that helps implement the BLoC (Business Logic Component) design pattern.
-version: 4.0.0-dev.2
+version: 4.0.0-dev.3
 repository: https://github.com/felangel/bloc/tree/master/packages/bloc
 issue_tracker: https://github.com/felangel/bloc/issues
 homepage: https://bloclibrary.dev

--- a/packages/bloc/test/helpers/counter/counter_bloc.dart
+++ b/packages/bloc/test/helpers/counter/counter_bloc.dart
@@ -35,16 +35,19 @@ class CounterBloc extends Bloc<CounterEvent, int> {
 
   @override
   void onEvent(CounterEvent event) {
+    super.onEvent(event);
     onEventCallback?.call(event);
   }
 
   @override
   void onTransition(Transition<CounterEvent, int> transition) {
+    super.onTransition(transition);
     onTransitionCallback?.call(transition);
   }
 
   @override
   void onError(Object error, StackTrace stacktrace) {
+    super.onError(error, stacktrace);
     onErrorCallback?.call(error, stacktrace);
   }
 }

--- a/packages/bloc/test/helpers/counter/on_error_bloc.dart
+++ b/packages/bloc/test/helpers/counter/on_error_bloc.dart
@@ -15,6 +15,7 @@ class OnErrorBloc extends Bloc<CounterEvent, int> {
 
   @override
   void onError(Object error, StackTrace stacktrace) {
+    super.onError(error, stacktrace);
     onErrorCallback(error, stacktrace);
   }
 

--- a/packages/bloc/test/helpers/counter/on_exception_bloc.dart
+++ b/packages/bloc/test/helpers/counter/on_exception_bloc.dart
@@ -15,6 +15,7 @@ class OnExceptionBloc extends Bloc<CounterEvent, int> {
 
   @override
   void onError(Object error, StackTrace stacktrace) {
+    super.onError(error, stacktrace);
     onErrorCallback(error, stacktrace);
   }
 

--- a/packages/bloc/test/helpers/counter/on_transition_error_bloc.dart
+++ b/packages/bloc/test/helpers/counter/on_transition_error_bloc.dart
@@ -15,6 +15,7 @@ class OnTransitionErrorBloc extends Bloc<CounterEvent, int> {
 
   @override
   void onError(Object error, StackTrace stacktrace) {
+    super.onError(error, stacktrace);
     onErrorCallback(error, stacktrace);
   }
 


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
YES

## Description
- Add `mustCallSuper` to `onEvent`, `onTransition`, and `onError`

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
Breaking change which will be included in v4.0.0