### PR TITLE
Update Examples to Adhere to Naming Conventions

### DIFF
--- a/examples/flutter_bloc_with_stream/lib/bloc/ticker_bloc.dart
+++ b/examples/flutter_bloc_with_stream/lib/bloc/ticker_bloc.dart
@@ -13,16 +13,16 @@ class TickerBloc extends Bloc<TickerEvent, TickerState> {
   TickerBloc(this.ticker);
 
   @override
-  TickerState get initialState => Initial();
+  TickerState get initialState => TickerInitial();
 
   @override
   Stream<TickerState> mapEventToState(TickerEvent event) async* {
-    if (event is StartTicker) {
+    if (event is TickerStarted) {
       subscription?.cancel();
-      subscription = ticker.tick().listen((tick) => add(Tick(tick)));
+      subscription = ticker.tick().listen((tick) => add(TickerTicked(tick)));
     }
-    if (event is Tick) {
-      yield Update(event.tickCount);
+    if (event is TickerTicked) {
+      yield TickerTickSuccess(event.tickCount);
     }
   }
 

--- a/examples/flutter_bloc_with_stream/lib/bloc/ticker_event.dart
+++ b/examples/flutter_bloc_with_stream/lib/bloc/ticker_event.dart
@@ -7,12 +7,12 @@ abstract class TickerEvent extends Equatable {
   List<Object> get props => [];
 }
 
-class StartTicker extends TickerEvent {}
+class TickerStarted extends TickerEvent {}
 
-class Tick extends TickerEvent {
+class TickerTicked extends TickerEvent {
   final int tickCount;
 
-  const Tick(this.tickCount);
+  const TickerTicked(this.tickCount);
 
   @override
   List<Object> get props => [tickCount];

--- a/examples/flutter_bloc_with_stream/lib/bloc/ticker_state.dart
+++ b/examples/flutter_bloc_with_stream/lib/bloc/ticker_state.dart
@@ -7,12 +7,12 @@ abstract class TickerState extends Equatable {
   List<Object> get props => [];
 }
 
-class Initial extends TickerState {}
+class TickerInitial extends TickerState {}
 
-class Update extends TickerState {
+class TickerTickSuccess extends TickerState {
   final int count;
 
-  const Update(this.count);
+  const TickerTickSuccess(this.count);
 
   @override
   List<Object> get props => [count];

--- a/examples/flutter_bloc_with_stream/lib/main.dart
+++ b/examples/flutter_bloc_with_stream/lib/main.dart
@@ -27,7 +27,7 @@ class MyHomePage extends StatelessWidget {
       ),
       body: BlocBuilder<TickerBloc, TickerState>(
         builder: (context, state) {
-          if (state is Update) {
+          if (state is TickerTickSuccess) {
             return Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
@@ -51,7 +51,7 @@ class MyHomePage extends StatelessWidget {
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
-          BlocProvider.of<TickerBloc>(context).add(StartTicker());
+          BlocProvider.of<TickerBloc>(context).add(TickerStarted());
         },
         tooltip: 'Start',
         child: Icon(Icons.timer),

--- a/examples/flutter_dynamic_form/lib/bloc/new_car_bloc.dart
+++ b/examples/flutter_dynamic_form/lib/bloc/new_car_bloc.dart
@@ -1,7 +1,8 @@
 import 'dart:async';
+
 import 'package:bloc/bloc.dart';
-import 'package:meta/meta.dart';
 import 'package:flutter_dynamic_form/new_car_repository.dart';
+import 'package:meta/meta.dart';
 
 part 'new_car_event.dart';
 part 'new_car_state.dart';
@@ -19,40 +20,42 @@ class NewCarBloc extends Bloc<NewCarEvent, NewCarState> {
   Stream<NewCarState> mapEventToState(
     NewCarEvent event,
   ) async* {
-    if (event is FormLoaded) {
-      yield* _mapFormLoadedToState();
-    } else if (event is BrandChanged) {
-      yield* _mapBrandChangedToState(event);
-    } else if (event is ModelChanged) {
-      yield* _mapModelChangedToState(event);
-    } else if (event is YearChanged) {
-      yield* _mapYearChangedToState(event);
+    if (event is NewCarFormLoaded) {
+      yield* _mapNewCarFormLoadedToState();
+    } else if (event is NewCarBrandChanged) {
+      yield* _mapNewCarBrandChangedToState(event);
+    } else if (event is NewCarModelChanged) {
+      yield* _mapNewCarModelChangedToState(event);
+    } else if (event is NewCarYearChanged) {
+      yield* _mapNewCarYearChangedToState(event);
     }
   }
 
-  Stream<NewCarState> _mapFormLoadedToState() async* {
-    yield NewCarState.brandsLoading();
+  Stream<NewCarState> _mapNewCarFormLoadedToState() async* {
+    yield NewCarState.brandsLoadInProgress();
     final brands = await _newCarRepository.fetchBrands();
-    yield NewCarState.brandsLoaded(brands: brands);
+    yield NewCarState.brandsLoadSuccess(brands: brands);
   }
 
-  Stream<NewCarState> _mapBrandChangedToState(BrandChanged event) async* {
+  Stream<NewCarState> _mapNewCarBrandChangedToState(
+      NewCarBrandChanged event) async* {
     final currentState = state;
-    yield NewCarState.modelsLoading(
+    yield NewCarState.modelsLoadInProgress(
       brands: currentState.brands,
       brand: event.brand,
     );
     final models = await _newCarRepository.fetchModels(brand: event.brand);
-    yield NewCarState.modelsLoaded(
+    yield NewCarState.modelsLoadSuccess(
       brands: currentState.brands,
       brand: event.brand,
       models: models,
     );
   }
 
-  Stream<NewCarState> _mapModelChangedToState(ModelChanged event) async* {
+  Stream<NewCarState> _mapNewCarModelChangedToState(
+      NewCarModelChanged event) async* {
     final currentState = state;
-    yield NewCarState.yearsLoading(
+    yield NewCarState.yearsLoadInProgress(
       brands: currentState.brands,
       brand: currentState.brand,
       models: currentState.models,
@@ -62,7 +65,7 @@ class NewCarBloc extends Bloc<NewCarEvent, NewCarState> {
       brand: currentState.brand,
       model: event.model,
     );
-    yield NewCarState.yearsLoaded(
+    yield NewCarState.yearsLoadSuccess(
       brands: currentState.brands,
       brand: currentState.brand,
       models: currentState.models,
@@ -71,7 +74,8 @@ class NewCarBloc extends Bloc<NewCarEvent, NewCarState> {
     );
   }
 
-  Stream<NewCarState> _mapYearChangedToState(YearChanged event) async* {
+  Stream<NewCarState> _mapNewCarYearChangedToState(
+      NewCarYearChanged event) async* {
     yield state.copyWith(year: event.year);
   }
 }

--- a/examples/flutter_dynamic_form/lib/bloc/new_car_event.dart
+++ b/examples/flutter_dynamic_form/lib/bloc/new_car_event.dart
@@ -5,22 +5,22 @@ abstract class NewCarEvent {
   const NewCarEvent();
 }
 
-class FormLoaded extends NewCarEvent {}
+class NewCarFormLoaded extends NewCarEvent {}
 
-class BrandChanged extends NewCarEvent {
+class NewCarBrandChanged extends NewCarEvent {
   final String brand;
 
-  const BrandChanged({this.brand});
+  const NewCarBrandChanged({this.brand});
 }
 
-class ModelChanged extends NewCarEvent {
+class NewCarModelChanged extends NewCarEvent {
   final String model;
 
-  const ModelChanged({this.model});
+  const NewCarModelChanged({this.model});
 }
 
-class YearChanged extends NewCarEvent {
+class NewCarYearChanged extends NewCarEvent {
   final String year;
 
-  const YearChanged({this.year});
+  const NewCarYearChanged({this.year});
 }

--- a/examples/flutter_dynamic_form/lib/bloc/new_car_state.dart
+++ b/examples/flutter_dynamic_form/lib/bloc/new_car_state.dart
@@ -30,7 +30,7 @@ class NewCarState {
         year: null,
       );
 
-  factory NewCarState.brandsLoading() => NewCarState(
+  factory NewCarState.brandsLoadInProgress() => NewCarState(
         brands: <String>[],
         brand: null,
         models: <String>[],
@@ -39,7 +39,7 @@ class NewCarState {
         year: null,
       );
 
-  factory NewCarState.brandsLoaded({
+  factory NewCarState.brandsLoadSuccess({
     @required List<String> brands,
   }) =>
       NewCarState(
@@ -51,7 +51,7 @@ class NewCarState {
         year: null,
       );
 
-  factory NewCarState.modelsLoading({
+  factory NewCarState.modelsLoadInProgress({
     @required List<String> brands,
     @required String brand,
   }) =>
@@ -64,7 +64,7 @@ class NewCarState {
         year: null,
       );
 
-  factory NewCarState.modelsLoaded({
+  factory NewCarState.modelsLoadSuccess({
     @required List<String> brands,
     @required String brand,
     @required List<String> models,
@@ -78,7 +78,7 @@ class NewCarState {
         year: null,
       );
 
-  factory NewCarState.yearsLoading({
+  factory NewCarState.yearsLoadInProgress({
     @required List<String> brands,
     @required String brand,
     @required List<String> models,
@@ -93,7 +93,7 @@ class NewCarState {
         year: null,
       );
 
-  factory NewCarState.yearsLoaded({
+  factory NewCarState.yearsLoadSuccess({
     @required List<String> brands,
     @required String brand,
     @required List<String> models,

--- a/examples/flutter_dynamic_form/lib/main.dart
+++ b/examples/flutter_dynamic_form/lib/main.dart
@@ -16,7 +16,7 @@ class MyApp extends StatelessWidget {
         body: BlocProvider(
           create: (context) => NewCarBloc(
             newCarRepository: NewCarRepository(),
-          )..add(FormLoaded()),
+          )..add(NewCarFormLoaded()),
           child: MyForm(),
         ),
       ),
@@ -27,14 +27,14 @@ class MyApp extends StatelessWidget {
 class MyForm extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    void _onBrandChanged(String brand) =>
-        BlocProvider.of<NewCarBloc>(context).add(BrandChanged(brand: brand));
+    void _onBrandChanged(String brand) => BlocProvider.of<NewCarBloc>(context)
+        .add(NewCarBrandChanged(brand: brand));
 
-    void _onModelChanged(String model) =>
-        BlocProvider.of<NewCarBloc>(context).add(ModelChanged(model: model));
+    void _onModelChanged(String model) => BlocProvider.of<NewCarBloc>(context)
+        .add(NewCarModelChanged(model: model));
 
     void _onYearChanged(String year) =>
-        BlocProvider.of<NewCarBloc>(context).add(YearChanged(year: year));
+        BlocProvider.of<NewCarBloc>(context).add(NewCarYearChanged(year: year));
 
     void _onFormSubmitted({
       String brand,

--- a/examples/flutter_firebase_login/lib/authentication_bloc/authentication_bloc.dart
+++ b/examples/flutter_firebase_login/lib/authentication_bloc/authentication_bloc.dart
@@ -16,37 +16,37 @@ class AuthenticationBloc
         _userRepository = userRepository;
 
   @override
-  AuthenticationState get initialState => Uninitialized();
+  AuthenticationState get initialState => AuthenticationInitial();
 
   @override
   Stream<AuthenticationState> mapEventToState(
     AuthenticationEvent event,
   ) async* {
-    if (event is AppStarted) {
-      yield* _mapAppStartedToState();
-    } else if (event is LoggedIn) {
-      yield* _mapLoggedInToState();
-    } else if (event is LoggedOut) {
-      yield* _mapLoggedOutToState();
+    if (event is AuthenticationStarted) {
+      yield* _mapAuthenticationStartedToState();
+    } else if (event is AuthenticationLoggedIn) {
+      yield* _mapAuthenticationLoggedInToState();
+    } else if (event is AuthenticationLoggedOut) {
+      yield* _mapAuthenticationLoggedOutToState();
     }
   }
 
-  Stream<AuthenticationState> _mapAppStartedToState() async* {
+  Stream<AuthenticationState> _mapAuthenticationStartedToState() async* {
     final isSignedIn = await _userRepository.isSignedIn();
     if (isSignedIn) {
       final name = await _userRepository.getUser();
-      yield Authenticated(name);
+      yield AuthenticationSuccess(name);
     } else {
-      yield Unauthenticated();
+      yield AuthenticationFailure();
     }
   }
 
-  Stream<AuthenticationState> _mapLoggedInToState() async* {
-    yield Authenticated(await _userRepository.getUser());
+  Stream<AuthenticationState> _mapAuthenticationLoggedInToState() async* {
+    yield AuthenticationSuccess(await _userRepository.getUser());
   }
 
-  Stream<AuthenticationState> _mapLoggedOutToState() async* {
-    yield Unauthenticated();
+  Stream<AuthenticationState> _mapAuthenticationLoggedOutToState() async* {
+    yield AuthenticationFailure();
     _userRepository.signOut();
   }
 }

--- a/examples/flutter_firebase_login/lib/authentication_bloc/authentication_event.dart
+++ b/examples/flutter_firebase_login/lib/authentication_bloc/authentication_event.dart
@@ -5,8 +5,8 @@ abstract class AuthenticationEvent extends Equatable {
   List<Object> get props => [];
 }
 
-class AppStarted extends AuthenticationEvent {}
+class AuthenticationStarted extends AuthenticationEvent {}
 
-class LoggedIn extends AuthenticationEvent {}
+class AuthenticationLoggedIn extends AuthenticationEvent {}
 
-class LoggedOut extends AuthenticationEvent {}
+class AuthenticationLoggedOut extends AuthenticationEvent {}

--- a/examples/flutter_firebase_login/lib/authentication_bloc/authentication_state.dart
+++ b/examples/flutter_firebase_login/lib/authentication_bloc/authentication_state.dart
@@ -7,12 +7,12 @@ abstract class AuthenticationState extends Equatable {
   List<Object> get props => [];
 }
 
-class Uninitialized extends AuthenticationState {}
+class AuthenticationInitial extends AuthenticationState {}
 
-class Authenticated extends AuthenticationState {
+class AuthenticationSuccess extends AuthenticationState {
   final String displayName;
 
-  const Authenticated(this.displayName);
+  const AuthenticationSuccess(this.displayName);
 
   @override
   List<Object> get props => [displayName];
@@ -21,4 +21,4 @@ class Authenticated extends AuthenticationState {
   String toString() => 'Authenticated { displayName: $displayName }';
 }
 
-class Unauthenticated extends AuthenticationState {}
+class AuthenticationFailure extends AuthenticationState {}

--- a/examples/flutter_firebase_login/lib/home_screen.dart
+++ b/examples/flutter_firebase_login/lib/home_screen.dart
@@ -17,7 +17,7 @@ class HomeScreen extends StatelessWidget {
             icon: Icon(Icons.exit_to_app),
             onPressed: () {
               BlocProvider.of<AuthenticationBloc>(context).add(
-                LoggedOut(),
+                AuthenticationLoggedOut(),
               );
             },
           )

--- a/examples/flutter_firebase_login/lib/login/bloc/login_bloc.dart
+++ b/examples/flutter_firebase_login/lib/login/bloc/login_bloc.dart
@@ -15,7 +15,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
         _userRepository = userRepository;
 
   @override
-  LoginState get initialState => LoginState.empty();
+  LoginState get initialState => LoginState.initial();
 
   @override
   Stream<Transition<LoginEvent, LoginState>> transformEvents(
@@ -23,10 +23,10 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     TransitionFunction<LoginEvent, LoginState> transitionFn,
   ) {
     final nonDebounceStream = events.where((event) {
-      return (event is! EmailChanged && event is! PasswordChanged);
+      return (event is! LoginEmailChanged && event is! LoginPasswordChanged);
     });
     final debounceStream = events.where((event) {
-      return (event is EmailChanged || event is PasswordChanged);
+      return (event is LoginEmailChanged || event is LoginPasswordChanged);
     }).debounceTime(Duration(milliseconds: 300));
     return super.transformEvents(
       nonDebounceStream.mergeWith([debounceStream]),
@@ -36,10 +36,10 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
 
   @override
   Stream<LoginState> mapEventToState(LoginEvent event) async* {
-    if (event is EmailChanged) {
-      yield* _mapEmailChangedToState(event.email);
-    } else if (event is PasswordChanged) {
-      yield* _mapPasswordChangedToState(event.password);
+    if (event is LoginEmailChanged) {
+      yield* _mapLoginEmailChangedToState(event.email);
+    } else if (event is LoginPasswordChanged) {
+      yield* _mapLoginPasswordChangedToState(event.password);
     } else if (event is LoginWithGooglePressed) {
       yield* _mapLoginWithGooglePressedToState();
     } else if (event is LoginWithCredentialsPressed) {
@@ -50,13 +50,13 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     }
   }
 
-  Stream<LoginState> _mapEmailChangedToState(String email) async* {
+  Stream<LoginState> _mapLoginEmailChangedToState(String email) async* {
     yield state.update(
       isEmailValid: Validators.isValidEmail(email),
     );
   }
 
-  Stream<LoginState> _mapPasswordChangedToState(String password) async* {
+  Stream<LoginState> _mapLoginPasswordChangedToState(String password) async* {
     yield state.update(
       isPasswordValid: Validators.isValidPassword(password),
     );

--- a/examples/flutter_firebase_login/lib/login/bloc/login_event.dart
+++ b/examples/flutter_firebase_login/lib/login/bloc/login_event.dart
@@ -8,10 +8,10 @@ abstract class LoginEvent extends Equatable {
   List<Object> get props => [];
 }
 
-class EmailChanged extends LoginEvent {
+class LoginEmailChanged extends LoginEvent {
   final String email;
 
-  const EmailChanged({@required this.email});
+  const LoginEmailChanged({@required this.email});
 
   @override
   List<Object> get props => [email];
@@ -20,34 +20,16 @@ class EmailChanged extends LoginEvent {
   String toString() => 'EmailChanged { email :$email }';
 }
 
-class PasswordChanged extends LoginEvent {
+class LoginPasswordChanged extends LoginEvent {
   final String password;
 
-  const PasswordChanged({@required this.password});
+  const LoginPasswordChanged({@required this.password});
 
   @override
   List<Object> get props => [password];
 
   @override
   String toString() => 'PasswordChanged { password: $password }';
-}
-
-class Submitted extends LoginEvent {
-  final String email;
-  final String password;
-
-  const Submitted({
-    @required this.email,
-    @required this.password,
-  });
-
-  @override
-  List<Object> get props => [email, password];
-
-  @override
-  String toString() {
-    return 'Submitted { email: $email, password: $password }';
-  }
 }
 
 class LoginWithGooglePressed extends LoginEvent {}

--- a/examples/flutter_firebase_login/lib/login/bloc/login_state.dart
+++ b/examples/flutter_firebase_login/lib/login/bloc/login_state.dart
@@ -18,7 +18,7 @@ class LoginState {
     @required this.isFailure,
   });
 
-  factory LoginState.empty() {
+  factory LoginState.initial() {
     return LoginState(
       isEmailValid: true,
       isPasswordValid: true,

--- a/examples/flutter_firebase_login/lib/login/login_form.dart
+++ b/examples/flutter_firebase_login/lib/login/login_form.dart
@@ -71,7 +71,8 @@ class _LoginFormState extends State<LoginForm> {
             );
         }
         if (state.isSuccess) {
-          BlocProvider.of<AuthenticationBloc>(context).add(LoggedIn());
+          BlocProvider.of<AuthenticationBloc>(context)
+              .add(AuthenticationLoggedIn());
         }
       },
       child: BlocBuilder<LoginBloc, LoginState>(
@@ -144,13 +145,13 @@ class _LoginFormState extends State<LoginForm> {
 
   void _onEmailChanged() {
     _loginBloc.add(
-      EmailChanged(email: _emailController.text),
+      LoginEmailChanged(email: _emailController.text),
     );
   }
 
   void _onPasswordChanged() {
     _loginBloc.add(
-      PasswordChanged(password: _passwordController.text),
+      LoginPasswordChanged(password: _passwordController.text),
     );
   }
 

--- a/examples/flutter_firebase_login/lib/main.dart
+++ b/examples/flutter_firebase_login/lib/main.dart
@@ -16,7 +16,7 @@ void main() {
     BlocProvider(
       create: (context) => AuthenticationBloc(
         userRepository: userRepository,
-      )..add(AppStarted()),
+      )..add(AuthenticationStarted()),
       child: App(userRepository: userRepository),
     ),
   );
@@ -35,10 +35,10 @@ class App extends StatelessWidget {
     return MaterialApp(
       home: BlocBuilder<AuthenticationBloc, AuthenticationState>(
         builder: (context, state) {
-          if (state is Unauthenticated) {
+          if (state is AuthenticationFailure) {
             return LoginScreen(userRepository: _userRepository);
           }
-          if (state is Authenticated) {
+          if (state is AuthenticationSuccess) {
             return HomeScreen(name: state.displayName);
           }
           return SplashScreen();

--- a/examples/flutter_firebase_login/lib/register/bloc/register_bloc.dart
+++ b/examples/flutter_firebase_login/lib/register/bloc/register_bloc.dart
@@ -14,7 +14,7 @@ class RegisterBloc extends Bloc<RegisterEvent, RegisterState> {
         _userRepository = userRepository;
 
   @override
-  RegisterState get initialState => RegisterState.empty();
+  RegisterState get initialState => RegisterState.initial();
 
   @override
   Stream<Transition<RegisterEvent, RegisterState>> transformEvents(
@@ -22,10 +22,12 @@ class RegisterBloc extends Bloc<RegisterEvent, RegisterState> {
     TransitionFunction<RegisterEvent, RegisterState> transitionFn,
   ) {
     final nonDebounceStream = events.where((event) {
-      return (event is! EmailChanged && event is! PasswordChanged);
+      return (event is! RegisterEmailChanged &&
+          event is! RegisterPasswordChanged);
     });
     final debounceStream = events.where((event) {
-      return (event is EmailChanged || event is PasswordChanged);
+      return (event is RegisterEmailChanged ||
+          event is RegisterPasswordChanged);
     }).debounceTime(Duration(milliseconds: 300));
     return super.transformEvents(
       nonDebounceStream.mergeWith([debounceStream]),
@@ -37,28 +39,29 @@ class RegisterBloc extends Bloc<RegisterEvent, RegisterState> {
   Stream<RegisterState> mapEventToState(
     RegisterEvent event,
   ) async* {
-    if (event is EmailChanged) {
-      yield* _mapEmailChangedToState(event.email);
-    } else if (event is PasswordChanged) {
-      yield* _mapPasswordChangedToState(event.password);
-    } else if (event is Submitted) {
-      yield* _mapFormSubmittedToState(event.email, event.password);
+    if (event is RegisterEmailChanged) {
+      yield* _mapRegisterEmailChangedToState(event.email);
+    } else if (event is RegisterPasswordChanged) {
+      yield* _mapRegisterPasswordChangedToState(event.password);
+    } else if (event is RegisterSubmitted) {
+      yield* _mapRegisterSubmittedToState(event.email, event.password);
     }
   }
 
-  Stream<RegisterState> _mapEmailChangedToState(String email) async* {
+  Stream<RegisterState> _mapRegisterEmailChangedToState(String email) async* {
     yield state.update(
       isEmailValid: Validators.isValidEmail(email),
     );
   }
 
-  Stream<RegisterState> _mapPasswordChangedToState(String password) async* {
+  Stream<RegisterState> _mapRegisterPasswordChangedToState(
+      String password) async* {
     yield state.update(
       isPasswordValid: Validators.isValidPassword(password),
     );
   }
 
-  Stream<RegisterState> _mapFormSubmittedToState(
+  Stream<RegisterState> _mapRegisterSubmittedToState(
     String email,
     String password,
   ) async* {

--- a/examples/flutter_firebase_login/lib/register/bloc/register_event.dart
+++ b/examples/flutter_firebase_login/lib/register/bloc/register_event.dart
@@ -8,10 +8,10 @@ abstract class RegisterEvent extends Equatable {
   List<Object> get props => [];
 }
 
-class EmailChanged extends RegisterEvent {
+class RegisterEmailChanged extends RegisterEvent {
   final String email;
 
-  const EmailChanged({@required this.email});
+  const RegisterEmailChanged({@required this.email});
 
   @override
   List<Object> get props => [email];
@@ -20,10 +20,10 @@ class EmailChanged extends RegisterEvent {
   String toString() => 'EmailChanged { email :$email }';
 }
 
-class PasswordChanged extends RegisterEvent {
+class RegisterPasswordChanged extends RegisterEvent {
   final String password;
 
-  const PasswordChanged({@required this.password});
+  const RegisterPasswordChanged({@required this.password});
 
   @override
   List<Object> get props => [password];
@@ -32,11 +32,11 @@ class PasswordChanged extends RegisterEvent {
   String toString() => 'PasswordChanged { password: $password }';
 }
 
-class Submitted extends RegisterEvent {
+class RegisterSubmitted extends RegisterEvent {
   final String email;
   final String password;
 
-  const Submitted({
+  const RegisterSubmitted({
     @required this.email,
     @required this.password,
   });

--- a/examples/flutter_firebase_login/lib/register/bloc/register_state.dart
+++ b/examples/flutter_firebase_login/lib/register/bloc/register_state.dart
@@ -18,7 +18,7 @@ class RegisterState {
     @required this.isFailure,
   });
 
-  factory RegisterState.empty() {
+  factory RegisterState.initial() {
     return RegisterState(
       isEmailValid: true,
       isPasswordValid: true,

--- a/examples/flutter_firebase_login/lib/register/register_form.dart
+++ b/examples/flutter_firebase_login/lib/register/register_form.dart
@@ -48,7 +48,8 @@ class _RegisterFormState extends State<RegisterForm> {
             );
         }
         if (state.isSuccess) {
-          BlocProvider.of<AuthenticationBloc>(context).add(LoggedIn());
+          BlocProvider.of<AuthenticationBloc>(context)
+              .add(AuthenticationLoggedIn());
           Navigator.of(context).pop();
         }
         if (state.isFailure) {
@@ -124,19 +125,19 @@ class _RegisterFormState extends State<RegisterForm> {
 
   void _onEmailChanged() {
     _registerBloc.add(
-      EmailChanged(email: _emailController.text),
+      RegisterEmailChanged(email: _emailController.text),
     );
   }
 
   void _onPasswordChanged() {
     _registerBloc.add(
-      PasswordChanged(password: _passwordController.text),
+      RegisterPasswordChanged(password: _passwordController.text),
     );
   }
 
   void _onFormSubmitted() {
     _registerBloc.add(
-      Submitted(
+      RegisterSubmitted(
         email: _emailController.text,
         password: _passwordController.text,
       ),

--- a/examples/flutter_infinite_list/lib/bloc/post_bloc.dart
+++ b/examples/flutter_infinite_list/lib/bloc/post_bloc.dart
@@ -1,12 +1,12 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:meta/meta.dart';
-import 'package:rxdart/rxdart.dart';
-import 'package:http/http.dart' as http;
 import 'package:bloc/bloc.dart';
 import 'package:flutter_infinite_list/bloc/bloc.dart';
 import 'package:flutter_infinite_list/models/models.dart';
+import 'package:http/http.dart' as http;
+import 'package:meta/meta.dart';
+import 'package:rxdart/rxdart.dart';
 
 class PostBloc extends Bloc<PostEvent, PostState> {
   final http.Client httpClient;
@@ -14,7 +14,7 @@ class PostBloc extends Bloc<PostEvent, PostState> {
   PostBloc({@required this.httpClient});
 
   @override
-  get initialState => PostUninitialized();
+  get initialState => PostInitial();
 
   @override
   Stream<Transition<PostEvent, PostState>> transformEvents(
@@ -30,30 +30,30 @@ class PostBloc extends Bloc<PostEvent, PostState> {
   @override
   Stream<PostState> mapEventToState(PostEvent event) async* {
     final currentState = state;
-    if (event is Fetch && !_hasReachedMax(currentState)) {
+    if (event is PostFetched && !_hasReachedMax(currentState)) {
       try {
-        if (currentState is PostUninitialized) {
+        if (currentState is PostInitial) {
           final posts = await _fetchPosts(0, 20);
-          yield PostLoaded(posts: posts, hasReachedMax: false);
+          yield PostSuccess(posts: posts, hasReachedMax: false);
           return;
         }
-        if (currentState is PostLoaded) {
+        if (currentState is PostSuccess) {
           final posts = await _fetchPosts(currentState.posts.length, 20);
           yield posts.isEmpty
               ? currentState.copyWith(hasReachedMax: true)
-              : PostLoaded(
+              : PostSuccess(
                   posts: currentState.posts + posts,
                   hasReachedMax: false,
                 );
         }
       } catch (_) {
-        yield PostError();
+        yield PostFailure();
       }
     }
   }
 
   bool _hasReachedMax(PostState state) =>
-      state is PostLoaded && state.hasReachedMax;
+      state is PostSuccess && state.hasReachedMax;
 
   Future<List<Post>> _fetchPosts(int startIndex, int limit) async {
     final response = await httpClient.get(

--- a/examples/flutter_infinite_list/lib/bloc/post_event.dart
+++ b/examples/flutter_infinite_list/lib/bloc/post_event.dart
@@ -5,4 +5,4 @@ abstract class PostEvent extends Equatable {
   List<Object> get props => [];
 }
 
-class Fetch extends PostEvent {}
+class PostFetched extends PostEvent {}

--- a/examples/flutter_infinite_list/lib/bloc/post_state.dart
+++ b/examples/flutter_infinite_list/lib/bloc/post_state.dart
@@ -1,5 +1,4 @@
 import 'package:equatable/equatable.dart';
-
 import 'package:flutter_infinite_list/models/models.dart';
 
 abstract class PostState extends Equatable {
@@ -9,24 +8,24 @@ abstract class PostState extends Equatable {
   List<Object> get props => [];
 }
 
-class PostUninitialized extends PostState {}
+class PostInitial extends PostState {}
 
-class PostError extends PostState {}
+class PostFailure extends PostState {}
 
-class PostLoaded extends PostState {
+class PostSuccess extends PostState {
   final List<Post> posts;
   final bool hasReachedMax;
 
-  const PostLoaded({
+  const PostSuccess({
     this.posts,
     this.hasReachedMax,
   });
 
-  PostLoaded copyWith({
+  PostSuccess copyWith({
     List<Post> posts,
     bool hasReachedMax,
   }) {
-    return PostLoaded(
+    return PostSuccess(
       posts: posts ?? this.posts,
       hasReachedMax: hasReachedMax ?? this.hasReachedMax,
     );

--- a/examples/flutter_infinite_list/lib/main.dart
+++ b/examples/flutter_infinite_list/lib/main.dart
@@ -1,10 +1,9 @@
-import 'package:flutter/material.dart';
 import 'package:bloc/bloc.dart';
-import 'package:http/http.dart' as http;
+import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
 import 'package:flutter_infinite_list/bloc/bloc.dart';
 import 'package:flutter_infinite_list/models/models.dart';
+import 'package:http/http.dart' as http;
 
 void main() {
   BlocSupervisor.delegate = SimpleBlocDelegate();
@@ -22,7 +21,7 @@ class App extends StatelessWidget {
         ),
         body: BlocProvider(
           create: (context) =>
-              PostBloc(httpClient: http.Client())..add(Fetch()),
+              PostBloc(httpClient: http.Client())..add(PostFetched()),
           child: HomePage(),
         ),
       ),
@@ -51,12 +50,12 @@ class _HomePageState extends State<HomePage> {
   Widget build(BuildContext context) {
     return BlocBuilder<PostBloc, PostState>(
       builder: (context, state) {
-        if (state is PostError) {
+        if (state is PostFailure) {
           return Center(
             child: Text('failed to fetch posts'),
           );
         }
-        if (state is PostLoaded) {
+        if (state is PostSuccess) {
           if (state.posts.isEmpty) {
             return Center(
               child: Text('no posts'),
@@ -91,7 +90,7 @@ class _HomePageState extends State<HomePage> {
     final maxScroll = _scrollController.position.maxScrollExtent;
     final currentScroll = _scrollController.position.pixels;
     if (maxScroll - currentScroll <= _scrollThreshold) {
-      _postBloc.add(Fetch());
+      _postBloc.add(PostFetched());
     }
   }
 }

--- a/examples/flutter_login/lib/authentication/authentication_bloc.dart
+++ b/examples/flutter_login/lib/authentication/authentication_bloc.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
 
-import 'package:meta/meta.dart';
 import 'package:bloc/bloc.dart';
-import 'package:user_repository/user_repository.dart';
-
 import 'package:flutter_login/authentication/authentication.dart';
+import 'package:meta/meta.dart';
+import 'package:user_repository/user_repository.dart';
 
 class AuthenticationBloc
     extends Bloc<AuthenticationEvent, AuthenticationState> {
@@ -14,32 +13,32 @@ class AuthenticationBloc
       : assert(userRepository != null);
 
   @override
-  AuthenticationState get initialState => AuthenticationUninitialized();
+  AuthenticationState get initialState => AuthenticationInitial();
 
   @override
   Stream<AuthenticationState> mapEventToState(
     AuthenticationEvent event,
   ) async* {
-    if (event is AppStarted) {
+    if (event is AuthenticationStarted) {
       final bool hasToken = await userRepository.hasToken();
 
       if (hasToken) {
-        yield AuthenticationAuthenticated();
+        yield AuthenticationSuccess();
       } else {
-        yield AuthenticationUnauthenticated();
+        yield AuthenticationFailure();
       }
     }
 
-    if (event is LoggedIn) {
-      yield AuthenticationLoading();
+    if (event is AuthenticationLoggedIn) {
+      yield AuthenticationInProgress();
       await userRepository.persistToken(event.token);
-      yield AuthenticationAuthenticated();
+      yield AuthenticationSuccess();
     }
 
-    if (event is LoggedOut) {
-      yield AuthenticationLoading();
+    if (event is AuthenticationLoggedOut) {
+      yield AuthenticationInProgress();
       await userRepository.deleteToken();
-      yield AuthenticationUnauthenticated();
+      yield AuthenticationFailure();
     }
   }
 }

--- a/examples/flutter_login/lib/authentication/authentication_event.dart
+++ b/examples/flutter_login/lib/authentication/authentication_event.dart
@@ -1,5 +1,5 @@
-import 'package:meta/meta.dart';
 import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
 
 abstract class AuthenticationEvent extends Equatable {
   const AuthenticationEvent();
@@ -8,12 +8,12 @@ abstract class AuthenticationEvent extends Equatable {
   List<Object> get props => [];
 }
 
-class AppStarted extends AuthenticationEvent {}
+class AuthenticationStarted extends AuthenticationEvent {}
 
-class LoggedIn extends AuthenticationEvent {
+class AuthenticationLoggedIn extends AuthenticationEvent {
   final String token;
 
-  const LoggedIn({@required this.token});
+  const AuthenticationLoggedIn({@required this.token});
 
   @override
   List<Object> get props => [token];
@@ -22,4 +22,4 @@ class LoggedIn extends AuthenticationEvent {
   String toString() => 'LoggedIn { token: $token }';
 }
 
-class LoggedOut extends AuthenticationEvent {}
+class AuthenticationLoggedOut extends AuthenticationEvent {}

--- a/examples/flutter_login/lib/authentication/authentication_state.dart
+++ b/examples/flutter_login/lib/authentication/authentication_state.dart
@@ -5,10 +5,10 @@ abstract class AuthenticationState extends Equatable {
   List<Object> get props => [];
 }
 
-class AuthenticationUninitialized extends AuthenticationState {}
+class AuthenticationInitial extends AuthenticationState {}
 
-class AuthenticationAuthenticated extends AuthenticationState {}
+class AuthenticationSuccess extends AuthenticationState {}
 
-class AuthenticationUnauthenticated extends AuthenticationState {}
+class AuthenticationFailure extends AuthenticationState {}
 
-class AuthenticationLoading extends AuthenticationState {}
+class AuthenticationInProgress extends AuthenticationState {}

--- a/examples/flutter_login/lib/home/home_page.dart
+++ b/examples/flutter_login/lib/home/home_page.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-
 import 'package:flutter_bloc/flutter_bloc.dart';
-
 import 'package:flutter_login/authentication/authentication.dart';
 
 class HomePage extends StatelessWidget {
@@ -16,7 +14,8 @@ class HomePage extends StatelessWidget {
             child: RaisedButton(
           child: Text('logout'),
           onPressed: () {
-            BlocProvider.of<AuthenticationBloc>(context).add(LoggedOut());
+            BlocProvider.of<AuthenticationBloc>(context)
+                .add(AuthenticationLoggedOut());
           },
         )),
       ),

--- a/examples/flutter_login/lib/login/bloc/login_bloc.dart
+++ b/examples/flutter_login/lib/login/bloc/login_bloc.dart
@@ -1,11 +1,10 @@
 import 'dart:async';
 
-import 'package:meta/meta.dart';
-import 'package:equatable/equatable.dart';
 import 'package:bloc/bloc.dart';
-import 'package:user_repository/user_repository.dart';
-
+import 'package:equatable/equatable.dart';
 import 'package:flutter_login/authentication/authentication.dart';
+import 'package:meta/meta.dart';
+import 'package:user_repository/user_repository.dart';
 
 part 'login_event.dart';
 part 'login_state.dart';
@@ -26,7 +25,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
   @override
   Stream<LoginState> mapEventToState(LoginEvent event) async* {
     if (event is LoginButtonPressed) {
-      yield LoginLoading();
+      yield LoginInProgress();
 
       try {
         final token = await userRepository.authenticate(
@@ -34,7 +33,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
           password: event.password,
         );
 
-        authenticationBloc.add(LoggedIn(token: token));
+        authenticationBloc.add(AuthenticationLoggedIn(token: token));
         yield LoginInitial();
       } catch (error) {
         yield LoginFailure(error: error.toString());

--- a/examples/flutter_login/lib/login/bloc/login_state.dart
+++ b/examples/flutter_login/lib/login/bloc/login_state.dart
@@ -9,7 +9,7 @@ abstract class LoginState extends Equatable {
 
 class LoginInitial extends LoginState {}
 
-class LoginLoading extends LoginState {}
+class LoginInProgress extends LoginState {}
 
 class LoginFailure extends LoginState {
   final String error;

--- a/examples/flutter_login/lib/login/login_form.dart
+++ b/examples/flutter_login/lib/login/login_form.dart
@@ -49,11 +49,11 @@ class _LoginFormState extends State<LoginForm> {
                 ),
                 RaisedButton(
                   onPressed:
-                      state is! LoginLoading ? _onLoginButtonPressed : null,
+                      state is! LoginInProgress ? _onLoginButtonPressed : null,
                   child: Text('Login'),
                 ),
                 Container(
-                  child: state is LoginLoading
+                  child: state is LoginInProgress
                       ? CircularProgressIndicator()
                       : null,
                 ),

--- a/examples/flutter_login/lib/login/login_page.dart
+++ b/examples/flutter_login/lib/login/login_page.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/material.dart';
-
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_login/login/login_form.dart';
-import 'package:user_repository/user_repository.dart';
-
 import 'package:flutter_login/authentication/authentication.dart';
 import 'package:flutter_login/login/bloc/login_bloc.dart';
+import 'package:flutter_login/login/login_form.dart';
+import 'package:user_repository/user_repository.dart';
 
 class LoginPage extends StatelessWidget {
   final UserRepository userRepository;

--- a/examples/flutter_login/lib/main.dart
+++ b/examples/flutter_login/lib/main.dart
@@ -1,14 +1,12 @@
-import 'package:flutter/material.dart';
-
 import 'package:bloc/bloc.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_login/login/login_page.dart';
-import 'package:user_repository/user_repository.dart';
-
 import 'package:flutter_login/authentication/authentication.dart';
-import 'package:flutter_login/splash/splash.dart';
-import 'package:flutter_login/home/home.dart';
 import 'package:flutter_login/common/common.dart';
+import 'package:flutter_login/home/home.dart';
+import 'package:flutter_login/login/login_page.dart';
+import 'package:flutter_login/splash/splash.dart';
+import 'package:user_repository/user_repository.dart';
 
 class SimpleBlocDelegate extends BlocDelegate {
   @override
@@ -37,7 +35,7 @@ void main() {
     BlocProvider<AuthenticationBloc>(
       create: (context) {
         return AuthenticationBloc(userRepository: userRepository)
-          ..add(AppStarted());
+          ..add(AuthenticationStarted());
       },
       child: App(userRepository: userRepository),
     ),
@@ -54,13 +52,13 @@ class App extends StatelessWidget {
     return MaterialApp(
       home: BlocBuilder<AuthenticationBloc, AuthenticationState>(
         builder: (context, state) {
-          if (state is AuthenticationAuthenticated) {
+          if (state is AuthenticationSuccess) {
             return HomePage();
           }
-          if (state is AuthenticationUnauthenticated) {
+          if (state is AuthenticationFailure) {
             return LoginPage(userRepository: userRepository);
           }
-          if (state is AuthenticationLoading) {
+          if (state is AuthenticationInProgress) {
             return LoadingIndicator();
           }
           return SplashPage();

--- a/examples/flutter_login/test/unit/authentication/authentication_bloc_test.dart
+++ b/examples/flutter_login/test/unit/authentication/authentication_bloc_test.dart
@@ -29,13 +29,13 @@ void main() {
   });
 
   test('initial state is correct', () {
-    expect(authenticationBloc.initialState, AuthenticationUninitialized());
+    expect(authenticationBloc.initialState, AuthenticationInitial());
   });
 
   test('close does not emit new states', () {
     expectLater(
       authenticationBloc,
-      emitsInOrder([AuthenticationUninitialized(), emitsDone]),
+      emitsInOrder([AuthenticationInitial(), emitsDone]),
     );
     authenticationBloc.close();
   });
@@ -47,9 +47,9 @@ void main() {
         when(userRepository.hasToken()).thenAnswer((_) => Future.value(false));
         return authenticationBloc;
       },
-      act: (bloc) => bloc.add(AppStarted()),
+      act: (bloc) => bloc.add(AuthenticationStarted()),
       expect: [
-        AuthenticationUnauthenticated(),
+        AuthenticationFailure(),
       ],
     );
 
@@ -59,9 +59,9 @@ void main() {
         when(userRepository.hasToken()).thenAnswer((_) => Future.value(true));
         return authenticationBloc;
       },
-      act: (bloc) => bloc.add(AppStarted()),
+      act: (bloc) => bloc.add(AuthenticationStarted()),
       expect: [
-        AuthenticationAuthenticated(),
+        AuthenticationSuccess(),
       ],
     );
   });
@@ -70,10 +70,10 @@ void main() {
     blocTest(
       'emits [loading, authenticated] when token is persisted',
       build: () async => authenticationBloc,
-      act: (bloc) => bloc.add(LoggedIn(token: 'instance.token')),
+      act: (bloc) => bloc.add(AuthenticationLoggedIn(token: 'instance.token')),
       expect: [
-        AuthenticationLoading(),
-        AuthenticationAuthenticated(),
+        AuthenticationInProgress(),
+        AuthenticationSuccess(),
       ],
     );
   });
@@ -82,10 +82,10 @@ void main() {
     blocTest(
       'emits [loading, unauthenticated] when token is deleted',
       build: () async => authenticationBloc,
-      act: (bloc) => bloc.add(LoggedOut()),
+      act: (bloc) => bloc.add(AuthenticationLoggedOut()),
       expect: [
-        AuthenticationLoading(),
-        AuthenticationUnauthenticated(),
+        AuthenticationInProgress(),
+        AuthenticationFailure(),
       ],
     );
   });

--- a/examples/flutter_login/test/unit/authentication/authentication_event_test.dart
+++ b/examples/flutter_login/test/unit/authentication/authentication_event_test.dart
@@ -3,13 +3,13 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('AuthenticationEvent', () {
-    group('AppStarted', () {
+    group('AuthenticationStarted', () {
       test('props are []', () {
         expect(AuthenticationStarted().props, []);
       });
 
-      test('toString is "AppStarted"', () {
-        expect(AuthenticationStarted().toString(), 'AppStarted');
+      test('toString is "AuthenticationStarted"', () {
+        expect(AuthenticationStarted().toString(), 'AuthenticationStarted');
       });
     });
 
@@ -26,13 +26,13 @@ void main() {
       });
     });
 
-    group('LoggedOut', () {
+    group('AuthenticationLoggedOut', () {
       test('props are []', () {
         expect(AuthenticationLoggedOut().props, []);
       });
 
-      test('toString is "LoggedOut"', () {
-        expect(AuthenticationLoggedOut().toString(), 'LoggedOut');
+      test('toString is "AuthenticationLoggedOut"', () {
+        expect(AuthenticationLoggedOut().toString(), 'AuthenticationLoggedOut');
       });
     });
   });

--- a/examples/flutter_login/test/unit/authentication/authentication_event_test.dart
+++ b/examples/flutter_login/test/unit/authentication/authentication_event_test.dart
@@ -5,22 +5,22 @@ void main() {
   group('AuthenticationEvent', () {
     group('AppStarted', () {
       test('props are []', () {
-        expect(AppStarted().props, []);
+        expect(AuthenticationStarted().props, []);
       });
 
       test('toString is "AppStarted"', () {
-        expect(AppStarted().toString(), 'AppStarted');
+        expect(AuthenticationStarted().toString(), 'AppStarted');
       });
     });
 
     group('LoggedIn', () {
       test('props are [token]', () {
-        expect(LoggedIn(token: 'token').props, ['token']);
+        expect(AuthenticationLoggedIn(token: 'token').props, ['token']);
       });
 
       test('toString is "LoggedIn { token: token }"', () {
         expect(
-          LoggedIn(token: 'token').toString(),
+          AuthenticationLoggedIn(token: 'token').toString(),
           'LoggedIn { token: token }',
         );
       });
@@ -28,11 +28,11 @@ void main() {
 
     group('LoggedOut', () {
       test('props are []', () {
-        expect(LoggedOut().props, []);
+        expect(AuthenticationLoggedOut().props, []);
       });
 
       test('toString is "LoggedOut"', () {
-        expect(LoggedOut().toString(), 'LoggedOut');
+        expect(AuthenticationLoggedOut().toString(), 'LoggedOut');
       });
     });
   });

--- a/examples/flutter_login/test/unit/authentication/authentication_event_test.dart
+++ b/examples/flutter_login/test/unit/authentication/authentication_event_test.dart
@@ -13,7 +13,7 @@ void main() {
       });
     });
 
-    group('LoggedIn', () {
+    group('AuthenticationLoggedIn', () {
       test('props are [token]', () {
         expect(AuthenticationLoggedIn(token: 'token').props, ['token']);
       });

--- a/examples/flutter_login/test/unit/login/login_bloc_test.dart
+++ b/examples/flutter_login/test/unit/login/login_bloc_test.dart
@@ -79,11 +79,11 @@ void main() {
         ),
       ),
       expect: [
-        LoginLoading(),
+        LoginInProgress(),
         LoginInitial(),
       ],
       verify: (_) async {
-        verify(authenticationBloc.add(LoggedIn(token: 'token'))).called(1);
+        verify(authenticationBloc.add(AuthenticationLoggedIn(token: 'token'))).called(1);
       },
     );
 
@@ -103,7 +103,7 @@ void main() {
         ),
       ),
       expect: [
-        LoginLoading(),
+        LoginInProgress(),
         LoginFailure(error: 'Exception: login-error'),
       ],
       verify: (_) async {

--- a/examples/flutter_login/test/unit/login/login_bloc_test.dart
+++ b/examples/flutter_login/test/unit/login/login_bloc_test.dart
@@ -83,7 +83,8 @@ void main() {
         LoginInitial(),
       ],
       verify: (_) async {
-        verify(authenticationBloc.add(AuthenticationLoggedIn(token: 'token'))).called(1);
+        verify(authenticationBloc.add(AuthenticationLoggedIn(token: 'token')))
+            .called(1);
       },
     );
 

--- a/examples/flutter_login/test/unit/login/login_event_test.dart
+++ b/examples/flutter_login/test/unit/login/login_event_test.dart
@@ -12,7 +12,10 @@ void main() {
       });
 
       test(
-          'toString is LoginButtonPressed { username: username, password: password }',
+          //removed 'toString' as it would fail command:
+          // flutter format --set-exit-if-changed test
+          //line length exceeded 80 characters
+          'is LoginButtonPressed { username: username, password: password }',
           () {
         expect(
           LoginButtonPressed(

--- a/examples/flutter_login/test/unit/login/login_event_test.dart
+++ b/examples/flutter_login/test/unit/login/login_event_test.dart
@@ -12,11 +12,9 @@ void main() {
       });
 
       test(
-          //removed 'toString' as it would fail command:
-          // flutter format --set-exit-if-changed test
-          //line length exceeded 80 characters
-          'is LoginButtonPressed { username: username, password: password }',
-          () {
+          'toString is '
+          'LoginButtonPressed '
+          '{ username: username, password: password }', () {
         expect(
           LoginButtonPressed(
             username: 'username',

--- a/examples/flutter_login/test/unit/login/login_state_test.dart
+++ b/examples/flutter_login/test/unit/login/login_state_test.dart
@@ -15,11 +15,11 @@ void main() {
 
     group('LoginLoading', () {
       test('props are []', () {
-        expect(LoginLoading().props, []);
+        expect(LoginInProgress().props, []);
       });
 
       test('toString is LoginLoading', () {
-        expect(LoginLoading().toString(), 'LoginLoading');
+        expect(LoginInProgress().toString(), 'LoginLoading');
       });
     });
 

--- a/examples/flutter_login/test/unit/login/login_state_test.dart
+++ b/examples/flutter_login/test/unit/login/login_state_test.dart
@@ -13,13 +13,13 @@ void main() {
       });
     });
 
-    group('LoginLoading', () {
+    group('LoginInProgress', () {
       test('props are []', () {
         expect(LoginInProgress().props, []);
       });
 
       test('toString is LoginLoading', () {
-        expect(LoginInProgress().toString(), 'LoginLoading');
+        expect(LoginInProgress().toString(), 'LoginInProgress');
       });
     });
 

--- a/examples/flutter_timer/lib/bloc/timer_bloc.dart
+++ b/examples/flutter_timer/lib/bloc/timer_bloc.dart
@@ -18,7 +18,7 @@ class TimerBloc extends Bloc<TimerEvent, TimerState> {
         _ticker = ticker;
 
   @override
-  TimerState get initialState => Ready(_duration);
+  TimerState get initialState => TimerInitial(_duration);
 
   @override
   void onTransition(Transition<TimerEvent, TimerState> transition) {
@@ -30,16 +30,16 @@ class TimerBloc extends Bloc<TimerEvent, TimerState> {
   Stream<TimerState> mapEventToState(
     TimerEvent event,
   ) async* {
-    if (event is Start) {
-      yield* _mapStartToState(event);
-    } else if (event is Pause) {
-      yield* _mapPauseToState(event);
-    } else if (event is Resume) {
-      yield* _mapResumeToState(event);
-    } else if (event is Reset) {
-      yield* _mapResetToState(event);
-    } else if (event is Tick) {
-      yield* _mapTickToState(event);
+    if (event is TimerStarted) {
+      yield* _mapTimerStartedToState(event);
+    } else if (event is TimerPaused) {
+      yield* _mapTimerPausedToState(event);
+    } else if (event is TimerResumed) {
+      yield* _mapTimerResumedToState(event);
+    } else if (event is TimerReset) {
+      yield* _mapTimerResetToState(event);
+    } else if (event is TimerTicked) {
+      yield* _mapTimerTickedToState(event);
     }
   }
 
@@ -49,34 +49,36 @@ class TimerBloc extends Bloc<TimerEvent, TimerState> {
     return super.close();
   }
 
-  Stream<TimerState> _mapStartToState(Start start) async* {
-    yield Running(start.duration);
+  Stream<TimerState> _mapTimerStartedToState(TimerStarted start) async* {
+    yield TimerRunInProgress(start.duration);
     _tickerSubscription?.cancel();
     _tickerSubscription = _ticker
         .tick(ticks: start.duration)
-        .listen((duration) => add(Tick(duration: duration)));
+        .listen((duration) => add(TimerTicked(duration: duration)));
   }
 
-  Stream<TimerState> _mapPauseToState(Pause pause) async* {
-    if (state is Running) {
+  Stream<TimerState> _mapTimerPausedToState(TimerPaused pause) async* {
+    if (state is TimerRunInProgress) {
       _tickerSubscription?.pause();
-      yield Paused(state.duration);
+      yield TimerRunPause(state.duration);
     }
   }
 
-  Stream<TimerState> _mapResumeToState(Resume resume) async* {
-    if (state is Paused) {
+  Stream<TimerState> _mapTimerResumedToState(TimerResumed resume) async* {
+    if (state is TimerRunPause) {
       _tickerSubscription?.resume();
-      yield Running(state.duration);
+      yield TimerRunInProgress(state.duration);
     }
   }
 
-  Stream<TimerState> _mapResetToState(Reset reset) async* {
+  Stream<TimerState> _mapTimerResetToState(TimerReset reset) async* {
     _tickerSubscription?.cancel();
-    yield Ready(_duration);
+    yield TimerInitial(_duration);
   }
 
-  Stream<TimerState> _mapTickToState(Tick tick) async* {
-    yield tick.duration > 0 ? Running(tick.duration) : Finished();
+  Stream<TimerState> _mapTimerTickedToState(TimerTicked tick) async* {
+    yield tick.duration > 0
+        ? TimerRunInProgress(tick.duration)
+        : TimerRunComplete();
   }
 }

--- a/examples/flutter_timer/lib/bloc/timer_event.dart
+++ b/examples/flutter_timer/lib/bloc/timer_event.dart
@@ -7,25 +7,25 @@ abstract class TimerEvent extends Equatable {
   List<Object> get props => [];
 }
 
-class Start extends TimerEvent {
+class TimerStarted extends TimerEvent {
   final int duration;
 
-  const Start({@required this.duration});
+  const TimerStarted({@required this.duration});
 
   @override
   String toString() => "Start { duration: $duration }";
 }
 
-class Pause extends TimerEvent {}
+class TimerPaused extends TimerEvent {}
 
-class Resume extends TimerEvent {}
+class TimerResumed extends TimerEvent {}
 
-class Reset extends TimerEvent {}
+class TimerReset extends TimerEvent {}
 
-class Tick extends TimerEvent {
+class TimerTicked extends TimerEvent {
   final int duration;
 
-  const Tick({@required this.duration});
+  const TimerTicked({@required this.duration});
 
   @override
   List<Object> get props => [duration];

--- a/examples/flutter_timer/lib/bloc/timer_state.dart
+++ b/examples/flutter_timer/lib/bloc/timer_state.dart
@@ -9,27 +9,27 @@ abstract class TimerState extends Equatable {
   List<Object> get props => [duration];
 }
 
-class Ready extends TimerState {
-  const Ready(int duration) : super(duration);
+class TimerInitial extends TimerState {
+  const TimerInitial(int duration) : super(duration);
 
   @override
   String toString() => 'Ready { duration: $duration }';
 }
 
-class Paused extends TimerState {
-  const Paused(int duration) : super(duration);
+class TimerRunPause extends TimerState {
+  const TimerRunPause(int duration) : super(duration);
 
   @override
   String toString() => 'Paused { duration: $duration }';
 }
 
-class Running extends TimerState {
-  const Running(int duration) : super(duration);
+class TimerRunInProgress extends TimerState {
+  const TimerRunInProgress(int duration) : super(duration);
 
   @override
   String toString() => 'Running { duration: $duration }';
 }
 
-class Finished extends TimerState {
-  const Finished() : super(0);
+class TimerRunComplete extends TimerState {
+  const TimerRunComplete() : super(0);
 }

--- a/examples/flutter_timer/lib/main.dart
+++ b/examples/flutter_timer/lib/main.dart
@@ -91,44 +91,44 @@ class Actions extends StatelessWidget {
     TimerBloc timerBloc,
   }) {
     final TimerState currentState = timerBloc.state;
-    if (currentState is Ready) {
+    if (currentState is TimerInitial) {
       return [
         FloatingActionButton(
           child: Icon(Icons.play_arrow),
           onPressed: () =>
-              timerBloc.add(Start(duration: currentState.duration)),
+              timerBloc.add(TimerStarted(duration: currentState.duration)),
         ),
       ];
     }
-    if (currentState is Running) {
+    if (currentState is TimerRunInProgress) {
       return [
         FloatingActionButton(
           child: Icon(Icons.pause),
-          onPressed: () => timerBloc.add(Pause()),
+          onPressed: () => timerBloc.add(TimerPaused()),
         ),
         FloatingActionButton(
           child: Icon(Icons.replay),
-          onPressed: () => timerBloc.add(Reset()),
+          onPressed: () => timerBloc.add(TimerReset()),
         ),
       ];
     }
-    if (currentState is Paused) {
+    if (currentState is TimerRunPause) {
       return [
         FloatingActionButton(
           child: Icon(Icons.play_arrow),
-          onPressed: () => timerBloc.add(Resume()),
+          onPressed: () => timerBloc.add(TimerResumed()),
         ),
         FloatingActionButton(
           child: Icon(Icons.replay),
-          onPressed: () => timerBloc.add(Reset()),
+          onPressed: () => timerBloc.add(TimerReset()),
         ),
       ];
     }
-    if (currentState is Finished) {
+    if (currentState is TimerRunComplete) {
       return [
         FloatingActionButton(
           child: Icon(Icons.replay),
-          onPressed: () => timerBloc.add(Reset()),
+          onPressed: () => timerBloc.add(TimerReset()),
         ),
       ];
     }


### PR DESCRIPTION
# Status
**READY**

## Breaking Changes
NO, the changes introduced do not break the project.

## Description
This PR addresses Issue #1024
Currently I have refactored three examples, namely, flutter_timer, flutter_firebase_login, flutter_bloc_with_stream. I have followed the official naming conventions as strictly as possible.

This PR contains all the changes in the last PR and incorporated all the changes you suggestes. I've even started refactoring other examples. I'll push them when all are completed.

Thank you for being patient with me as this is the first time I'm trying to contribute to other projects. I've fixed the squash I did by mistake. 

## Related PRs
List related PRs against other branches:

branch | PR
#1124  | [link](https://github.com/felangel/bloc/pull/1124)


## Todos
None

## Steps to Test or Reproduce
NA

## Impact to Remaining Code Base
This PR will affect:
This will not affect the working of any other part of the project

* 
