### PR TITLE
fix(hydrated_bloc): storage.write error + e2e

### DIFF
--- a/.github/workflows/hydrated_bloc.yaml
+++ b/.github/workflows/hydrated_bloc.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Analyze
         run: flutter analyze lib test example
       - name: Run tests
-        run: flutter test --no-pub --coverage --test-randomize-ordering-seed random
+        run: flutter test -j 1 --no-pub --coverage --test-randomize-ordering-seed random
       - name: Check Code Coverage
         uses: ChicagoFlutter/lcov-cop@v1.0.0
         with:

--- a/packages/hydrated_bloc/lib/src/hydrated_cubit.dart
+++ b/packages/hydrated_bloc/lib/src/hydrated_cubit.dart
@@ -103,11 +103,7 @@ mixin HydratedMixin<State> on Cubit<State> {
     if (storage == null) throw const StorageNotFound();
     final stateJson = toJson(state);
     if (stateJson != null) {
-      try {
-        storage.write(storageToken, stateJson);
-      } on dynamic catch (error, stackTrace) {
-        onError(error, stackTrace);
-      }
+      storage.write(storageToken, stateJson).then((_) {}, onError: onError);
     }
   }
 
@@ -133,11 +129,7 @@ mixin HydratedMixin<State> on Cubit<State> {
     final state = change.nextState;
     final stateJson = toJson(state);
     if (stateJson != null) {
-      try {
-        storage.write(storageToken, stateJson);
-      } on dynamic catch (error, stackTrace) {
-        onError(error, stackTrace);
-      }
+      storage.write(storageToken, stateJson).then((_) {}, onError: onError);
     }
     _state = state;
     super.onChange(change);

--- a/packages/hydrated_bloc/pubspec.yaml
+++ b/packages/hydrated_bloc/pubspec.yaml
@@ -21,7 +21,12 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  build_runner: ^1.10.0  
   crypto: ^2.1.4
+  freezed_annotation: ^0.11.0
+  freezed: ^0.11.2
+  json_serializable: ^3.3.0
+  json_annotation: ^3.0.1
   mockito: ^4.0.0
   path: ^1.6.4
   pedantic: ^1.9.0

--- a/packages/hydrated_bloc/test/cubits/cubits.dart
+++ b/packages/hydrated_bloc/test/cubits/cubits.dart
@@ -1,0 +1,5 @@
+export 'freezed_cubit.dart';
+export 'json_serializable_cubit.dart';
+export 'list_cubit.dart';
+export 'manual_cubit.dart';
+export 'simple_cubit.dart';

--- a/packages/hydrated_bloc/test/cubits/freezed_cubit.dart
+++ b/packages/hydrated_bloc/test/cubits/freezed_cubit.dart
@@ -1,0 +1,39 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+
+part 'freezed_cubit.freezed.dart';
+part 'freezed_cubit.g.dart';
+
+class FreezedCubit extends HydratedCubit<Question> {
+  FreezedCubit() : super(null);
+
+  void setQuestion(Question question) => emit(question);
+
+  @override
+  Map<String, dynamic> toJson(Question state) => state?.toJson();
+
+  @override
+  Question fromJson(Map<String, dynamic> json) => Question.fromJson(json);
+}
+
+@freezed
+abstract class Question with _$Question {
+  const factory Question({
+    int id,
+    String question,
+  }) = _Question;
+
+  factory Question.fromJson(Map<String, dynamic> json) =>
+      _$QuestionFromJson(json);
+}
+
+@freezed
+abstract class Tree with _$Tree {
+  const factory Tree({
+    Question question,
+    Tree left,
+    Tree right,
+  }) = _QTree;
+
+  factory Tree.fromJson(Map<String, dynamic> json) => _$TreeFromJson(json);
+}

--- a/packages/hydrated_bloc/test/cubits/freezed_cubit.freezed.dart
+++ b/packages/hydrated_bloc/test/cubits/freezed_cubit.freezed.dart
@@ -1,0 +1,307 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, lines_longer_than_80_chars
+
+part of 'freezed_cubit.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+Question _$QuestionFromJson(Map<String, dynamic> json) {
+  return _Question.fromJson(json);
+}
+
+class _$QuestionTearOff {
+  const _$QuestionTearOff();
+
+  _Question call({int id, String question}) {
+    return _Question(
+      id: id,
+      question: question,
+    );
+  }
+}
+
+// ignore: unused_element
+const $Question = _$QuestionTearOff();
+
+mixin _$Question {
+  int get id;
+  String get question;
+
+  Map<String, dynamic> toJson();
+  $QuestionCopyWith<Question> get copyWith;
+}
+
+abstract class $QuestionCopyWith<$Res> {
+  factory $QuestionCopyWith(Question value, $Res Function(Question) then) =
+      _$QuestionCopyWithImpl<$Res>;
+  $Res call({int id, String question});
+}
+
+class _$QuestionCopyWithImpl<$Res> implements $QuestionCopyWith<$Res> {
+  _$QuestionCopyWithImpl(this._value, this._then);
+
+  final Question _value;
+  // ignore: unused_field
+  final $Res Function(Question) _then;
+
+  @override
+  $Res call({
+    Object id = freezed,
+    Object question = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: id == freezed ? _value.id : id as int,
+      question: question == freezed ? _value.question : question as String,
+    ));
+  }
+}
+
+abstract class _$QuestionCopyWith<$Res> implements $QuestionCopyWith<$Res> {
+  factory _$QuestionCopyWith(_Question value, $Res Function(_Question) then) =
+      __$QuestionCopyWithImpl<$Res>;
+  @override
+  $Res call({int id, String question});
+}
+
+class __$QuestionCopyWithImpl<$Res> extends _$QuestionCopyWithImpl<$Res>
+    implements _$QuestionCopyWith<$Res> {
+  __$QuestionCopyWithImpl(_Question _value, $Res Function(_Question) _then)
+      : super(_value, (v) => _then(v as _Question));
+
+  @override
+  _Question get _value => super._value as _Question;
+
+  @override
+  $Res call({
+    Object id = freezed,
+    Object question = freezed,
+  }) {
+    return _then(_Question(
+      id: id == freezed ? _value.id : id as int,
+      question: question == freezed ? _value.question : question as String,
+    ));
+  }
+}
+
+@JsonSerializable()
+class _$_Question implements _Question {
+  const _$_Question({this.id, this.question});
+
+  factory _$_Question.fromJson(Map<String, dynamic> json) =>
+      _$_$_QuestionFromJson(json);
+
+  @override
+  final int id;
+  @override
+  final String question;
+
+  @override
+  String toString() {
+    return 'Question(id: $id, question: $question)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is _Question &&
+            (identical(other.id, id) ||
+                const DeepCollectionEquality().equals(other.id, id)) &&
+            (identical(other.question, question) ||
+                const DeepCollectionEquality()
+                    .equals(other.question, question)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(id) ^
+      const DeepCollectionEquality().hash(question);
+
+  @override
+  _$QuestionCopyWith<_Question> get copyWith =>
+      __$QuestionCopyWithImpl<_Question>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$_$_QuestionToJson(this);
+  }
+}
+
+abstract class _Question implements Question {
+  const factory _Question({int id, String question}) = _$_Question;
+
+  factory _Question.fromJson(Map<String, dynamic> json) = _$_Question.fromJson;
+
+  @override
+  int get id;
+  @override
+  String get question;
+  @override
+  _$QuestionCopyWith<_Question> get copyWith;
+}
+
+Tree _$TreeFromJson(Map<String, dynamic> json) {
+  return _QTree.fromJson(json);
+}
+
+class _$TreeTearOff {
+  const _$TreeTearOff();
+
+  _QTree call({Question question, Tree left, Tree right}) {
+    return _QTree(
+      question: question,
+      left: left,
+      right: right,
+    );
+  }
+}
+
+// ignore: unused_element
+const $Tree = _$TreeTearOff();
+
+mixin _$Tree {
+  Question get question;
+  Tree get left;
+  Tree get right;
+
+  Map<String, dynamic> toJson();
+  $TreeCopyWith<Tree> get copyWith;
+}
+
+abstract class $TreeCopyWith<$Res> {
+  factory $TreeCopyWith(Tree value, $Res Function(Tree) then) =
+      _$TreeCopyWithImpl<$Res>;
+  $Res call({Question question, Tree left, Tree right});
+
+  $QuestionCopyWith<$Res> get question;
+}
+
+class _$TreeCopyWithImpl<$Res> implements $TreeCopyWith<$Res> {
+  _$TreeCopyWithImpl(this._value, this._then);
+
+  final Tree _value;
+  // ignore: unused_field
+  final $Res Function(Tree) _then;
+
+  @override
+  $Res call({
+    Object question = freezed,
+    Object left = freezed,
+    Object right = freezed,
+  }) {
+    return _then(_value.copyWith(
+      question: question == freezed ? _value.question : question as Question,
+      left: left == freezed ? _value.left : left as Tree,
+      right: right == freezed ? _value.right : right as Tree,
+    ));
+  }
+
+  @override
+  $QuestionCopyWith<$Res> get question {
+    if (_value.question == null) {
+      return null;
+    }
+    return $QuestionCopyWith<$Res>(_value.question, (value) {
+      return _then(_value.copyWith(question: value));
+    });
+  }
+}
+
+abstract class _$QTreeCopyWith<$Res> implements $TreeCopyWith<$Res> {
+  factory _$QTreeCopyWith(_QTree value, $Res Function(_QTree) then) =
+      __$QTreeCopyWithImpl<$Res>;
+  @override
+  $Res call({Question question, Tree left, Tree right});
+
+  @override
+  $QuestionCopyWith<$Res> get question;
+}
+
+class __$QTreeCopyWithImpl<$Res> extends _$TreeCopyWithImpl<$Res>
+    implements _$QTreeCopyWith<$Res> {
+  __$QTreeCopyWithImpl(_QTree _value, $Res Function(_QTree) _then)
+      : super(_value, (v) => _then(v as _QTree));
+
+  @override
+  _QTree get _value => super._value as _QTree;
+
+  @override
+  $Res call({
+    Object question = freezed,
+    Object left = freezed,
+    Object right = freezed,
+  }) {
+    return _then(_QTree(
+      question: question == freezed ? _value.question : question as Question,
+      left: left == freezed ? _value.left : left as Tree,
+      right: right == freezed ? _value.right : right as Tree,
+    ));
+  }
+}
+
+@JsonSerializable()
+class _$_QTree implements _QTree {
+  const _$_QTree({this.question, this.left, this.right});
+
+  factory _$_QTree.fromJson(Map<String, dynamic> json) =>
+      _$_$_QTreeFromJson(json);
+
+  @override
+  final Question question;
+  @override
+  final Tree left;
+  @override
+  final Tree right;
+
+  @override
+  String toString() {
+    return 'Tree(question: $question, left: $left, right: $right)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is _QTree &&
+            (identical(other.question, question) ||
+                const DeepCollectionEquality()
+                    .equals(other.question, question)) &&
+            (identical(other.left, left) ||
+                const DeepCollectionEquality().equals(other.left, left)) &&
+            (identical(other.right, right) ||
+                const DeepCollectionEquality().equals(other.right, right)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(question) ^
+      const DeepCollectionEquality().hash(left) ^
+      const DeepCollectionEquality().hash(right);
+
+  @override
+  _$QTreeCopyWith<_QTree> get copyWith =>
+      __$QTreeCopyWithImpl<_QTree>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$_$_QTreeToJson(this);
+  }
+}
+
+abstract class _QTree implements Tree {
+  const factory _QTree({Question question, Tree left, Tree right}) = _$_QTree;
+
+  factory _QTree.fromJson(Map<String, dynamic> json) = _$_QTree.fromJson;
+
+  @override
+  Question get question;
+  @override
+  Tree get left;
+  @override
+  Tree get right;
+  @override
+  _$QTreeCopyWith<_QTree> get copyWith;
+}

--- a/packages/hydrated_bloc/test/cubits/freezed_cubit.g.dart
+++ b/packages/hydrated_bloc/test/cubits/freezed_cubit.g.dart
@@ -1,0 +1,41 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: non_constant_identifier_names
+
+part of 'freezed_cubit.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_Question _$_$_QuestionFromJson(Map<String, dynamic> json) {
+  return _$_Question(
+    id: json['id'] as int,
+    question: json['question'] as String,
+  );
+}
+
+Map<String, dynamic> _$_$_QuestionToJson(_$_Question instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'question': instance.question,
+    };
+
+_$_QTree _$_$_QTreeFromJson(Map<String, dynamic> json) {
+  return _$_QTree(
+    question: json['question'] == null
+        ? null
+        : Question.fromJson(json['question'] as Map<String, dynamic>),
+    left: json['left'] == null
+        ? null
+        : Tree.fromJson(json['left'] as Map<String, dynamic>),
+    right: json['right'] == null
+        ? null
+        : Tree.fromJson(json['right'] as Map<String, dynamic>),
+  );
+}
+
+Map<String, dynamic> _$_$_QTreeToJson(_$_QTree instance) => <String, dynamic>{
+      'question': instance.question,
+      'left': instance.left,
+      'right': instance.right,
+    };

--- a/packages/hydrated_bloc/test/cubits/json_serializable_cubit.dart
+++ b/packages/hydrated_bloc/test/cubits/json_serializable_cubit.dart
@@ -1,0 +1,100 @@
+import 'package:collection/collection.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'json_serializable_cubit.g.dart';
+
+class JsonSerializableCubit extends HydratedCubit<User> {
+  JsonSerializableCubit() : super(const User.initial());
+
+  void updateFavoriteColor(Color color) =>
+      emit(state.copyWith(favoriteColor: color));
+
+  @override
+  User fromJson(Map<String, dynamic> json) => User.fromJson(json);
+
+  @override
+  Map<String, dynamic> toJson(User state) => state.toJson();
+}
+
+@JsonSerializable(explicitToJson: true)
+class User {
+  const User(this.name, this.age, this.favoriteColor, this.todos);
+
+  const User.initial()
+      : this(
+          'John Doe',
+          42,
+          Color.green,
+          const <Todo>[Todo('0', 'wash car'), Todo('1', 'dishes')],
+        );
+
+  factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);
+  Map<String, dynamic> toJson() => _$UserToJson(this);
+
+  final String name;
+  final int age;
+  final Color favoriteColor;
+  final List<Todo> todos;
+
+  User copyWith({
+    String name,
+    int age,
+    Color favoriteColor,
+    List<Todo> todos,
+  }) {
+    return User(
+      name ?? this.name,
+      age ?? this.age,
+      favoriteColor ?? this.favoriteColor,
+      todos ?? this.todos,
+    );
+  }
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+    final listEquals = const DeepCollectionEquality().equals;
+
+    return o is User &&
+        o.name == name &&
+        o.age == age &&
+        o.favoriteColor == favoriteColor &&
+        listEquals(o.todos, todos);
+  }
+
+  @override
+  int get hashCode {
+    return name.hashCode ^
+        age.hashCode ^
+        favoriteColor.hashCode ^
+        todos.hashCode;
+  }
+
+  @override
+  String toString() {
+    return '''User(name: $name, age: $age, favoriteColor: $favoriteColor, todos: $todos)''';
+  }
+}
+
+enum Color { red, green, blue }
+
+@JsonSerializable(explicitToJson: true)
+class Todo {
+  const Todo(this.id, this.task);
+  factory Todo.fromJson(Map<String, dynamic> json) => _$TodoFromJson(json);
+  Map<String, dynamic> toJson() => _$TodoToJson(this);
+
+  final String id;
+  final String task;
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+
+    return o is Todo && o.id == id && o.task == task;
+  }
+
+  @override
+  int get hashCode => id.hashCode ^ task.hashCode;
+}

--- a/packages/hydrated_bloc/test/cubits/json_serializable_cubit.g.dart
+++ b/packages/hydrated_bloc/test/cubits/json_serializable_cubit.g.dart
@@ -1,0 +1,77 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'json_serializable_cubit.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+User _$UserFromJson(Map<String, dynamic> json) {
+  return User(
+    json['name'] as String,
+    json['age'] as int,
+    _$enumDecodeNullable(_$ColorEnumMap, json['favoriteColor']),
+    (json['todos'] as List)
+        ?.map(
+            // ignore: implicit_dynamic_parameter
+            (e) => e == null ? null : Todo.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+  );
+}
+
+Map<String, dynamic> _$UserToJson(User instance) => <String, dynamic>{
+      'name': instance.name,
+      'age': instance.age,
+      'favoriteColor': _$ColorEnumMap[instance.favoriteColor],
+      'todos': instance.todos?.map((e) => e?.toJson())?.toList(),
+    };
+
+T _$enumDecode<T>(
+  Map<T, dynamic> enumValues,
+  dynamic source, {
+  T unknownValue,
+}) {
+  if (source == null) {
+    throw ArgumentError('A value must be provided. Supported values: '
+        '${enumValues.values.join(', ')}');
+  }
+
+  final value = enumValues.entries
+      .singleWhere((e) => e.value == source, orElse: () => null)
+      ?.key;
+
+  if (value == null && unknownValue == null) {
+    throw ArgumentError('`$source` is not one of the supported values: '
+        '${enumValues.values.join(', ')}');
+  }
+  return value ?? unknownValue;
+}
+
+T _$enumDecodeNullable<T>(
+  Map<T, dynamic> enumValues,
+  dynamic source, {
+  T unknownValue,
+}) {
+  if (source == null) {
+    return null;
+  }
+  return _$enumDecode<T>(enumValues, source, unknownValue: unknownValue);
+}
+
+const _$ColorEnumMap = {
+  Color.red: 'red',
+  Color.green: 'green',
+  Color.blue: 'blue',
+};
+
+Todo _$TodoFromJson(Map<String, dynamic> json) {
+  return Todo(
+    json['id'] as String,
+    json['task'] as String,
+  );
+}
+
+Map<String, dynamic> _$TodoToJson(Todo instance) => <String, dynamic>{
+      'id': instance.id,
+      'task': instance.task,
+    };

--- a/packages/hydrated_bloc/test/cubits/list_cubit.dart
+++ b/packages/hydrated_bloc/test/cubits/list_cubit.dart
@@ -1,0 +1,17 @@
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+
+class ListCubit extends HydratedCubit<List<String>> {
+  ListCubit() : super(const <String>[]);
+
+  void addItem(String item) => emit(List.from(state)..add(item));
+
+  @override
+  Map<String, dynamic> toJson(List<String> state) {
+    return <String, dynamic>{'state': state};
+  }
+
+  @override
+  List<String> fromJson(Map<String, dynamic> json) {
+    return json['state'] as List<String>;
+  }
+}

--- a/packages/hydrated_bloc/test/cubits/manual_cubit.dart
+++ b/packages/hydrated_bloc/test/cubits/manual_cubit.dart
@@ -1,0 +1,85 @@
+import 'package:collection/collection.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+
+class ManualCubit extends HydratedCubit<Dog> {
+  ManualCubit() : super(null);
+
+  void setDog(Dog dog) => emit(dog);
+
+  @override
+  Map<String, dynamic> toJson(Dog state) => state?.toJson();
+
+  @override
+  Dog fromJson(Map<String, dynamic> json) => Dog.fromJson(json);
+}
+
+class Dog {
+  const Dog(this.name, this.age, this.toys);
+
+  factory Dog.fromJson(Map<String, dynamic> json) {
+    return Dog(
+      json['name'] as String,
+      json['age'] as int,
+      (json['toys'] as List)
+          .map(
+            (dynamic toy) =>
+                Toy.fromJson(Map<String, dynamic>.from(toy as Map)),
+          )
+          .toList(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'name': name,
+      'age': age,
+      'toys': toys.map<dynamic>((toy) => toy.toJson()).toList(),
+    };
+  }
+
+  final String name;
+  final int age;
+  final List<Toy> toys;
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+    final listEquals = const DeepCollectionEquality().equals;
+
+    return o is Dog &&
+        o.name == name &&
+        o.age == age &&
+        listEquals(o.toys, toys);
+  }
+
+  @override
+  int get hashCode => name.hashCode ^ age.hashCode ^ toys.hashCode;
+}
+
+class Toy {
+  const Toy(this.name);
+
+  factory Toy.fromJson(Map<String, dynamic> json) {
+    return Toy(
+      json['name'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'name': name,
+    };
+  }
+
+  final String name;
+
+  @override
+  bool operator ==(Object o) {
+    if (identical(this, o)) return true;
+
+    return o is Toy && o.name == name;
+  }
+
+  @override
+  int get hashCode => name.hashCode;
+}

--- a/packages/hydrated_bloc/test/cubits/simple_cubit.dart
+++ b/packages/hydrated_bloc/test/cubits/simple_cubit.dart
@@ -1,0 +1,17 @@
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+
+class SimpleCubit extends HydratedCubit<int> {
+  SimpleCubit() : super(0);
+
+  void increment() => emit(state + 1);
+
+  @override
+  Map<String, dynamic> toJson(int state) {
+    return <String, dynamic>{'state': state};
+  }
+
+  @override
+  int fromJson(Map<String, dynamic> json) {
+    return json['state'] as int;
+  }
+}

--- a/packages/hydrated_bloc/test/e2e_test.dart
+++ b/packages/hydrated_bloc/test/e2e_test.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+
+import 'cubits/cubits.dart';
+
+Future<void> sleep() => Future<void>.delayed(const Duration(milliseconds: 100));
+
+void main() {
+  group('E2E', () {
+    Storage storage;
+
+    setUp(() async {
+      storage = await HydratedStorage.build(
+        storageDirectory: Directory.current,
+      );
+      HydratedBloc.storage = storage;
+    });
+
+    tearDown(() async {
+      await storage?.clear();
+    });
+
+    group('FreezedCubit', () {
+      test('persists and restores state correctly', () async {
+        const question = Question(id: 0, question: '?');
+        final cubit = FreezedCubit();
+        expect(cubit.state, isNull);
+        cubit.setQuestion(question);
+        await sleep();
+        expect(FreezedCubit().state, question);
+      });
+    });
+
+    group('JsonSerializableCubit', () {
+      test('persists and restores state correctly', () async {
+        final cubit = JsonSerializableCubit();
+        final expected = const User.initial().copyWith(
+          favoriteColor: Color.green,
+        );
+        expect(cubit.state, const User.initial());
+        cubit.updateFavoriteColor(Color.green);
+        await sleep();
+        expect(JsonSerializableCubit().state, expected);
+      });
+    });
+
+    group('ListCubit', () {
+      test('persists and restores state correctly', () async {
+        const item = 'foo';
+        final cubit = ListCubit();
+        expect(cubit.state, isEmpty);
+        cubit.addItem(item);
+        await sleep();
+        expect(ListCubit().state, const <String>[item]);
+      });
+    });
+
+    group('ManualCubit', () {
+      test('persists and restores state correctly', () async {
+        const dog = Dog('Rover', 5, [Toy('Ball')]);
+        final cubit = ManualCubit();
+        expect(cubit.state, isNull);
+        cubit.setDog(dog);
+        await sleep();
+        expect(ManualCubit().state, dog);
+      });
+    });
+
+    group('SimpleCubit', () {
+      test('persists and restores state correctly', () async {
+        final cubit = SimpleCubit();
+        expect(cubit.state, 0);
+        cubit.increment();
+        expect(cubit.state, 1);
+        await sleep();
+        expect(SimpleCubit().state, 1);
+      });
+    });
+  });
+}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->
- tests: add e2e tests for hydrated_bloc
- fix: error handling for `storage.write` 

@orsenkucher what do you think of these changes? I made a bunch of e2e tests with different (de)serialization approaches and they all seem to work fine without needing #1456.

The other thing that I noticed was we weren't awaiting `storage.write` and yet we still had it wrapped in a try/catch which didn't seem to make sense so I refactored to use `onError` instead. Let me know what you think.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [X] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
