### PR TITLE
(flutter_bloc) BlocState & ProvidedBlocState

### DIFF
--- a/packages/flutter_bloc/lib/flutter_bloc.dart
+++ b/packages/flutter_bloc/lib/flutter_bloc.dart
@@ -6,8 +6,10 @@ export './src/bloc_builder.dart';
 export './src/bloc_consumer.dart';
 export './src/bloc_listener.dart' hide BlocListenerSingleChildWidget;
 export './src/bloc_provider.dart' hide BlocProviderSingleChildWidget;
+export './src/bloc_state.dart';
 export './src/multi_bloc_listener.dart';
 export './src/multi_bloc_provider.dart';
 export './src/multi_repository_provider.dart';
+export './src/provided_bloc_state.dart';
 export './src/repository_provider.dart'
     hide RepositoryProviderSingleChildWidget;

--- a/packages/flutter_bloc/lib/src/bloc_state.dart
+++ b/packages/flutter_bloc/lib/src/bloc_state.dart
@@ -1,0 +1,27 @@
+import 'package:bloc/bloc.dart';
+
+import 'package:flutter/widgets.dart';
+
+/// [State] with defined [Bloc]
+/// uses stateBloc function to initialize Bloc and provide it
+/// to [State] as an object
+abstract class BlocState<T extends StatefulWidget, B extends Bloc>
+    extends State<T> {
+  ///public Bloc object in a [State]
+  B bloc;
+
+  ///abstract Function to create a Bloc
+  B stateBloc(BuildContext context);
+
+  @override
+  void initState() {
+    bloc = stateBloc(context);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    bloc.close();
+    super.dispose();
+  }
+}

--- a/packages/flutter_bloc/lib/src/provided_bloc_state.dart
+++ b/packages/flutter_bloc/lib/src/provided_bloc_state.dart
@@ -11,17 +11,10 @@ abstract class ProvidedBlocState<T extends StatefulWidget, B extends Bloc>
   ///public Bloc object in a [State]
   B bloc;
 
-  B _stateBloc(BuildContext context) => BlocProvider.of<B>(context);
-
   @override
   void initState() {
-    bloc = _stateBloc(context);
+    bloc = BlocProvider.of<B>(context);
     super.initState();
   }
 
-  @override
-  void dispose() {
-    bloc.close();
-    super.dispose();
-  }
 }

--- a/packages/flutter_bloc/lib/src/provided_bloc_state.dart
+++ b/packages/flutter_bloc/lib/src/provided_bloc_state.dart
@@ -1,0 +1,27 @@
+import 'package:bloc/bloc.dart';
+
+import 'package:flutter/widgets.dart';
+import 'bloc_provider.dart';
+
+/// [State] with provided defined [Bloc]
+/// gets Bloc from [BuildContext] and provides it
+/// to [State] as an object
+abstract class ProvidedBlocState<T extends StatefulWidget, B extends Bloc>
+    extends State<T> {
+  ///public Bloc object in a [State]
+  B bloc;
+
+  B _stateBloc(BuildContext context) => BlocProvider.of<B>(context);
+
+  @override
+  void initState() {
+    bloc = _stateBloc(context);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    bloc.close();
+    super.dispose();
+  }
+}


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
To reduce boilerplate Bloc can be initialized/provided and closed in a State under the hood.


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Examples

## Impact to Remaining Code Base
This PR will affect:

* reduce boilerplate