### PR TITLE
angular_bloc v5.0.0-dev.1

### DIFF
--- a/examples/angular_counter/lib/src/counter_page/counter_page_component.css
+++ b/examples/angular_counter/lib/src/counter_page/counter_page_component.css
@@ -2,7 +2,10 @@
   text-align: center;
 }
 
-.counter-fab-button {
+.counter-button {
   background: lightskyblue;
   color: black;
+  padding: 24px;
+  border-radius: 50%;
+  font-size: 24px;
 }

--- a/examples/angular_counter/lib/src/counter_page/counter_page_component.dart
+++ b/examples/angular_counter/lib/src/counter_page/counter_page_component.dart
@@ -1,5 +1,4 @@
 import 'package:angular/angular.dart';
-import 'package:angular_components/angular_components.dart';
 
 import 'package:angular_bloc/angular_bloc.dart';
 
@@ -9,7 +8,6 @@ import './counter_bloc.dart';
   selector: 'counter-page',
   templateUrl: 'counter_page_component.html',
   styleUrls: ['counter_page_component.css'],
-  directives: [MaterialFabComponent],
   providers: [ClassProvider(CounterBloc)],
   pipes: [BlocPipe],
 )

--- a/examples/angular_counter/lib/src/counter_page/counter_page_component.html
+++ b/examples/angular_counter/lib/src/counter_page/counter_page_component.html
@@ -1,6 +1,6 @@
 <div class="counter-page-container">
   <h1>Counter App</h1>
   <h2>Current Count: {{ counterBloc | bloc }}</h2>
-  <material-fab class="counter-fab-button" (trigger)="increment()">+</material-fab>
-  <material-fab class="counter-fab-button" (trigger)="decrement()">-</material-fab>
+  <button class="counter-button" (click)="increment()">➕</button>
+  <button class="counter-button" (click)="decrement()">➖</button>
 </div>

--- a/examples/angular_counter/pubspec.yaml
+++ b/examples/angular_counter/pubspec.yaml
@@ -5,14 +5,10 @@ environment:
   sdk: ">=2.6.0 <3.0.0"
 
 dependencies:
-  angular: ^5.3.0
-  angular_components: ^0.13.0
+  angular: ^6.0.0-alpha+1
   angular_bloc:
     path: ../../packages/angular_bloc
 
 dev_dependencies:
-  angular_test: ^2.0.0
   build_runner: ">=1.6.2 <2.0.0"
-  build_test: ^0.10.2
   build_web_compilers: ">=1.2.0 <3.0.0"
-  test: ^1.0.0

--- a/packages/angular_bloc/CHANGELOG.md
+++ b/packages/angular_bloc/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.0.0-dev.1
+
+Update to `angular_dart: ^6.0.0-alpha+1`
+
 # 4.0.0
 
 Update to `bloc: ^4.0.0`

--- a/packages/angular_bloc/README.md
+++ b/packages/angular_bloc/README.md
@@ -54,12 +54,8 @@ class CounterBloc extends Bloc<CounterEvent, int> {
 <div class="counter-page-container">
   <h1>Counter App</h1>
   <h2>Current Count: {{ counterBloc | bloc }}</h2>
-  <material-fab class="counter-fab-button" (trigger)="increment()"
-    >+</material-fab
-  >
-  <material-fab class="counter-fab-button" (trigger)="decrement()"
-    >-</material-fab
-  >
+  <button class="counter-button" (click)="increment()">+</button>
+  <button class="counter-button" (click)="decrement()">-</button>
 </div>
 ```
 
@@ -67,7 +63,6 @@ class CounterBloc extends Bloc<CounterEvent, int> {
 
 ```dart
 import 'package:angular/angular.dart';
-import 'package:angular_components/angular_components.dart';
 
 import 'package:angular_bloc/angular_bloc.dart';
 
@@ -77,7 +72,6 @@ import './counter_bloc.dart';
   selector: 'counter-page',
   templateUrl: 'counter_page_component.html',
   styleUrls: ['counter_page_component.css'],
-  directives: [MaterialFabComponent],
   pipes: [BlocPipe],
 )
 class CounterPageComponent implements OnInit, OnDestroy {

--- a/packages/angular_bloc/pubspec.yaml
+++ b/packages/angular_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: angular_bloc
 description: Angular Components that make it easy to implement the BLoC (Business Logic Component) design pattern. Built to be used with the bloc state management package.
-version: 4.0.0
+version: 5.0.0-dev.1
 repository: https://github.com/felangel/bloc/tree/master/packages/angular_bloc
 issue_tracker: https://github.com/felangel/bloc/issues
 homepage: https://bloclibrary.dev
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.6.0 <3.0.0"
 
 dependencies:
-  angular: ^5.3.0
+  angular: ^6.0.0-alpha+1
   bloc: ^4.0.0
 
 dev_dependencies:


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
YES

## Description
closes #1174 
- Update `angular_bloc` to `angular_dart: ^6.0.0-alpha+1`

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
- updates which will be released pending merge in v5.0.0-dev.1