### PR TITLE
bloc_test v5.1.0

### DIFF
--- a/packages/bloc_test/CHANGELOG.md
+++ b/packages/bloc_test/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 5.1.0
 
 - Add `errors` to `blocTest` to enable expecting unhandled exceptions within blocs.
+- Update `whenListen` to also handle stubbing the state property of the bloc.
 
 # 5.0.0
 

--- a/packages/bloc_test/CHANGELOG.md
+++ b/packages/bloc_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.1.0
+
+- Add `errors` to `blocTest` to enable expecting unhandled exceptions within blocs.
+
 # 5.0.0
 
 - Update to `bloc: ^4.0.0`

--- a/packages/bloc_test/README.md
+++ b/packages/bloc_test/README.md
@@ -50,9 +50,11 @@ expectLater(counterBloc, emitsInOrder(<int>[0, 1, 2, 3])))
 
 `wait` is an optional `Duration` which can be used to wait for async operations within the `bloc` under test such as `debounceTime`.
 
-`expect` is an `Iterable<State>` which the `bloc` under test is expected to emit after `act` is executed.
+`expect` is an optional `Iterable<State>` which the `bloc` under test is expected to emit after `act` is executed.
 
 `verify` is an optional callback which is invoked after `expect` and can be used for additional verification/assertions. `verify` is called with the `bloc` returned by `build`.
+
+`errors` is an optional `Iterable` of error matchers which the `bloc` under test is expected to have thrown after `act` is executed.
 
 ```dart
 group('CounterBloc', () {
@@ -106,6 +108,19 @@ blocTest(
   verify: (_) async {
     verify(repository.someMethod(any)).called(1);
   }
+);
+```
+
+`blocTest` can also be used to expect that exceptions have been thrown.
+
+```dart
+blocTest(
+  'CounterBloc throws Exception when null is added',
+  build: () async => CounterBloc(),
+  act: (bloc) => bloc.add(null),
+  errors: [
+    isA<Exception>(),
+  ]
 );
 ```
 

--- a/packages/bloc_test/README.md
+++ b/packages/bloc_test/README.md
@@ -25,7 +25,7 @@ class MockCounterBloc extends MockBloc<CounterEvent, int> implements CounterBloc
 
 ## Stub the Bloc Stream
 
-**whenListen** creates a stub response for the `listen` method on a `Bloc`. Use `whenListen` if you want to return a canned `Stream` of states for a bloc instance.
+**whenListen** creates a stub response for the `listen` method on a `Bloc`. Use `whenListen` if you want to return a canned `Stream` of states for a bloc instance. `whenListen` also handles stubbing the `state` of the bloc to stay in sync with the emitted state.
 
 ```dart
 // Create a mock instance
@@ -35,7 +35,10 @@ final counterBloc = MockCounterBloc();
 whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
 
 // Assert that the bloc emits the stubbed `Stream`.
-expectLater(counterBloc, emitsInOrder(<int>[0, 1, 2, 3])))
+await expectLater(counterBloc, emitsInOrder(<int>[0, 1, 2, 3])))
+
+// Assert that the bloc's current state is in sync with the `Stream`.
+expect(counterBloc.state, equals(3));
 ```
 
 ## Unit Test a Real Bloc with blocTest

--- a/packages/bloc_test/lib/src/when_listen.dart
+++ b/packages/bloc_test/lib/src/when_listen.dart
@@ -7,6 +7,9 @@ import 'package:mockito/mockito.dart';
 /// Use [whenListen] if you want to return a canned `Stream` of states
 /// for a [bloc] instance.
 ///
+/// [whenListen] also handles stubbing the `state` of the bloc to stay
+/// in sync with the emitted state.
+///
 /// Return a canned state stream of `[0, 1, 2, 3]`
 /// when `counterBloc.listen` is called.
 ///
@@ -18,21 +21,28 @@ import 'package:mockito/mockito.dart';
 /// is the canned `Stream`.
 ///
 /// ```dart
-/// expectLater(
+/// await expectLater(
 ///   counterBloc,
 ///   emitsInOrder(
 ///     <Matcher>[equals(0), equals(1), equals(2), equals(3), emitsDone],
 ///   )
-/// )
+/// );
+/// expect(counterBloc.state, equals(3));
 /// ```
 void whenListen<Event, State>(
   Bloc<Event, State> bloc,
   Stream<State> stream,
 ) {
+  StreamSubscription<State> subscription;
   final broadcastStream = stream.asBroadcastStream();
+  subscription = broadcastStream.listen(
+    (state) => when(bloc.state).thenReturn(state),
+    onDone: () => subscription?.cancel(),
+  );
   when(bloc.skip(any)).thenAnswer(
-    (invocation) =>
-        broadcastStream.skip(invocation.positionalArguments.first as int),
+    (invocation) => broadcastStream.skip(
+      invocation.positionalArguments.first as int,
+    ),
   );
 
   when(bloc.listen(

--- a/packages/bloc_test/lib/src/when_listen.dart
+++ b/packages/bloc_test/lib/src/when_listen.dart
@@ -43,7 +43,7 @@ void whenListen<Event, State>(
       subscription?.cancel();
       subscription = stream.listen(
         (state) => when(bloc.state).thenReturn(state),
-        onDone: subscription?.cancel,
+        onDone: () => subscription?.cancel(),
       );
       return stream;
     },

--- a/packages/bloc_test/pubspec.yaml
+++ b/packages/bloc_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc_test
 description: A testing library which makes it easy to test blocs. Built to be used with the bloc state management package.
-version: 5.0.0
+version: 5.1.0
 repository: https://github.com/felangel/bloc/tree/master/packages/bloc_test
 issue_tracker: https://github.com/felangel/bloc/issues
 homepage: https://bloclibrary.dev

--- a/packages/bloc_test/test/bloc_test_test.dart
+++ b/packages/bloc_test/test/bloc_test_test.dart
@@ -167,6 +167,84 @@ void main() {
       );
     });
 
+    group('ExceptionCounterBloc', () {
+      blocTest(
+        'emits [] when nothing is added',
+        build: () async => ExceptionCounterBloc(),
+        expect: [],
+      );
+
+      blocTest(
+        'emits [0] when nothing is added and skip: 0',
+        build: () async => ExceptionCounterBloc(),
+        skip: 0,
+        expect: [0],
+      );
+
+      blocTest(
+        'emits [1] when increment is added',
+        build: () async => ExceptionCounterBloc(),
+        act: (bloc) => bloc.add(ExceptionCounterEvent.increment),
+        expect: [1],
+      );
+
+      blocTest(
+        'throws ExceptionCounterBlocException when increment is added',
+        build: () async => ExceptionCounterBloc(),
+        act: (bloc) => bloc.add(ExceptionCounterEvent.increment),
+        errors: [
+          isA<ExceptionCounterBlocException>(),
+        ],
+      );
+
+      blocTest(
+        'emits [1] and throws ExceptionCounterBlocException '
+        'when increment is added',
+        build: () async => ExceptionCounterBloc(),
+        act: (bloc) => bloc.add(ExceptionCounterEvent.increment),
+        expect: [1],
+        errors: [
+          isA<ExceptionCounterBlocException>(),
+        ],
+      );
+
+      blocTest(
+        'emits [1, 2] when increment is added twice',
+        build: () async => ExceptionCounterBloc(),
+        act: (bloc) async => bloc
+          ..add(ExceptionCounterEvent.increment)
+          ..add(ExceptionCounterEvent.increment),
+        expect: [1, 2],
+      );
+
+      blocTest(
+        'throws two ExceptionCounterBlocExceptions '
+        'when increment is added twice',
+        build: () async => ExceptionCounterBloc(),
+        act: (bloc) async => bloc
+          ..add(ExceptionCounterEvent.increment)
+          ..add(ExceptionCounterEvent.increment),
+        errors: [
+          isA<ExceptionCounterBlocException>(),
+          isA<ExceptionCounterBlocException>(),
+        ],
+      );
+
+      blocTest(
+        'emits [1, 2] and throws two ExceptionCounterBlocException '
+        'when increment is added twice',
+        build: () async => ExceptionCounterBloc(),
+        act: (bloc) async => bloc
+          ..add(ExceptionCounterEvent.increment)
+          ..add(ExceptionCounterEvent.increment),
+        expect: [1, 2],
+        errors: [
+          isA<ExceptionCounterBlocException>(),
+          isA<ExceptionCounterBlocException>(),
+        ],
+      );
+    });
+
     group('SideEffectCounterBloc', () {
       Repository repository;
 

--- a/packages/bloc_test/test/helpers/exception_counter_bloc.dart
+++ b/packages/bloc_test/test/helpers/exception_counter_bloc.dart
@@ -1,0 +1,24 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+
+class ExceptionCounterBlocException implements Exception {}
+
+enum ExceptionCounterEvent { increment }
+
+class ExceptionCounterBloc extends Bloc<ExceptionCounterEvent, int> {
+  @override
+  int get initialState => 0;
+
+  @override
+  Stream<int> mapEventToState(
+    ExceptionCounterEvent event,
+  ) async* {
+    switch (event) {
+      case ExceptionCounterEvent.increment:
+        yield state + 1;
+        throw ExceptionCounterBlocException();
+        break;
+    }
+  }
+}

--- a/packages/bloc_test/test/helpers/helpers.dart
+++ b/packages/bloc_test/test/helpers/helpers.dart
@@ -2,6 +2,7 @@ export 'async_counter_bloc.dart';
 export 'complex_bloc.dart';
 export 'counter_bloc.dart';
 export 'debounce_counter_bloc.dart';
+export 'exception_counter_bloc.dart';
 export 'multi_counter_bloc.dart';
 export 'side_effect_counter_bloc.dart';
 export 'sum_bloc.dart';

--- a/packages/bloc_test/test/when_listen_test.dart
+++ b/packages/bloc_test/test/when_listen_test.dart
@@ -29,6 +29,60 @@ void main() {
       );
     });
 
+    test('can mock the stream of a single bloc with delays', () async {
+      final counterBloc = MockCounterBloc();
+      final controller = StreamController<int>();
+      whenListen(counterBloc, controller.stream);
+      expectLater(
+        counterBloc,
+        emitsInOrder(
+          <Matcher>[equals(0), equals(1), equals(2), equals(3), emitsDone],
+        ),
+      );
+      controller.add(0);
+      await Future.delayed(const Duration(milliseconds: 10));
+      controller.add(1);
+      await Future.delayed(const Duration(milliseconds: 10));
+      controller.add(2);
+      await Future.delayed(const Duration(milliseconds: 10));
+      controller.add(3);
+      controller.close();
+    });
+
+    test('can mock the state of a single bloc with delays', () async {
+      final counterBloc = MockCounterBloc();
+      final controller = StreamController<int>();
+      whenListen(counterBloc, controller.stream);
+      expectLater(
+        counterBloc,
+        emitsInOrder(
+          <Matcher>[equals(0), equals(1), equals(2), equals(3), emitsDone],
+        ),
+      ).then((_) {
+        expect(counterBloc.state, equals(3));
+      });
+      controller.add(0);
+      await Future.delayed(const Duration(milliseconds: 10));
+      controller.add(1);
+      await Future.delayed(const Duration(milliseconds: 10));
+      controller.add(2);
+      await Future.delayed(const Duration(milliseconds: 10));
+      controller.add(3);
+      controller.close();
+    });
+
+    test('can mock the state of a single bloc', () async {
+      final counterBloc = MockCounterBloc();
+      whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
+      await expectLater(
+        counterBloc,
+        emitsInOrder(
+          <Matcher>[equals(0), equals(1), equals(2), equals(3), emitsDone],
+        ),
+      );
+      expect(counterBloc.state, equals(3));
+    });
+
     test('can mock the stream of a single bloc as broadcast stream', () {
       final counterBloc = MockCounterBloc();
       whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
@@ -57,6 +111,18 @@ void main() {
       );
     });
 
+    test('can mock the state of a single bloc with skip(1)', () async {
+      final counterBloc = MockCounterBloc();
+      whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
+      await expectLater(
+        counterBloc.skip(1),
+        emitsInOrder(
+          <Matcher>[equals(1), equals(2), equals(3), emitsDone],
+        ),
+      );
+      expect(counterBloc.state, equals(3));
+    });
+
     test('can mock the stream of a single bloc with skip(2)', () {
       final counterBloc = MockCounterBloc();
       whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
@@ -66,6 +132,18 @@ void main() {
           <Matcher>[equals(2), equals(3), emitsDone],
         ),
       );
+    });
+
+    test('can mock the state of a single bloc with skip(2)', () async {
+      final counterBloc = MockCounterBloc();
+      whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
+      await expectLater(
+        counterBloc.skip(2),
+        emitsInOrder(
+          <Matcher>[equals(2), equals(3), emitsDone],
+        ),
+      );
+      expect(counterBloc.state, equals(3));
     });
 
     test('can mock the stream of a single bloc with skip(3)', () {
@@ -79,11 +157,31 @@ void main() {
       );
     });
 
+    test('can mock the state of a single bloc with skip(3)', () async {
+      final counterBloc = MockCounterBloc();
+      whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
+      await expectLater(
+        counterBloc.skip(3),
+        emitsInOrder(
+          <Matcher>[equals(3), emitsDone],
+        ),
+      );
+      expect(counterBloc.state, equals(3));
+    });
+
     test('can mock the stream of a bloc dependency', () {
       final counterBloc = MockCounterBloc();
       whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
       final sumBloc = SumBloc(counterBloc);
       expectLater(sumBloc, emitsInOrder(<int>[0, 1, 3, 6]));
+    });
+
+    test('can mock the state of a bloc dependency', () async {
+      final counterBloc = MockCounterBloc();
+      whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
+      final sumBloc = SumBloc(counterBloc);
+      await expectLater(sumBloc, emitsInOrder(<int>[0, 1, 3, 6]));
+      expect(sumBloc.state, equals(6));
     });
   });
 }

--- a/packages/bloc_test/test/when_listen_test.dart
+++ b/packages/bloc_test/test/when_listen_test.dart
@@ -49,6 +49,27 @@ void main() {
       controller.close();
     });
 
+    test('can mock the stream of a single bloc with delays and skip(1)',
+        () async {
+      final counterBloc = MockCounterBloc();
+      final controller = StreamController<int>();
+      whenListen(counterBloc, controller.stream);
+      expectLater(
+        counterBloc.skip(1),
+        emitsInOrder(
+          <Matcher>[equals(1), equals(2), equals(3), emitsDone],
+        ),
+      );
+      controller.add(0);
+      await Future.delayed(const Duration(milliseconds: 10));
+      controller.add(1);
+      await Future.delayed(const Duration(milliseconds: 10));
+      controller.add(2);
+      await Future.delayed(const Duration(milliseconds: 10));
+      controller.add(3);
+      controller.close();
+    });
+
     test('can mock the state of a single bloc with delays', () async {
       final counterBloc = MockCounterBloc();
       final controller = StreamController<int>();
@@ -57,6 +78,29 @@ void main() {
         counterBloc,
         emitsInOrder(
           <Matcher>[equals(0), equals(1), equals(2), equals(3), emitsDone],
+        ),
+      ).then((_) {
+        expect(counterBloc.state, equals(3));
+      });
+      controller.add(0);
+      await Future.delayed(const Duration(milliseconds: 10));
+      controller.add(1);
+      await Future.delayed(const Duration(milliseconds: 10));
+      controller.add(2);
+      await Future.delayed(const Duration(milliseconds: 10));
+      controller.add(3);
+      controller.close();
+    });
+
+    test('can mock the state of a single bloc with delays and skip(1)',
+        () async {
+      final counterBloc = MockCounterBloc();
+      final controller = StreamController<int>();
+      whenListen(counterBloc, controller.stream);
+      expectLater(
+        counterBloc.skip(1),
+        emitsInOrder(
+          <Matcher>[equals(1), equals(2), equals(3), emitsDone],
         ),
       ).then((_) {
         expect(counterBloc.state, equals(3));
@@ -100,6 +144,24 @@ void main() {
       );
     });
 
+    test('can mock the stream of a single bloc as broadcast stream with skips',
+        () {
+      final counterBloc = MockCounterBloc();
+      whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
+      expectLater(
+        counterBloc.skip(1),
+        emitsInOrder(
+          <Matcher>[equals(1), equals(2), equals(3), emitsDone],
+        ),
+      );
+      expectLater(
+        counterBloc.skip(2),
+        emitsInOrder(
+          <Matcher>[equals(2), equals(3), emitsDone],
+        ),
+      );
+    });
+
     test('can mock the stream of a single bloc with skip(1)', () {
       final counterBloc = MockCounterBloc();
       whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
@@ -123,6 +185,16 @@ void main() {
       expect(counterBloc.state, equals(3));
     });
 
+    test('can mock the state of a single bloc with skip(1).listen', () async {
+      final counterBloc = MockCounterBloc();
+      final states = <int>[];
+      whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
+      counterBloc.skip(1).listen(states.add);
+      await Future.delayed(Duration.zero);
+      expect(states, [1, 2, 3]);
+      expect(counterBloc.state, equals(3));
+    });
+
     test('can mock the stream of a single bloc with skip(2)', () {
       final counterBloc = MockCounterBloc();
       whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
@@ -134,6 +206,16 @@ void main() {
       );
     });
 
+    test('can mock the state of a single bloc with skip(2).listen', () async {
+      final counterBloc = MockCounterBloc();
+      final states = <int>[];
+      whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
+      counterBloc.skip(2).listen(states.add);
+      await Future.delayed(Duration.zero);
+      expect(states, [2, 3]);
+      expect(counterBloc.state, equals(3));
+    });
+
     test('can mock the state of a single bloc with skip(2)', () async {
       final counterBloc = MockCounterBloc();
       whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
@@ -143,6 +225,16 @@ void main() {
           <Matcher>[equals(2), equals(3), emitsDone],
         ),
       );
+      expect(counterBloc.state, equals(3));
+    });
+
+    test('can mock the state of a single bloc with skip(3).listen', () async {
+      final counterBloc = MockCounterBloc();
+      final states = <int>[];
+      whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
+      counterBloc.skip(3).listen(states.add);
+      await Future.delayed(Duration.zero);
+      expect(states, [3]);
       expect(counterBloc.state, equals(3));
     });
 


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Closes #1122 
- Add optional `errors` to `blocTest` to enable developers to write expectations against unhandled exceptions thrown in the bloc throughout the course of the test.


```dart
blocTest(
  'CounterBloc throws Exception when null is added',
  build: () async => CounterBloc(),
  act: (bloc) => bloc.add(null),
  errors: [
    isA<Exception>(),
  ]
);
```

- Enable `whenListen` to stub the bloc state property as well as the state stream to ensure a consistent behavior and eliminate the need to have an additional `when`.

Previously, the following didn't guarantee that if you called `counterBloc.state` it would return 3. You'd need to stub the state separately.

```dart
whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]);
print(counterBloc.state); // null

// we'd need to stub the state separately like...
when(counterBloc.state).thenReturn(3);
```

Now, `whenListen` will handle keeping the two in sync:

```dart
whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]);
print(counterBloc.state); // 3
```

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
- Pending approval, changes will be published as part of `bloc_test v5.1.0`