### PR TITLE
flutter_bloc: Fix provider exception

### DIFF
--- a/packages/flutter_bloc/lib/src/bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/bloc_provider.dart
@@ -103,7 +103,8 @@ class BlocProvider<T extends Bloc<dynamic, dynamic>>
   static T of<T extends Bloc<dynamic, dynamic>>(BuildContext context) {
     try {
       return Provider.of<T>(context, listen: false);
-    } on ProviderNotFoundException catch (_) {
+    } on ProviderNotFoundException catch (e) {
+      if (e.valueType != T) rethrow;
       throw FlutterError(
         """
         BlocProvider.of() called with a context that does not contain a Bloc of type $T.

--- a/packages/flutter_bloc/test/bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/bloc_provider_test.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
-
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
 
 class MyApp extends StatelessWidget {
   final CounterBloc Function(BuildContext context) _create;
@@ -434,6 +434,20 @@ void main() {
 """;
       expect(exception is FlutterError, true);
       expect(exception.message, expectedMessage);
+    });
+
+    testWidgets(
+        'should not wrap into FlutterError if '
+        'ProviderNotFoundException with wrong valueType '
+        'is thrown', (tester) async {
+      await tester.pumpWidget(
+        BlocProvider<CounterBloc>(
+          create: (context) => CounterBloc(onClose: Provider.of(context)),
+          child: CounterPage(),
+        ),
+      );
+      final dynamic exception = tester.takeException();
+      expect(exception is ProviderNotFoundException, true);
     });
 
     testWidgets(


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
If BLoC depends on something injected with `Provider` and it's **not** lazily created, the exception is wrapped into `FlutterError` and provides description related to `BlocProvider`. That is wrong and confusing for the client as the problem is not in missing BLoC.

This PR fixes the error by checking the `valueType` of the thrown exception.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Examples
