### PR TITLE
feat(bloc): do not throw in onError with custom observer

### DIFF
--- a/packages/bloc/CHANGELOG.md
+++ b/packages/bloc/CHANGELOG.md
@@ -1,10 +1,14 @@
+# 5.0.0-dev.11
+
+- feat: do not throw `BlocUnhandledException` when custom `BlocObserver` is used ([#1254](https://github.com/felangel/bloc/issues/1254)).
+
 # 5.0.0-dev.10
 
-- docs: additional minor improvement to bloc logo alignment
+- docs: additional minor improvement to bloc logo alignment.
 
 # 5.0.0-dev.9
 
-- docs: minor improvement to bloc logo alignment
+- docs: minor improvement to bloc logo alignment.
 
 # 5.0.0-dev.8
 

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -108,9 +108,11 @@ abstract class Bloc<Event, State> extends CubitStream<State>
   @mustCallSuper
   void onError(Object error, StackTrace stackTrace) {
     observer.onError(this, error, stackTrace);
-    assert(() {
-      throw BlocUnhandledErrorException(this, error, stackTrace);
-    }());
+    if (observer.isDefault) {
+      assert(() {
+        throw BlocUnhandledErrorException(this, error, stackTrace);
+      }());
+    }
   }
 
   /// Notifies the [bloc] of a new [event] which triggers [mapEventToState].
@@ -242,4 +244,8 @@ abstract class Bloc<Event, State> extends CubitStream<State>
       }
     }, onError: onError);
   }
+}
+
+extension on BlocObserver {
+  bool get isDefault => runtimeType == BlocObserver;
 }

--- a/packages/bloc/pubspec.yaml
+++ b/packages/bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc
 description: A predictable state management library that helps implement the BLoC (Business Logic Component) design pattern.
-version: 5.0.0-dev.10
+version: 5.0.0-dev.11
 repository: https://github.com/felangel/bloc/tree/master/packages/bloc
 issue_tracker: https://github.com/felangel/bloc/issues
 homepage: https://bloclibrary.dev
@@ -10,11 +10,11 @@ environment:
 
 dependencies:
   cubit: ^0.0.13
-  meta: ^1.1.6
+  meta: ^1.1.8
 
 dev_dependencies:
   effective_dart: ^1.2.0
-  mockito: ^4.0.0
+  mockito: ^4.1.1
   rxdart: ^0.24.0
-  test_coverage: ^0.2.0
-  test: ">=1.3.0 <2.0.0"
+  test_coverage: ^0.4.1
+  test: ^1.14.6

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -619,6 +619,51 @@ void main() {
         });
       });
 
+      test(
+          'triggers BlocUnhandledErrorException '
+          'when default observer is used.', () {
+        runZoned(() {
+          Bloc.observer = BlocObserver();
+          final expectedStates = [0, -1, emitsDone];
+          final counterBloc = CounterExceptionBloc();
+
+          expectLater(counterBloc, emitsInOrder(expectedStates));
+
+          counterBloc.add(CounterEvent.increment);
+          counterBloc.add(CounterEvent.decrement);
+
+          counterBloc.close();
+        }, onError: (error, stackTrace) {
+          expect(
+            (error as BlocUnhandledErrorException).toString(),
+            contains(
+              'Unhandled error Exception: fatal exception occurred '
+              'in bloc Instance of \'CounterExceptionBloc\'.',
+            ),
+          );
+          expect(stackTrace, isNotNull);
+        });
+      });
+
+      test(
+          'does not trigger BlocUnhandledErrorException '
+          'when custom observer is used.', () {
+        runZoned(() {
+          Bloc.observer = MockBlocObserver();
+          final expectedStates = [0, -1, emitsDone];
+          final counterBloc = CounterExceptionBloc();
+
+          expectLater(counterBloc, emitsInOrder(expectedStates));
+
+          counterBloc.add(CounterEvent.increment);
+          counterBloc.add(CounterEvent.decrement);
+
+          counterBloc.close();
+        }, onError: (error, stackTrace) {
+          fail('should not throw');
+        });
+      });
+
       test('triggers onError from mapEventToState', () {
         runZoned(() {
           final exception = Exception('fatal exception');


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- When custom `BlocObserver` is provided, avoid throwing `BlocUnhandledErrorException` (closes #1254)

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
- To be included in v5.0.0 release of bloc