### PR TITLE
feat(bloc): addError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ unlinked_spec.ds
 
 # Coverage
 coverage/
+coverage_badge.svg
 .test_coverage.dart
 *.lcov
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
-<img src="https://raw.githubusercontent.com/felangel/bloc/feat/bloc-extends-cubit/docs/assets/bloc_logo_full.png" height="150" alt="Bloc" />
+<p align="center">
+<img src="https://raw.githubusercontent.com/felangel/bloc/feat/bloc-extends-cubit/docs/assets/bloc_logo_full.png" height="100" alt="Bloc" />
+</p>
 
-[![build](https://github.com/felangel/bloc/workflows/build/badge.svg)](https://github.com/felangel/bloc/actions)
-[![codecov](https://codecov.io/gh/felangel/Bloc/branch/master/graph/badge.svg)](https://codecov.io/gh/felangel/bloc)
-[![Star on GitHub](https://img.shields.io/github/stars/felangel/bloc.svg?style=flat&logo=github&colorB=deeppink&label=stars)](https://github.com/felangel/bloc)
-[![style: effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://github.com/tenhobi/effective_dart)
-[![Flutter Website](https://img.shields.io/badge/flutter-website-deepskyblue.svg)](https://flutter.dev/docs/development/data-and-backend/state-mgmt/options#bloc--rx)
-[![Awesome Flutter](https://img.shields.io/badge/awesome-flutter-blue.svg?longCache=true)](https://github.com/Solido/awesome-flutter#standard)
-[![Flutter Samples](https://img.shields.io/badge/flutter-samples-teal.svg?longCache=true)](http://fluttersamples.com)
-[![Discord](https://img.shields.io/discord/649708778631200778.svg?logo=discord&color=blue)](https://discord.gg/Hc5KD3g)
-[![License: MIT](https://img.shields.io/badge/license-MIT-purple.svg)](https://opensource.org/licenses/MIT)
+<p align="center">
+<a href="https://github.com/felangel/bloc/actions"><img src="https://github.com/felangel/bloc/workflows/build/badge.svg" alt="build"></a>
+<a href="https://codecov.io/gh/felangel/bloc"><img src="https://codecov.io/gh/felangel/Bloc/branch/master/graph/badge.svg" alt="codecov"></a>
+<a href="https://github.com/felangel/bloc"><img src="https://img.shields.io/github/stars/felangel/bloc.svg?style=flat&logo=github&colorB=deeppink&label=stars" alt="Star on Github"></a>
+<a href="https://github.com/tenhobi/effective_dart"><img src="https://img.shields.io/badge/style-effective_dart-40c4ff.svg" alt="style: effective dart"></a>
+<a href="https://flutter.dev/docs/development/data-and-backend/state-mgmt/options#bloc--rx"><img src="https://img.shields.io/badge/flutter-website-deepskyblue.svg" alt="Flutter Website"></a>
+<a href="https://github.com/Solido/awesome-flutter#standard"><img src="https://img.shields.io/badge/awesome-flutter-blue.svg?longCache=true" alt="Awesome Flutter"></a>
+<a href="http://fluttersamples.com"><img src="https://img.shields.io/badge/flutter-samples-teal.svg?longCache=true" alt="Flutter Samples"></a>
+<a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-purple.svg" alt="License: MIT"></a>
+<a href="https://discord.gg/Hc5KD3g"><img src="https://img.shields.io/discord/649708778631200778.svg?logo=discord&color=blue" alt="Discord"></a>
+<a href="https://github.com/felangel/bloc"><img src="https://tinyurl.com/bloc-library" alt="Bloc Library"></a>
+</p>
 
 ---
 

--- a/packages/bloc/CHANGELOG.md
+++ b/packages/bloc/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.0.0-dev.11
+
+- feat: add `addError` to conform to `EventSink` interface.
+
 # 5.0.0-dev.10
 
 - docs: additional minor improvement to bloc logo alignment

--- a/packages/bloc/CHANGELOG.md
+++ b/packages/bloc/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 5.0.0-dev.11
 
 - feat: add `addError` to conform to `EventSink` interface.
+- feat: mark `onError`, `onTransition`, `onEvent` as `protected`.
 
 # 5.0.0-dev.10
 

--- a/packages/bloc/README.md
+++ b/packages/bloc/README.md
@@ -1,23 +1,30 @@
-[<img src="https://raw.githubusercontent.com/felangel/bloc/master/docs/assets/flutter_favorite.png" width="100" />](https://flutter.dev/docs/development/packages-and-plugins/favorites)
+<p align="right">
+<a href="https://flutter.dev/docs/development/packages-and-plugins/favorites"><img src="https://raw.githubusercontent.com/felangel/bloc/master/docs/assets/flutter_favorite.png" width="100" alt="build"></a>
+</p>
 
-[<img src="https://raw.githubusercontent.com/felangel/bloc/feat/bloc-extends-cubit/docs/assets/bloc_logo_full.png" height="100" />](https://github.com/felangel/bloc)
+<p align="center">
+<img src="https://raw.githubusercontent.com/felangel/bloc/feat/bloc-extends-cubit/docs/assets/bloc_logo_full.png" height="100" alt="Bloc" />
+</p>
 
-[![Pub](https://img.shields.io/pub/v/bloc.svg)](https://pub.dev/packages/bloc)
-[![build](https://github.com/felangel/bloc/workflows/build/badge.svg)](https://github.com/felangel/bloc/actions)
-[![codecov](https://codecov.io/gh/felangel/Bloc/branch/master/graph/badge.svg)](https://codecov.io/gh/felangel/bloc)
-[![style: effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://github.com/tenhobi/effective_dart)
-[![Flutter Website](https://img.shields.io/badge/flutter-website-deepskyblue.svg)](https://flutter.dev/docs/development/data-and-backend/state-mgmt/options#bloc--rx)
-[![Awesome Flutter](https://img.shields.io/badge/awesome-flutter-blue.svg?longCache=true)](https://github.com/Solido/awesome-flutter#standard)
-[![Flutter Samples](https://img.shields.io/badge/flutter-samples-teal.svg?longCache=true)](http://fluttersamples.com)
-[![Star on GitHub](https://img.shields.io/github/stars/felangel/bloc.svg?style=flat&logo=github&colorB=deeppink&label=stars)](https://github.com/felangel/bloc)
-[![Discord](https://img.shields.io/discord/649708778631200778.svg?logo=discord&color=blue)](https://discord.gg/Hc5KD3g)
-[![License: MIT](https://img.shields.io/badge/license-MIT-purple.svg)](https://opensource.org/licenses/MIT)
+<p align="center">
+<a href="https://pub.dev/packages/bloc"><img src="https://img.shields.io/pub/v/bloc.svg" alt="build"></a>
+<a href="https://github.com/felangel/bloc/actions"><img src="https://github.com/felangel/bloc/workflows/build/badge.svg" alt="build"></a>
+<a href="https://codecov.io/gh/felangel/bloc"><img src="https://codecov.io/gh/felangel/Bloc/branch/master/graph/badge.svg" alt="codecov"></a>
+<a href="https://github.com/felangel/bloc"><img src="https://img.shields.io/github/stars/felangel/bloc.svg?style=flat&logo=github&colorB=deeppink&label=stars" alt="Star on Github"></a>
+<a href="https://github.com/tenhobi/effective_dart"><img src="https://img.shields.io/badge/style-effective_dart-40c4ff.svg" alt="style: effective dart"></a>
+<a href="https://flutter.dev/docs/development/data-and-backend/state-mgmt/options#bloc--rx"><img src="https://img.shields.io/badge/flutter-website-deepskyblue.svg" alt="Flutter Website"></a>
+<a href="https://github.com/Solido/awesome-flutter#standard"><img src="https://img.shields.io/badge/awesome-flutter-blue.svg?longCache=true" alt="Awesome Flutter"></a>
+<a href="http://fluttersamples.com"><img src="https://img.shields.io/badge/flutter-samples-teal.svg?longCache=true" alt="Flutter Samples"></a>
+<a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-purple.svg" alt="License: MIT"></a>
+<a href="https://discord.gg/Hc5KD3g"><img src="https://img.shields.io/discord/649708778631200778.svg?logo=discord&color=blue" alt="Discord"></a>
+<a href="https://github.com/felangel/bloc"><img src="https://tinyurl.com/bloc-library" alt="Bloc Library"></a>
+</p>
 
 ---
 
 A dart package that helps implement the [BLoC pattern](https://www.didierboelens.com/2018/08/reactive-programming---streams---bloc).
 
-This package is built to work with [flutter_bloc](https://pub.dev/packages/flutter_bloc) and [angular_bloc](https://pub.dev/packages/angular_bloc).
+This package is built to work with [flutter_bloc](https://pub.dev/packages/flutter_bloc) and [angular_bloc](https://pub.dev/packages/angular_bloc) and is built on top of [cubit](https://pub.dev/packages/cubit).
 
 ## Overview
 

--- a/packages/bloc/README.md
+++ b/packages/bloc/README.md
@@ -50,6 +50,8 @@ This design pattern helps to separate _presentation_ from _business logic_. Foll
 
 **add** is a method that takes an `event` and triggers `mapEventToState`. If `close` has already been called, any subsequent calls to `add` will be ignored and will not result in any subsequent state changes.
 
+**addError** is a method that takes an `error` and `stackTrace` and triggers `onError`.
+
 **transformEvents** is a method that transforms the `Stream<Event>` along with a transition function, `transitionFn`, into a `Stream<Transition>`. Events that should be processed by `mapEventToState` need to be passed to `transitionFn`. **By default `asyncExpand` is used to ensure all events are processed in the order in which they are received**. You can override `transformEvents` for advanced usage in order to manipulate the frequency and specificity with which `mapEventToState` is called as well as which events are processed.
 
 **transformTransitions** is a method that transforms the `Stream<Transition>` into a new `Stream<Transition>`. By default `transformTransitions` returns the incoming `Stream<Transition>`. You can override `transformTransitions` for advanced usage in order to manipulate the frequency and specificity at which `transitions` (state changes) occur.

--- a/packages/bloc/example/main.dart
+++ b/packages/bloc/example/main.dart
@@ -21,7 +21,7 @@ class CounterBloc extends Bloc<CounterEvent, int> {
         yield state + 1;
         break;
       default:
-        throw Exception('unhandled event: $event');
+        addError(Exception('unhandled event: $event'));
     }
   }
 }

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -7,6 +7,10 @@ import '../bloc.dart';
 
 /// {@template bloc_unhandled_error_exception}
 /// Exception thrown in debug mode when an unhandled error occurs within a bloc.
+///
+/// See also:
+/// * [addError], API used to trigger [onError].
+///
 /// {@endtemplate}
 class BlocUnhandledErrorException implements Exception {
   /// The [bloc] in which the unhandled error occurred.
@@ -38,7 +42,7 @@ typedef TransitionFunction<Event, State> = Stream<Transition<Event, State>>
 /// and transforms them into a `Stream` of `States` as output.
 /// {@endtemplate}
 abstract class Bloc<Event, State> extends CubitStream<State>
-    implements Sink<Event> {
+    implements EventSink<Event> {
   /// The current [BlocObserver].
   static BlocObserver observer = BlocObserver();
 
@@ -125,6 +129,11 @@ abstract class Bloc<Event, State> extends CubitStream<State>
     } on dynamic catch (error, stackTrace) {
       onError(error, stackTrace);
     }
+  }
+
+  @override
+  void addError(Object error, [StackTrace stackTrace]) {
+    onError(error, stackTrace);
   }
 
   /// Closes the `event` and `state` `Streams`.

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -68,8 +68,12 @@ abstract class Bloc<Event, State> extends CubitStream<State>
   ///   super.onEvent(event);
   /// }
   /// ```
+  @protected
   @mustCallSuper
-  void onEvent(Event event) => observer.onEvent(this, event);
+  void onEvent(Event event) {
+    // ignore: invalid_use_of_protected_member
+    observer.onEvent(this, event);
+  }
 
   /// Called whenever a [transition] occurs with the given [transition].
   /// A [transition] occurs when a new `event` is [add]ed and [mapEventToState]
@@ -87,8 +91,10 @@ abstract class Bloc<Event, State> extends CubitStream<State>
   ///   super.onTransition(transition);
   /// }
   /// ```
+  @protected
   @mustCallSuper
   void onTransition(Transition<Event, State> transition) {
+    // ignore: invalid_use_of_protected_member
     observer.onTransition(this, transition);
   }
 
@@ -109,8 +115,10 @@ abstract class Bloc<Event, State> extends CubitStream<State>
   ///   super.onError(error, stackTrace);
   /// }
   /// ```
+  @protected
   @mustCallSuper
   void onError(Object error, StackTrace stackTrace) {
+    // ignore: invalid_use_of_protected_member
     observer.onError(this, error, stackTrace);
     assert(() {
       throw BlocUnhandledErrorException(this, error, stackTrace);

--- a/packages/bloc/lib/src/bloc_observer.dart
+++ b/packages/bloc/lib/src/bloc_observer.dart
@@ -6,6 +6,7 @@ import '../bloc.dart';
 class BlocObserver {
   /// Called whenever an [event] is `added` to any [bloc] with the given [bloc]
   /// and [event].
+  @protected
   @mustCallSuper
   void onEvent(Bloc bloc, Object event) {}
 
@@ -14,6 +15,7 @@ class BlocObserver {
   /// A [transition] occurs when a new `event` is `added` and `mapEventToState`
   /// executed.
   /// [onTransition] is called before a [bloc]'s state has been updated.
+  @protected
   @mustCallSuper
   void onTransition(Bloc bloc, Transition transition) {}
 
@@ -21,6 +23,7 @@ class BlocObserver {
   /// [error], and [stackTrace].
   /// The [stackTrace] argument may be `null` if the state stream received
   /// an error without a [stackTrace].
+  @protected
   @mustCallSuper
   void onError(Bloc bloc, Object error, StackTrace stackTrace) {}
 }

--- a/packages/bloc/pubspec.yaml
+++ b/packages/bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc
 description: A predictable state management library that helps implement the BLoC (Business Logic Component) design pattern.
-version: 5.0.0-dev.10
+version: 5.0.0-dev.11
 repository: https://github.com/felangel/bloc/tree/master/packages/bloc
 issue_tracker: https://github.com/felangel/bloc/issues
 homepage: https://bloclibrary.dev
@@ -10,11 +10,11 @@ environment:
 
 dependencies:
   cubit: ^0.0.13
-  meta: ^1.1.6
+  meta: ^1.1.8
 
 dev_dependencies:
   effective_dart: ^1.2.0
-  mockito: ^4.0.0
+  mockito: ^4.1.1
   rxdart: ^0.24.0
-  test_coverage: ^0.2.0
-  test: ">=1.3.0 <2.0.0"
+  test_coverage: ^0.4.1
+  test: ^1.14.6

--- a/packages/bloc/test/bloc_observer_test.dart
+++ b/packages/bloc/test/bloc_observer_test.dart
@@ -11,18 +11,21 @@ void main() {
   group('BlocObserver', () {
     group('onEvent', () {
       test('does nothing by default', () {
+        // ignore: invalid_use_of_protected_member
         BlocObserver().onEvent(MockBloc(), Object());
       });
     });
 
     group('onTransition', () {
       test('does nothing by default', () {
+        // ignore: invalid_use_of_protected_member
         BlocObserver().onTransition(MockBloc(), MockTransition());
       });
     });
 
     group('onError', () {
       test('does nothing by default', () {
+        // ignore: invalid_use_of_protected_member
         BlocObserver().onError(MockBloc(), Object(), StackTrace.current);
       });
     });

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: invalid_use_of_protected_member
+
 import 'dart:async';
 
 import 'package:bloc/bloc.dart';

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -619,6 +619,28 @@ void main() {
         });
       });
 
+      test('addError triggers onError', () async {
+        final expectedError = Exception('fatal exception');
+
+        runZoned(() {
+          final onExceptionBloc = OnExceptionBloc(
+            exception: expectedError,
+            onErrorCallback: (error, stackTrace) {},
+          );
+
+          onExceptionBloc.addError(expectedError, StackTrace.current);
+        }, onError: (error, stackTrace) {
+          expect(
+            (error as BlocUnhandledErrorException).toString(),
+            contains(
+              'Unhandled error Exception: fatal exception occurred '
+              'in bloc Instance of \'OnExceptionBloc\'.',
+            ),
+          );
+          expect(stackTrace, isNotNull);
+        });
+      });
+
       test('triggers onError from mapEventToState', () {
         runZoned(() {
           final exception = Exception('fatal exception');


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
Bloc to implement `EventSink` rather than `Sink` which exposes `addError` for a more intuitive, friendly API to handle exceptions within a bloc.

Currently you have to `rethrow`:

```dart
Stream<MyState> mapEventToState(MyEvent event) async* {
  try {
    await someOperation();
  } on SomeSpecificException catch (_) {
    yield SomeSpecificFailureState();
    rethrow; // currently necessary to propagate error to `onError` in `BlocObserver`.
  }
}
```

Or `throw` when using `Either`:

```dart
yield* either.fold(
  (failure) async * {
    yield FailureState(failure);
    throw failure;
  }, 
  (data) => ...
)
```

It is not immediately clear/obvious that (re)throwing bubbles the exception up to `onError` and can be improved:

```dart
Stream<MyState> mapEventToState(MyEvent event) async* {
  try {
    await someOperation();
  } on SomeSpecificException catch (error, stackTrace) {
    yield SomeSpecificFailureState();
    addError(error, stackTrace);
  }
}
```

```dart
yield* either.fold(
  (failure) async * {
    yield FailureState(failure);
    addError(failure);
  }, 
  (data) => ...
)
```

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
- Included in v5.0.0 of bloc