### PR TITLE
bloc_test: whenListen stubs state as well

### DIFF
--- a/packages/bloc_test/CHANGELOG.md
+++ b/packages/bloc_test/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 5.1.0
 
 - Add `errors` to `blocTest` to enable expecting unhandled exceptions within blocs.
+- Update `whenListen` to also handle stubbing the state property of the bloc.
 
 # 5.0.0
 

--- a/packages/bloc_test/README.md
+++ b/packages/bloc_test/README.md
@@ -25,7 +25,7 @@ class MockCounterBloc extends MockBloc<CounterEvent, int> implements CounterBloc
 
 ## Stub the Bloc Stream
 
-**whenListen** creates a stub response for the `listen` method on a `Bloc`. Use `whenListen` if you want to return a canned `Stream` of states for a bloc instance.
+**whenListen** creates a stub response for the `listen` method on a `Bloc`. Use `whenListen` if you want to return a canned `Stream` of states for a bloc instance. `whenListen` also handles stubbing the `state` of the bloc to stay in sync with the emitted state.
 
 ```dart
 // Create a mock instance
@@ -35,7 +35,10 @@ final counterBloc = MockCounterBloc();
 whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
 
 // Assert that the bloc emits the stubbed `Stream`.
-expectLater(counterBloc, emitsInOrder(<int>[0, 1, 2, 3])))
+await expectLater(counterBloc, emitsInOrder(<int>[0, 1, 2, 3])))
+
+// Assert that the bloc's current state is in sync with the `Stream`.
+expect(counterBloc.state, equals(3));
 ```
 
 ## Unit Test a Real Bloc with blocTest

--- a/packages/bloc_test/lib/src/when_listen.dart
+++ b/packages/bloc_test/lib/src/when_listen.dart
@@ -7,6 +7,9 @@ import 'package:mockito/mockito.dart';
 /// Use [whenListen] if you want to return a canned `Stream` of states
 /// for a [bloc] instance.
 ///
+/// [whenListen] also handles stubbing the `state` of the bloc to stay
+/// in sync with the emitted state.
+///
 /// Return a canned state stream of `[0, 1, 2, 3]`
 /// when `counterBloc.listen` is called.
 ///
@@ -18,21 +21,28 @@ import 'package:mockito/mockito.dart';
 /// is the canned `Stream`.
 ///
 /// ```dart
-/// expectLater(
+/// await expectLater(
 ///   counterBloc,
 ///   emitsInOrder(
 ///     <Matcher>[equals(0), equals(1), equals(2), equals(3), emitsDone],
 ///   )
-/// )
+/// );
+/// expect(counterBloc.state, equals(3));
 /// ```
 void whenListen<Event, State>(
   Bloc<Event, State> bloc,
   Stream<State> stream,
 ) {
+  StreamSubscription<State> subscription;
   final broadcastStream = stream.asBroadcastStream();
+  subscription = broadcastStream.listen(
+    (state) => when(bloc.state).thenReturn(state),
+    onDone: () => subscription?.cancel(),
+  );
   when(bloc.skip(any)).thenAnswer(
-    (invocation) =>
-        broadcastStream.skip(invocation.positionalArguments.first as int),
+    (invocation) => broadcastStream.skip(
+      invocation.positionalArguments.first as int,
+    ),
   );
 
   when(bloc.listen(

--- a/packages/bloc_test/test/when_listen_test.dart
+++ b/packages/bloc_test/test/when_listen_test.dart
@@ -29,6 +29,60 @@ void main() {
       );
     });
 
+    test('can mock the stream of a single bloc with delays', () async {
+      final counterBloc = MockCounterBloc();
+      final controller = StreamController<int>();
+      whenListen(counterBloc, controller.stream);
+      expectLater(
+        counterBloc,
+        emitsInOrder(
+          <Matcher>[equals(0), equals(1), equals(2), equals(3), emitsDone],
+        ),
+      );
+      controller.add(0);
+      await Future.delayed(const Duration(milliseconds: 10));
+      controller.add(1);
+      await Future.delayed(const Duration(milliseconds: 10));
+      controller.add(2);
+      await Future.delayed(const Duration(milliseconds: 10));
+      controller.add(3);
+      controller.close();
+    });
+
+    test('can mock the state of a single bloc with delays', () async {
+      final counterBloc = MockCounterBloc();
+      final controller = StreamController<int>();
+      whenListen(counterBloc, controller.stream);
+      expectLater(
+        counterBloc,
+        emitsInOrder(
+          <Matcher>[equals(0), equals(1), equals(2), equals(3), emitsDone],
+        ),
+      ).then((_) {
+        expect(counterBloc.state, equals(3));
+      });
+      controller.add(0);
+      await Future.delayed(const Duration(milliseconds: 10));
+      controller.add(1);
+      await Future.delayed(const Duration(milliseconds: 10));
+      controller.add(2);
+      await Future.delayed(const Duration(milliseconds: 10));
+      controller.add(3);
+      controller.close();
+    });
+
+    test('can mock the state of a single bloc', () async {
+      final counterBloc = MockCounterBloc();
+      whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
+      await expectLater(
+        counterBloc,
+        emitsInOrder(
+          <Matcher>[equals(0), equals(1), equals(2), equals(3), emitsDone],
+        ),
+      );
+      expect(counterBloc.state, equals(3));
+    });
+
     test('can mock the stream of a single bloc as broadcast stream', () {
       final counterBloc = MockCounterBloc();
       whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
@@ -57,6 +111,18 @@ void main() {
       );
     });
 
+    test('can mock the state of a single bloc with skip(1)', () async {
+      final counterBloc = MockCounterBloc();
+      whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
+      await expectLater(
+        counterBloc.skip(1),
+        emitsInOrder(
+          <Matcher>[equals(1), equals(2), equals(3), emitsDone],
+        ),
+      );
+      expect(counterBloc.state, equals(3));
+    });
+
     test('can mock the stream of a single bloc with skip(2)', () {
       final counterBloc = MockCounterBloc();
       whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
@@ -66,6 +132,18 @@ void main() {
           <Matcher>[equals(2), equals(3), emitsDone],
         ),
       );
+    });
+
+    test('can mock the state of a single bloc with skip(2)', () async {
+      final counterBloc = MockCounterBloc();
+      whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
+      await expectLater(
+        counterBloc.skip(2),
+        emitsInOrder(
+          <Matcher>[equals(2), equals(3), emitsDone],
+        ),
+      );
+      expect(counterBloc.state, equals(3));
     });
 
     test('can mock the stream of a single bloc with skip(3)', () {
@@ -79,11 +157,31 @@ void main() {
       );
     });
 
+    test('can mock the state of a single bloc with skip(3)', () async {
+      final counterBloc = MockCounterBloc();
+      whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
+      await expectLater(
+        counterBloc.skip(3),
+        emitsInOrder(
+          <Matcher>[equals(3), emitsDone],
+        ),
+      );
+      expect(counterBloc.state, equals(3));
+    });
+
     test('can mock the stream of a bloc dependency', () {
       final counterBloc = MockCounterBloc();
       whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
       final sumBloc = SumBloc(counterBloc);
       expectLater(sumBloc, emitsInOrder(<int>[0, 1, 3, 6]));
+    });
+
+    test('can mock the state of a bloc dependency', () async {
+      final counterBloc = MockCounterBloc();
+      whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]));
+      final sumBloc = SumBloc(counterBloc);
+      await expectLater(sumBloc, emitsInOrder(<int>[0, 1, 3, 6]));
+      expect(sumBloc.state, equals(6));
     });
   });
 }


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- Enable `whenListen` to stub the bloc state property as well as the state stream to ensure a consistent behavior and eliminate the need to have an additional `when`.

Previously, the following didn't guarantee that if you called `counterBloc.state` it would return 3. You'd need to stub the state separately.

```dart
whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]);
print(counterBloc.state); // null

// we'd need to stub the state separately like...
when(counterBloc.state).thenReturn(3);
```

Now, `whenListen` will handle keeping the two in sync:

```dart
whenListen(counterBloc, Stream.fromIterable([0, 1, 2, 3]);
print(counterBloc.state); // 3
```

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
- Pending approval will be merged and published in `bloc_test v5.1.0`.