### PR TITLE
surface unhandled bloc errors in debug mode

### DIFF
--- a/packages/bloc/CHANGELOG.md
+++ b/packages/bloc/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.0-dev.4
+
+- Surface Unhandled Bloc Errors in Debug Mode
+
 # 4.0.0-dev.3
 
 - Add `mustCallSuper` to `onEvent`, `onTransition`, and `onError`

--- a/packages/bloc/README.md
+++ b/packages/bloc/README.md
@@ -118,8 +118,8 @@ As our app grows and relies on multiple `Blocs`, it becomes useful to see the `T
 class SimpleBlocDelegate extends BlocDelegate {
   @override
   void onTransition(Bloc bloc, Transition transition) {
-    super.onTransition(bloc, transition);
     print(transition);
+    super.onTransition(bloc, transition);
   }
 }
 ```
@@ -150,14 +150,14 @@ If we want to be able to handle any incoming `Events` that are added to a `Bloc`
 class SimpleBlocDelegate extends BlocDelegate {
   @override
   void onEvent(Bloc bloc, Object event) {
-    super.onEvent(bloc, event);
     print(event);
+    super.onEvent(bloc, event);
   }
 
   @override
   void onTransition(Bloc bloc, Transition transition) {
-    super.onTransition(bloc, transition);
     print(transition);
+    super.onTransition(bloc, transition);
   }
 }
 ```
@@ -168,20 +168,20 @@ If we want to be able to handle any `Exceptions` that might be thrown in a `Bloc
 class SimpleBlocDelegate extends BlocDelegate {
   @override
   void onEvent(Bloc bloc, Object event) {
-    super.onEvent(bloc, event);
     print(event);
+    super.onEvent(bloc, event);
   }
 
   @override
   void onTransition(Bloc bloc, Transition transition) {
-    super.onTransition(bloc, transition);
     print(transition);
+    super.onTransition(bloc, transition);
   }
 
   @override
-  void onError(Bloc bloc, Object error, StackTrace stacktrace) {
-    super.onError(bloc, error, stacktrace);
-    print('$error, $stacktrace');
+  void onError(Bloc bloc, Object error, StackTrace stackTrace) {
+    print('$error, $stackTrace');
+    super.onError(bloc, error, stackTrace);
   }
 }
 ```

--- a/packages/bloc/example/main.dart
+++ b/packages/bloc/example/main.dart
@@ -30,20 +30,20 @@ class CounterBloc extends Bloc<CounterEvent, int> {
 class SimpleBlocDelegate extends BlocDelegate {
   @override
   void onEvent(Bloc bloc, Object event) {
-    super.onEvent(bloc, event);
     print('bloc: ${bloc.runtimeType}, event: $event');
+    super.onEvent(bloc, event);
   }
 
   @override
   void onTransition(Bloc bloc, Transition transition) {
-    super.onTransition(bloc, transition);
     print('bloc: ${bloc.runtimeType}, transition: $transition');
+    super.onTransition(bloc, transition);
   }
 
   @override
-  void onError(Bloc bloc, Object error, StackTrace stacktrace) {
-    super.onError(bloc, error, stacktrace);
+  void onError(Bloc bloc, Object error, StackTrace stackTrace) {
     print('bloc: ${bloc.runtimeType}, error: $error');
+    super.onError(bloc, error, stackTrace);
   }
 }
 

--- a/packages/bloc/lib/src/bloc_delegate.dart
+++ b/packages/bloc/lib/src/bloc_delegate.dart
@@ -21,10 +21,10 @@ class BlocDelegate {
   void onTransition(Bloc bloc, Transition transition) => null;
 
   /// Called whenever an [error] is thrown in any [bloc] with the given [bloc],
-  /// [error], and [stacktrace].
-  /// The [stacktrace] argument may be `null` if the state stream received
-  /// an error without a [stacktrace].
+  /// [error], and [stackTrace].
+  /// The [stackTrace] argument may be `null` if the state stream received
+  /// an error without a [stackTrace].
   /// A great spot to add universal error handling.
   @mustCallSuper
-  void onError(Bloc bloc, Object error, StackTrace stacktrace) => null;
+  void onError(Bloc bloc, Object error, StackTrace stackTrace) => null;
 }

--- a/packages/bloc/pubspec.yaml
+++ b/packages/bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc
 description: A predictable state management library that helps implement the BLoC (Business Logic Component) design pattern.
-version: 4.0.0-dev.3
+version: 4.0.0-dev.4
 repository: https://github.com/felangel/bloc/tree/master/packages/bloc
 issue_tracker: https://github.com/felangel/bloc/issues
 homepage: https://bloclibrary.dev

--- a/packages/bloc/test/helpers/counter/counter_bloc.dart
+++ b/packages/bloc/test/helpers/counter/counter_bloc.dart
@@ -4,7 +4,7 @@ import 'package:bloc/bloc.dart';
 
 typedef OnEventCallback = Function(CounterEvent);
 typedef OnTransitionCallback = Function(Transition<CounterEvent, int>);
-typedef OnErrorCallback = Function(Object error, StackTrace stacktrace);
+typedef OnErrorCallback = Function(Object error, StackTrace stackTrace);
 
 enum CounterEvent { increment, decrement }
 
@@ -35,19 +35,19 @@ class CounterBloc extends Bloc<CounterEvent, int> {
 
   @override
   void onEvent(CounterEvent event) {
-    super.onEvent(event);
     onEventCallback?.call(event);
+    super.onEvent(event);
   }
 
   @override
   void onTransition(Transition<CounterEvent, int> transition) {
-    super.onTransition(transition);
     onTransitionCallback?.call(transition);
+    super.onTransition(transition);
   }
 
   @override
-  void onError(Object error, StackTrace stacktrace) {
-    super.onError(error, stacktrace);
-    onErrorCallback?.call(error, stacktrace);
+  void onError(Object error, StackTrace stackTrace) {
+    onErrorCallback?.call(error, stackTrace);
+    super.onError(error, stackTrace);
   }
 }

--- a/packages/bloc/test/helpers/counter/on_error_bloc.dart
+++ b/packages/bloc/test/helpers/counter/on_error_bloc.dart
@@ -14,9 +14,9 @@ class OnErrorBloc extends Bloc<CounterEvent, int> {
   int get initialState => 0;
 
   @override
-  void onError(Object error, StackTrace stacktrace) {
-    super.onError(error, stacktrace);
-    onErrorCallback(error, stacktrace);
+  void onError(Object error, StackTrace stackTrace) {
+    onErrorCallback(error, stackTrace);
+    super.onError(error, stackTrace);
   }
 
   @override

--- a/packages/bloc/test/helpers/counter/on_exception_bloc.dart
+++ b/packages/bloc/test/helpers/counter/on_exception_bloc.dart
@@ -14,9 +14,9 @@ class OnExceptionBloc extends Bloc<CounterEvent, int> {
   int get initialState => 0;
 
   @override
-  void onError(Object error, StackTrace stacktrace) {
-    super.onError(error, stacktrace);
-    onErrorCallback(error, stacktrace);
+  void onError(Object error, StackTrace stackTrace) {
+    onErrorCallback(error, stackTrace);
+    super.onError(error, stackTrace);
   }
 
   @override

--- a/packages/bloc/test/helpers/counter/on_transition_error_bloc.dart
+++ b/packages/bloc/test/helpers/counter/on_transition_error_bloc.dart
@@ -14,9 +14,9 @@ class OnTransitionErrorBloc extends Bloc<CounterEvent, int> {
   int get initialState => 0;
 
   @override
-  void onError(Object error, StackTrace stacktrace) {
-    super.onError(error, stacktrace);
-    onErrorCallback(error, stacktrace);
+  void onError(Object error, StackTrace stackTrace) {
+    onErrorCallback(error, stackTrace);
+    super.onError(error, stackTrace);
   }
 
   @override


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
YES

## Description
- In debug mode, a `BlocUnhandledErrorException` will be thrown to make errors apparent while in development.
- In release mode, the bloc's behavior will remain unchanged.

As a result, with these changes it becomes important to call `super.onError` last when overriding `onError` in order to ensure the custom `onError` code is executed.

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
- Breaking changes which will be published in bloc v4.0.0-dev.4