### PR TITLE
Fix/angular bloc v6.0.0 dev.6

### DIFF
--- a/packages/angular_bloc/CHANGELOG.md
+++ b/packages/angular_bloc/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 6.0.0-dev.6
 
 Update to `bloc ^5.0.1`
-Update to `angular_cubit ^0.1.0-dev.3`
+Update to `angular_cubit ^0.1.0-dev.4`
 
 # 6.0.0-dev.5
 

--- a/packages/angular_bloc/CHANGELOG.md
+++ b/packages/angular_bloc/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.0.0-dev.6
+
+Update to `bloc ^5.0.1`
+
 # 6.0.0-dev.5
 
 Update to `bloc ^5.0.0`

--- a/packages/angular_bloc/CHANGELOG.md
+++ b/packages/angular_bloc/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 6.0.0-dev.6
 
 Update to `bloc ^5.0.1`
+Update to `angular_cubit ^0.1.0-dev.3`
 
 # 6.0.0-dev.5
 

--- a/packages/angular_bloc/README.md
+++ b/packages/angular_bloc/README.md
@@ -10,7 +10,7 @@
 <a href="https://github.com/tenhobi/effective_dart"><img src="https://img.shields.io/badge/style-effective_dart-40c4ff.svg" alt="style: effective dart"></a>
 <a href="https://flutter.dev/docs/development/data-and-backend/state-mgmt/options#bloc--rx"><img src="https://img.shields.io/badge/flutter-website-deepskyblue.svg" alt="Flutter Website"></a>
 <a href="https://github.com/Solido/awesome-flutter#standard"><img src="https://img.shields.io/badge/awesome-flutter-blue.svg?longCache=true" alt="Awesome Flutter"></a>
-<a href="http://fluttersamples.com"><img src="https://img.shields.io/badge/flutter-samples-teal.svg?longCache=true" alt="Flutter Samples"></a>
+<a href="https://fluttersamples.com"><img src="https://img.shields.io/badge/flutter-samples-teal.svg?longCache=true" alt="Flutter Samples"></a>
 <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-purple.svg" alt="License: MIT"></a>
 <a href="https://discord.gg/Hc5KD3g"><img src="https://img.shields.io/discord/649708778631200778.svg?logo=discord&color=blue" alt="Discord"></a>
 <a href="https://github.com/felangel/bloc"><img src="https://tinyurl.com/bloc-library" alt="Bloc Library"></a>

--- a/packages/angular_bloc/pubspec.yaml
+++ b/packages/angular_bloc/pubspec.yaml
@@ -1,9 +1,10 @@
 name: angular_bloc
 description: Angular Components that make it easy to implement the BLoC (Business Logic Component) design pattern. Built to be used with the bloc state management package.
-version: 6.0.0-dev.5
+version: 6.0.0-dev.6
 repository: https://github.com/felangel/bloc/tree/master/packages/angular_bloc
 issue_tracker: https://github.com/felangel/bloc/issues
 homepage: https://bloclibrary.dev
+documentation: https://bloclibrary.dev/#/gettingstarted
 
 environment:
   sdk: ">=2.6.0 <3.0.0"
@@ -11,7 +12,7 @@ environment:
 dependencies:
   angular: ^6.0.0-alpha+1
   angular_cubit: ^0.1.0-dev.1
-  bloc: ^5.0.0
+  bloc: ^5.0.1
 
 dev_dependencies:
   angular_test: ^2.3.0

--- a/packages/angular_bloc/pubspec.yaml
+++ b/packages/angular_bloc/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   angular: ^6.0.0-alpha+1
-  angular_cubit: ^0.1.0-dev.1
+  angular_cubit: ^0.1.0-dev.3
   bloc: ^5.0.1
 
 dev_dependencies:

--- a/packages/angular_bloc/pubspec.yaml
+++ b/packages/angular_bloc/pubspec.yaml
@@ -20,6 +20,6 @@ dev_dependencies:
   build_test: ^0.10.8
   build_web_compilers: ^2.3.0
   effective_dart: ^1.2.0
-  test: ^1.14.6
   meta: ">=1.0.0 <1.2.0"
   mockito: ^4.0.0
+  test: ^1.14.6

--- a/packages/angular_bloc/pubspec.yaml
+++ b/packages/angular_bloc/pubspec.yaml
@@ -19,7 +19,7 @@ dev_dependencies:
   build_runner: ^1.6.0
   build_test: ^0.10.8
   build_web_compilers: ^2.3.0
-  pedantic: ^1.8.0
-  test: ^1.6.0
-  mockito: ^4.0.0
   effective_dart: ^1.2.0
+  test: ^1.14.6
+  meta: ">=1.0.0 < 1.2.0"
+  mockito: ^4.0.0

--- a/packages/angular_bloc/pubspec.yaml
+++ b/packages/angular_bloc/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   angular: ^6.0.0-alpha+1
-  angular_cubit: ^0.1.0-dev.3
+  angular_cubit: ^0.1.0-dev.4
   bloc: ^5.0.1
 
 dev_dependencies:

--- a/packages/angular_bloc/pubspec.yaml
+++ b/packages/angular_bloc/pubspec.yaml
@@ -21,5 +21,5 @@ dev_dependencies:
   build_web_compilers: ^2.3.0
   effective_dart: ^1.2.0
   test: ^1.14.6
-  meta: ">=1.0.0 < 1.2.0"
+  meta: ">=1.0.0 <1.2.0"
   mockito: ^4.0.0


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- fix: update to `bloc ^5.0.1`
- fix: update to `angular_cubit ^0.1.0-dev.4`