### PR TITLE
docs: fix in snippets/bloc_listener_explicit_bloc

### DIFF
--- a/docs/_snippets/flutter_bloc_core_concepts/bloc_listener_explicit_bloc.dart.md
+++ b/docs/_snippets/flutter_bloc_core_concepts/bloc_listener_explicit_bloc.dart.md
@@ -3,6 +3,7 @@ BlocListener<BlocA, BlocAState>(
   bloc: blocA,
   listener: (context, state) {
     // do stuff here based on BlocA's state
-  }
+  },
+  child: Container()
 )
 ```


### PR DESCRIPTION
I think there is missing the child in this little example.


## Status

**READY**

## Breaking Changes

NO

## Description

Little fix in flutter bloc listener documentation.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
