### PR TITLE
docs: removing unused lines of code in snippets

### DIFF
--- a/docs/_snippets/flutter_weather_tutorial/integrate_gradient_container.dart.md
+++ b/docs/_snippets/flutter_weather_tutorial/integrate_gradient_container.dart.md
@@ -25,7 +25,6 @@ class _WeatherState extends State<Weather> {
 
   @override
   Widget build(BuildContext context) {
-    final weatherBloc = BlocProvider.of<WeatherBloc>(context);
     return Scaffold(
       appBar: AppBar(
         title: Text('Flutter Weather'),

--- a/docs/_snippets/flutter_weather_tutorial/settings.dart.md
+++ b/docs/_snippets/flutter_weather_tutorial/settings.dart.md
@@ -8,7 +8,6 @@ import 'package:flutter_weather/blocs/blocs.dart';
 class Settings extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final settingsBloc = BlocProvider.of<SettingsBloc>(context);
     return Scaffold(
       appBar: AppBar(title: Text('Settings')),
       body: ListView(


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
While I was following the weather app tutorial I've noticed there are two instances of blocs in the tutorial that aren't used. In the real weather app codebase, those lines aren't present either, so I decided to remove them.

## Related PRs
No PR's
## Todos
No todos

## Steps to Test or Reproduce
No steps

## Impact to Remaining Code Base
No impact 
