### PR TITLE
Fixed doc error in the bloc access recipe

### DIFF
--- a/docs/_snippets/recipes_flutter_bloc_access/anonymous_route_access/main.dart.md
+++ b/docs/_snippets/recipes_flutter_bloc_access/anonymous_route_access/main.dart.md
@@ -12,7 +12,7 @@ class App extends StatelessWidget {
       title: 'Flutter Demo',
       home: BlocProvider(
         create: (BuildContext context) => CounterBloc(),
-        child: CounterPage(),
+        child: HomePage(),
       ),
     );
   }


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
In the Anonymous Route Access section of the Bloc Access Recipe, the App Widget BlocProvider should have `HomePage()` as its child instead of the `CounterPage()`.  

This is correctly coded in the relevant [gist](https://gist.github.com/felangel/92b256270c5567210285526a07b4cf21) but not in the `main.dart` file of this example.

## Impact to Remaining Code Base
This PR will affect:

*  None

## Checkilst

- [ ] README
- [ ] Cover page
- [ ] Sidebar
- Introduction
  - [ ] Getting Started
  - [ ] Why Bloc?
- Core Concepts
  - [ ] bloc
  - [ ] flutter_bloc
- [ ] Architecture
- [ ] Testing
- [ ] Naming Conventions
- [ ] FAQs
- Tutorials
  - Flutter
    - [ ] Counter
    - [ ] Timer
    - [ ] Infinite List
    - [ ] Login
    - [ ] Weather
    - [ ] Todos
    - [ ] Firebase Login
    - [ ] Firestore Todos
  - AngularDart
    - [ ] Counter
  - Flutter + AngularDart
    - [ ] Github Search
- Recipes
  - Flutter
    - [ ] Show SnackBar
    - [ ] Navigation
    - [x] Bloc Access
- Tools
  - Extensions
    - [ ] IntelliJ
    - [ ] VSCode