### PR TITLE
suppress BlocUnhandledErrorException in debug mode when delegate.onEr…

### DIFF
--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -141,9 +141,11 @@ abstract class Bloc<Event, State> extends Stream<State> implements Sink<Event> {
   /// ```
   @mustCallSuper
   void onError(Object error, StackTrace stackTrace) {
-    BlocSupervisor.delegate.onError(this, error, stackTrace);
+    final caught = BlocSupervisor.delegate.onError(this, error, stackTrace);
     assert(() {
-      throw BlocUnhandledErrorException(this, error, stackTrace);
+      if(caught == null) {
+        throw BlocUnhandledErrorException(this, error, stackTrace);
+      }
     }());
   }
 

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -141,7 +141,12 @@ abstract class Bloc<Event, State> extends Stream<State> implements Sink<Event> {
   /// ```
   @mustCallSuper
   void onError(Object error, StackTrace stackTrace) {
-    assert(BlocSupervisor.delegate.onError(this, error, stackTrace) != null);
+    final caught = BlocSupervisor.delegate.onError(this, error, stackTrace);
+    assert(() {
+      if(caught == null) {
+        throw BlocUnhandledErrorException(this, error, stackTrace);
+      }
+    }());
   }
 
   /// Notifies the [bloc] of a new [event] which triggers [mapEventToState].

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -141,12 +141,7 @@ abstract class Bloc<Event, State> extends Stream<State> implements Sink<Event> {
   /// ```
   @mustCallSuper
   void onError(Object error, StackTrace stackTrace) {
-    final caught = BlocSupervisor.delegate.onError(this, error, stackTrace);
-    assert(() {
-      if(caught == null) {
-        throw BlocUnhandledErrorException(this, error, stackTrace);
-      }
-    }());
+    assert(BlocSupervisor.delegate.onError(this, error, stackTrace) != null);
   }
 
   /// Notifies the [bloc] of a new [event] which triggers [mapEventToState].

--- a/packages/bloc/lib/src/bloc_delegate.dart
+++ b/packages/bloc/lib/src/bloc_delegate.dart
@@ -24,7 +24,15 @@ class BlocDelegate {
   /// [error], and [stackTrace].
   /// The [stackTrace] argument may be `null` if the state stream received
   /// an error without a [stackTrace].
+  ///
   /// A great spot to add universal error handling.
+  ///
+  /// Returning a non-null value will mimic the production behavior, i.e. all
+  /// exceptions are ignored unless explicitly re-thrown
+  ///
+  /// If null is returned (default) the super.onError will throw a
+  /// BlocUnhandledErrorException in debug mode
+  ///
   @mustCallSuper
-  void onError(Bloc bloc, Object error, StackTrace stackTrace) => null;
+  dynamic onError(Bloc bloc, Object error, StackTrace stackTrace) => null;
 }


### PR DESCRIPTION
suppress certain BlocUnhandledErrorException in debug mode when delegate.onError returns non-null

This introduces a slight change in error handling behavior in debug mode:

Returning a non-null value from delegate.onError will mimic the production behavior, i.e. all exceptions are ignored unless explicitly re-thrown.

If null is returned (default) the super.onError will throw a BlocUnhandledErrorException in debug mode only (current behavior).

## Status
**READY/**

## Breaking Changes
NO

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Examples
