### PR TITLE
fix: blocTest improvements

### DIFF
--- a/docs/_snippets/testing/counter_bloc_test_bloc_test.dart.md
+++ b/docs/_snippets/testing/counter_bloc_test_bloc_test.dart.md
@@ -2,14 +2,14 @@
 blocTest(
     'emits [1] when CounterEvent.increment is added',
     build: () => counterBloc,
-    act: (bloc) async => bloc.add(CounterEvent.increment),
+    act: (bloc) => bloc.add(CounterEvent.increment),
     expect: [1],
 );
 
 blocTest(
     'emits [-1] when CounterEvent.decrement is added',
     build: () => counterBloc,
-    act: (bloc) async => bloc.add(CounterEvent.decrement),
+    act: (bloc) => bloc.add(CounterEvent.decrement),
     expect: [-1],
 );
 ```

--- a/docs/_snippets/testing/counter_bloc_test_bloc_test.dart.md
+++ b/docs/_snippets/testing/counter_bloc_test_bloc_test.dart.md
@@ -1,14 +1,14 @@
 ```dart
 blocTest(
     'emits [1] when CounterEvent.increment is added',
-    build: () async => counterBloc,
+    build: () => counterBloc,
     act: (bloc) async => bloc.add(CounterEvent.increment),
     expect: [1],
 );
 
 blocTest(
     'emits [-1] when CounterEvent.decrement is added',
-    build: () async => counterBloc,
+    build: () => counterBloc,
     act: (bloc) async => bloc.add(CounterEvent.decrement),
     expect: [-1],
 );

--- a/docs/_snippets/testing/pubspec.yaml.md
+++ b/docs/_snippets/testing/pubspec.yaml.md
@@ -1,5 +1,5 @@
 ```yaml
 dev_dependencies:
   test: ^1.3.0
-  bloc_test: ^6.0.0
+  bloc_test: ^7.0.0
 ```

--- a/packages/bloc_test/CHANGELOG.md
+++ b/packages/bloc_test/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 7.0.0-dev.2
+
+- **BREAKING**: `blocTest` make `build` synchronous
+- fix: `blocTest` improve `wait` behavior when debouncing, etc...
+
 # 7.0.0-dev.1
 
 - **BREAKING**: upgrade to `bloc ^6.0.0-dev.1`

--- a/packages/bloc_test/CHANGELOG.md
+++ b/packages/bloc_test/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **BREAKING**: `blocTest` make `build` synchronous
 - fix: `blocTest` improve `wait` behavior when debouncing, etc...
+- feat: `blocTest` do not require `async` on `act` and `verify`
 
 # 7.0.0-dev.1
 

--- a/packages/bloc_test/README.md
+++ b/packages/bloc_test/README.md
@@ -53,7 +53,7 @@ expect(counterBloc.state, equals(3));
 
 **blocTest** creates a new `cubit`-specific test case with the given `description`. `blocTest` will handle asserting that the `cubit` emits the `expect`ed states (in order) after `act` is executed. `blocTest` also handles ensuring that no additional states are emitted by closing the `cubit` stream before evaluating the `expect`ation.
 
-`build` should be used for all `cubit` initialization and preparation and must return the `cubit` under test as a `Future`.
+`build` should be used for all `cubit` initialization and preparation and must return the `cubit` under test.
 
 `act` is an optional callback which will be invoked with the `cubit` under test and should be used to `add` events to the `cubit`.
 
@@ -71,13 +71,13 @@ expect(counterBloc.state, equals(3));
 group('CounterBloc', () {
   blocTest(
     'emits [] when nothing is added',
-    build: () async => CounterBloc(),
+    build: () => CounterBloc(),
     expect: [],
   );
 
   blocTest(
     'emits [1] when CounterEvent.increment is added',
-    build: () async => CounterBloc(),
+    build: () => CounterBloc(),
     act: (bloc) async => bloc.add(CounterEvent.increment),
     expect: [1],
   );
@@ -89,7 +89,7 @@ group('CounterBloc', () {
 ```dart
 blocTest(
   'CounterBloc emits [1] when CounterEvent.increment is added',
-  build: () async => CounterBloc(),
+  build: () => CounterBloc(),
   act: (bloc) async => bloc..add(CounterEvent.increment)..add(CounterEvent.increment),
   skip: 1,
   expect: [1],
@@ -101,7 +101,7 @@ blocTest(
 ```dart
 blocTest(
   'CounterBloc emits [1] when CounterEvent.increment is added',
-  build: () async => CounterBloc(),
+  build: () => CounterBloc(),
   act: (bloc) async => bloc.add(CounterEvent.increment),
   wait: const Duration(milliseconds: 300),
   expect: [1],
@@ -113,7 +113,7 @@ blocTest(
 ```dart
 blocTest(
   'CounterBloc emits [1] when CounterEvent.increment is added',
-  build: () async => CounterBloc(),
+  build: () => CounterBloc(),
   act: (bloc) async => bloc.add(CounterEvent.increment),
   expect: [1],
   verify: (_) async {
@@ -127,7 +127,7 @@ blocTest(
 ```dart
 blocTest(
   'CounterBloc throws Exception when null is added',
-  build: () async => CounterBloc(),
+  build: () => CounterBloc(),
   act: (bloc) async => bloc.add(null),
   errors: [
     isA<Exception>(),
@@ -140,7 +140,7 @@ blocTest(
 ```dart
 blocTest(
   'emits [StateB] when MyEvent is added',
-  build: () async => MyBloc(),
+  build: () => MyBloc(),
   act: (bloc) async => bloc.add(MyEvent()),
   expect: [isA<StateB>()],
 );

--- a/packages/bloc_test/README.md
+++ b/packages/bloc_test/README.md
@@ -78,7 +78,7 @@ group('CounterBloc', () {
   blocTest(
     'emits [1] when CounterEvent.increment is added',
     build: () => CounterBloc(),
-    act: (bloc) async => bloc.add(CounterEvent.increment),
+    act: (bloc) => bloc.add(CounterEvent.increment),
     expect: [1],
   );
 });
@@ -90,7 +90,7 @@ group('CounterBloc', () {
 blocTest(
   'CounterBloc emits [1] when CounterEvent.increment is added',
   build: () => CounterBloc(),
-  act: (bloc) async => bloc..add(CounterEvent.increment)..add(CounterEvent.increment),
+  act: (bloc) => bloc..add(CounterEvent.increment)..add(CounterEvent.increment),
   skip: 1,
   expect: [1],
 );
@@ -102,7 +102,7 @@ blocTest(
 blocTest(
   'CounterBloc emits [1] when CounterEvent.increment is added',
   build: () => CounterBloc(),
-  act: (bloc) async => bloc.add(CounterEvent.increment),
+  act: (bloc) => bloc.add(CounterEvent.increment),
   wait: const Duration(milliseconds: 300),
   expect: [1],
 );
@@ -114,9 +114,9 @@ blocTest(
 blocTest(
   'CounterBloc emits [1] when CounterEvent.increment is added',
   build: () => CounterBloc(),
-  act: (bloc) async => bloc.add(CounterEvent.increment),
+  act: (bloc) => bloc.add(CounterEvent.increment),
   expect: [1],
-  verify: (_) async {
+  verify: (_) {
     verify(repository.someMethod(any)).called(1);
   }
 );
@@ -128,7 +128,7 @@ blocTest(
 blocTest(
   'CounterBloc throws Exception when null is added',
   build: () => CounterBloc(),
-  act: (bloc) async => bloc.add(null),
+  act: (bloc) => bloc.add(null),
   errors: [
     isA<Exception>(),
   ]
@@ -141,7 +141,7 @@ blocTest(
 blocTest(
   'emits [StateB] when MyEvent is added',
   build: () => MyBloc(),
-  act: (bloc) async => bloc.add(MyEvent()),
+  act: (bloc) => bloc.add(MyEvent()),
   expect: [isA<StateB>()],
 );
 ```

--- a/packages/bloc_test/example/main.dart
+++ b/packages/bloc_test/example/main.dart
@@ -33,13 +33,13 @@ void mainCubit() {
   group('CounterCubit', () {
     blocTest<CounterCubit, int>(
       'emits [] when nothing is called',
-      build: () async => CounterCubit(),
+      build: () => CounterCubit(),
       expect: const <int>[],
     );
 
     blocTest<CounterCubit, int>(
       'emits [1] when increment is called',
-      build: () async => CounterCubit(),
+      build: () => CounterCubit(),
       act: (cubit) async => cubit.increment(),
       expect: const <int>[1],
     );
@@ -76,13 +76,13 @@ void mainBloc() {
   group('CounterBloc', () {
     blocTest<CounterBloc, int>(
       'emits [] when nothing is added',
-      build: () async => CounterBloc(),
+      build: () => CounterBloc(),
       expect: const <int>[],
     );
 
     blocTest<CounterBloc, int>(
       'emits [1] when CounterEvent.increment is added',
-      build: () async => CounterBloc(),
+      build: () => CounterBloc(),
       act: (bloc) async => bloc.add(CounterEvent.increment),
       expect: const <int>[1],
     );

--- a/packages/bloc_test/lib/src/bloc_test.dart
+++ b/packages/bloc_test/lib/src/bloc_test.dart
@@ -11,7 +11,7 @@ import 'package:test/test.dart' as test;
 /// by closing the `cubit` stream before evaluating the [expect]ation.
 ///
 /// [build] should be used for all `cubit` initialization and preparation
-/// and must return the `cubit` under test as a `Future`.
+/// and must return the `cubit` under test.
 ///
 /// [act] is an optional callback which will be invoked with the `cubit` under
 /// test and should be used to interact with the `cubit`.
@@ -33,7 +33,7 @@ import 'package:test/test.dart' as test;
 /// ```dart
 /// blocTest(
 ///   'CounterCubit emits [1] when increment is called',
-///   build: () async => CounterCubit(),
+///   build: () => CounterCubit(),
 ///   act: (cubit) async => cubit.increment(),
 ///   expect: [1],
 /// );
@@ -45,7 +45,7 @@ import 'package:test/test.dart' as test;
 /// ```dart
 /// blocTest(
 ///   'CounterCubit emits [] when nothing is called',
-///   build: () async => CounterCubit(),
+///   build: () => CounterCubit(),
 ///   expect: [],
 /// );
 /// ```
@@ -57,7 +57,7 @@ import 'package:test/test.dart' as test;
 /// ```dart
 /// blocTest(
 ///   'CounterCubit emits [2] when increment is called twice',
-///   build: () async => CounterCubit(),
+///   build: () => CounterCubit(),
 ///   act: (cubit) async {
 ///     cubit
 ///       ..increment()
@@ -74,7 +74,7 @@ import 'package:test/test.dart' as test;
 /// ```dart
 /// blocTest(
 ///   'CounterCubit emits [1] when increment is called',
-///   build: () async => CounterCubit(),
+///   build: () => CounterCubit(),
 ///   act: (cubit) async => cubit.increment(),
 ///   wait: const Duration(milliseconds: 300),
 ///   expect: [1],
@@ -86,7 +86,7 @@ import 'package:test/test.dart' as test;
 /// ```dart
 /// blocTest(
 ///   'CounterCubit emits [1] when increment is called',
-///   build: () async => CounterCubit(),
+///   build: () => CounterCubit(),
 ///   act: (cubit) async => cubit.increment(),
 ///   expect: [1],
 ///   verify: (_) async {
@@ -102,7 +102,7 @@ import 'package:test/test.dart' as test;
 /// ```dart
 /// blocTest(
 ///  'emits [StateB] when emitB is called',
-///  build: () async => MyCubit(),
+///  build: () => MyCubit(),
 ///  act: (cubit) async => cubit.emitB(),
 ///  expect: [isA<StateB>()],
 /// );
@@ -110,7 +110,7 @@ import 'package:test/test.dart' as test;
 @isTest
 void blocTest<C extends Cubit<State>, State>(
   String description, {
-  @required Future<C> Function() build,
+  @required C Function() build,
   Future<void> Function(C cubit) act,
   Duration wait,
   int skip = 0,
@@ -122,11 +122,12 @@ void blocTest<C extends Cubit<State>, State>(
     final unhandledErrors = <Object>[];
     await runZoned(
       () async {
-        final cubit = await build();
         final states = <State>[];
+        final cubit = build();
         final subscription = cubit.skip(skip).listen(states.add);
         await act?.call(cubit);
         if (wait != null) await Future<void>.delayed(wait);
+        await Future<void>.delayed(Duration.zero);
         await cubit.close();
         if (expect != null) test.expect(states, expect);
         await subscription.cancel();

--- a/packages/bloc_test/lib/src/bloc_test.dart
+++ b/packages/bloc_test/lib/src/bloc_test.dart
@@ -34,7 +34,7 @@ import 'package:test/test.dart' as test;
 /// blocTest(
 ///   'CounterCubit emits [1] when increment is called',
 ///   build: () => CounterCubit(),
-///   act: (cubit) async => cubit.increment(),
+///   act: (cubit) => cubit.increment(),
 ///   expect: [1],
 /// );
 /// ```
@@ -58,7 +58,7 @@ import 'package:test/test.dart' as test;
 /// blocTest(
 ///   'CounterCubit emits [2] when increment is called twice',
 ///   build: () => CounterCubit(),
-///   act: (cubit) async {
+///   act: (cubit) {
 ///     cubit
 ///       ..increment()
 ///       ..increment();
@@ -75,7 +75,7 @@ import 'package:test/test.dart' as test;
 /// blocTest(
 ///   'CounterCubit emits [1] when increment is called',
 ///   build: () => CounterCubit(),
-///   act: (cubit) async => cubit.increment(),
+///   act: (cubit) => cubit.increment(),
 ///   wait: const Duration(milliseconds: 300),
 ///   expect: [1],
 /// );
@@ -87,9 +87,9 @@ import 'package:test/test.dart' as test;
 /// blocTest(
 ///   'CounterCubit emits [1] when increment is called',
 ///   build: () => CounterCubit(),
-///   act: (cubit) async => cubit.increment(),
+///   act: (cubit) => cubit.increment(),
 ///   expect: [1],
-///   verify: (_) async {
+///   verify: (_) {
 ///     verify(repository.someMethod(any)).called(1);
 ///   }
 /// );
@@ -103,7 +103,7 @@ import 'package:test/test.dart' as test;
 /// blocTest(
 ///  'emits [StateB] when emitB is called',
 ///  build: () => MyCubit(),
-///  act: (cubit) async => cubit.emitB(),
+///  act: (cubit) => cubit.emitB(),
 ///  expect: [isA<StateB>()],
 /// );
 /// ```
@@ -111,11 +111,11 @@ import 'package:test/test.dart' as test;
 void blocTest<C extends Cubit<State>, State>(
   String description, {
   @required C Function() build,
-  Future<void> Function(C cubit) act,
+  Function(C cubit) act,
   Duration wait,
   int skip = 0,
   Iterable expect,
-  Future<void> Function(C cubit) verify,
+  Function(C cubit) verify,
   Iterable errors,
 }) {
   test.test(description, () async {

--- a/packages/bloc_test/pubspec.yaml
+++ b/packages/bloc_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc_test
 description: A testing library which makes it easy to test blocs. Built to be used with the bloc state management package.
-version: 7.0.0-dev.1
+version: 7.0.0-dev.2
 repository: https://github.com/felangel/bloc/tree/master/packages/bloc_test
 issue_tracker: https://github.com/felangel/bloc/issues
 homepage: https://bloclibrary.dev

--- a/packages/bloc_test/test/bloc_bloc_test_test.dart
+++ b/packages/bloc_test/test/bloc_bloc_test_test.dart
@@ -13,20 +13,20 @@ void main() {
     group('CounterBloc', () {
       blocTest<CounterBloc, int>(
         'emits [] when nothing is added',
-        build: () async => CounterBloc(),
+        build: () => CounterBloc(),
         expect: const <int>[],
       );
 
       blocTest<CounterBloc, int>(
         'emits [1] when CounterEvent.increment is added',
-        build: () async => CounterBloc(),
+        build: () => CounterBloc(),
         act: (bloc) async => bloc.add(CounterEvent.increment),
         expect: const <int>[1],
       );
 
       blocTest<CounterBloc, int>(
         'emits [1] when CounterEvent.increment is added with async act',
-        build: () async => CounterBloc(),
+        build: () => CounterBloc(),
         act: (bloc) async {
           await Future<void>.delayed(const Duration(seconds: 1));
           bloc.add(CounterEvent.increment);
@@ -35,9 +35,9 @@ void main() {
       );
 
       blocTest<CounterBloc, int>(
-        'emits [1, 2] when CounterEvent.increment is called multiple times'
+        'emits [1, 2] when CounterEvent.increment is called multiple times '
         'with async act',
-        build: () async => CounterBloc(),
+        build: () => CounterBloc(),
         act: (bloc) async {
           bloc.add(CounterEvent.increment);
           await Future<void>.delayed(const Duration(milliseconds: 10));
@@ -48,114 +48,170 @@ void main() {
 
       blocTest<CounterBloc, int>(
         'emits [2] when CounterEvent.increment is added twice and skip: 1',
-        build: () async => CounterBloc(),
+        build: () => CounterBloc(),
         act: (bloc) async {
           bloc..add(CounterEvent.increment)..add(CounterEvent.increment);
         },
         skip: 1,
         expect: const <int>[2],
       );
+
+      blocTest<CounterBloc, int>(
+        'emits [11] when CounterEvent.increment is added and emitted 10',
+        build: () => CounterBloc()..emit(10),
+        act: (bloc) async => bloc.add(CounterEvent.increment),
+        expect: const <int>[11],
+      );
     });
 
     group('AsyncCounterBloc', () {
       blocTest<AsyncCounterBloc, int>(
         'emits [] when nothing is added',
-        build: () async => AsyncCounterBloc(),
+        build: () => AsyncCounterBloc(),
         expect: const <int>[],
       );
 
       blocTest<AsyncCounterBloc, int>(
-        'emits [1] when AsyncCounterEvent.increment is added',
-        build: () async => AsyncCounterBloc(),
-        act: (bloc) async => bloc.add(AsyncCounterEvent.increment),
+        'emits [1] when CounterEvent.increment is added',
+        build: () => AsyncCounterBloc(),
+        act: (bloc) async => bloc.add(CounterEvent.increment),
         expect: const <int>[1],
       );
 
       blocTest<AsyncCounterBloc, int>(
-        'emits [1, 2] when AsyncCounterEvent.increment is called multiple'
+        'emits [1, 2] when CounterEvent.increment is called multiple'
         'times with async act',
-        build: () async => AsyncCounterBloc(),
+        build: () => AsyncCounterBloc(),
         act: (bloc) async {
-          bloc.add(AsyncCounterEvent.increment);
+          bloc.add(CounterEvent.increment);
           await Future<void>.delayed(const Duration(milliseconds: 10));
-          bloc.add(AsyncCounterEvent.increment);
+          bloc.add(CounterEvent.increment);
         },
         expect: const <int>[1, 2],
       );
 
       blocTest<AsyncCounterBloc, int>(
-        'emits [2] when AsyncCounterEvent.increment is added twice and skip: 1',
-        build: () async => AsyncCounterBloc(),
-        act: (bloc) async => bloc
-          ..add(AsyncCounterEvent.increment)
-          ..add(AsyncCounterEvent.increment),
+        'emits [2] when CounterEvent.increment is added twice and skip: 1',
+        build: () => AsyncCounterBloc(),
+        act: (bloc) async =>
+            bloc..add(CounterEvent.increment)..add(CounterEvent.increment),
         skip: 1,
         expect: const <int>[2],
+      );
+
+      blocTest<AsyncCounterBloc, int>(
+        'emits [11] when CounterEvent.increment is added and emitted 10',
+        build: () => AsyncCounterBloc()..emit(10),
+        act: (bloc) async => bloc.add(CounterEvent.increment),
+        expect: const <int>[11],
       );
     });
 
     group('DebounceCounterBloc', () {
       blocTest<DebounceCounterBloc, int>(
         'emits [] when nothing is added',
-        build: () async => DebounceCounterBloc(),
+        build: () => DebounceCounterBloc(),
         expect: const <int>[],
       );
 
       blocTest<DebounceCounterBloc, int>(
-        'emits [1] when DebounceCounterEvent.increment is added',
-        build: () async => DebounceCounterBloc(),
-        act: (bloc) async => bloc.add(DebounceCounterEvent.increment),
+        'emits [1] when CounterEvent.increment is added',
+        build: () => DebounceCounterBloc(),
+        act: (bloc) async => bloc.add(CounterEvent.increment),
         wait: const Duration(milliseconds: 300),
         expect: const <int>[1],
       );
 
       blocTest<DebounceCounterBloc, int>(
-        'emits [2] when DebounceCounterEvent.increment '
+        'emits [2] when CounterEvent.increment '
         'is added twice and skip: 1',
-        build: () async => DebounceCounterBloc(),
+        build: () => DebounceCounterBloc(),
         act: (bloc) async {
-          bloc.add(DebounceCounterEvent.increment);
+          bloc.add(CounterEvent.increment);
           await Future<void>.delayed(const Duration(milliseconds: 305));
-          bloc.add(DebounceCounterEvent.increment);
+          bloc.add(CounterEvent.increment);
         },
         skip: 1,
-        wait: const Duration(milliseconds: 305),
+        wait: const Duration(milliseconds: 300),
         expect: const <int>[2],
+      );
+
+      blocTest<DebounceCounterBloc, int>(
+        'emits [11] when CounterEvent.increment is added and emitted 10',
+        build: () => DebounceCounterBloc()..emit(10),
+        act: (bloc) async => bloc.add(CounterEvent.increment),
+        wait: const Duration(milliseconds: 300),
+        expect: const <int>[11],
+      );
+    });
+
+    group('InstanceEmitBloc', () {
+      blocTest<InstantEmitBloc, int>(
+        'emits [1] when nothing is added',
+        build: () => InstantEmitBloc(),
+        expect: const <int>[1],
+      );
+
+      blocTest<InstantEmitBloc, int>(
+        'emits [1, 2] when CounterEvent.increment is added',
+        build: () => InstantEmitBloc(),
+        act: (bloc) async => bloc.add(CounterEvent.increment),
+        expect: const <int>[1, 2],
+      );
+
+      blocTest<InstantEmitBloc, int>(
+        'emits [1, 2, 3] when CounterEvent.increment is called'
+        'multiple times with async act',
+        build: () => InstantEmitBloc(),
+        act: (bloc) async {
+          bloc.add(CounterEvent.increment);
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          bloc.add(CounterEvent.increment);
+        },
+        expect: const <int>[1, 2, 3],
+      );
+
+      blocTest<InstantEmitBloc, int>(
+        'emits [3] when CounterEvent.increment is added twice and skip: 2',
+        build: () => InstantEmitBloc(),
+        act: (bloc) async =>
+            bloc..add(CounterEvent.increment)..add(CounterEvent.increment),
+        skip: 2,
+        expect: const <int>[3],
       );
     });
 
     group('MultiCounterBloc', () {
       blocTest<MultiCounterBloc, int>(
         'emits [] when nothing is added',
-        build: () async => MultiCounterBloc(),
+        build: () => MultiCounterBloc(),
         expect: const <int>[],
       );
 
       blocTest<MultiCounterBloc, int>(
-        'emits [1, 2] when MultiCounterEvent.increment is added',
-        build: () async => MultiCounterBloc(),
-        act: (bloc) async => bloc.add(MultiCounterEvent.increment),
+        'emits [1, 2] when CounterEvent.increment is added',
+        build: () => MultiCounterBloc(),
+        act: (bloc) async => bloc.add(CounterEvent.increment),
         expect: const <int>[1, 2],
       );
 
       blocTest<MultiCounterBloc, int>(
-        'emits [1, 2, 3, 4] when MultiCounterEvent.increment is called'
+        'emits [1, 2, 3, 4] when CounterEvent.increment is called'
         'multiple times with async act',
-        build: () async => MultiCounterBloc(),
+        build: () => MultiCounterBloc(),
         act: (bloc) async {
-          bloc.add(MultiCounterEvent.increment);
+          bloc.add(CounterEvent.increment);
           await Future<void>.delayed(const Duration(milliseconds: 10));
-          bloc.add(MultiCounterEvent.increment);
+          bloc.add(CounterEvent.increment);
         },
         expect: const <int>[1, 2, 3, 4],
       );
 
       blocTest<MultiCounterBloc, int>(
-        'emits [4] when MultiCounterEvent.increment is added twice and skip: 3',
-        build: () async => MultiCounterBloc(),
-        act: (bloc) async => bloc
-          ..add(MultiCounterEvent.increment)
-          ..add(MultiCounterEvent.increment),
+        'emits [4] when CounterEvent.increment is added twice and skip: 3',
+        build: () => MultiCounterBloc(),
+        act: (bloc) async =>
+            bloc..add(CounterEvent.increment)..add(CounterEvent.increment),
         skip: 3,
         expect: const <int>[4],
       );
@@ -164,13 +220,13 @@ void main() {
     group('ComplexBloc', () {
       blocTest<ComplexBloc, ComplexState>(
         'emits [] when nothing is added',
-        build: () async => ComplexBloc(),
+        build: () => ComplexBloc(),
         expect: const <ComplexState>[],
       );
 
       blocTest<ComplexBloc, ComplexState>(
         'emits [ComplexStateB] when ComplexEventB is added',
-        build: () async => ComplexBloc(),
+        build: () => ComplexBloc(),
         act: (bloc) async => bloc.add(ComplexEventB()),
         expect: <Matcher>[isA<ComplexStateB>()],
       );
@@ -178,7 +234,7 @@ void main() {
       blocTest<ComplexBloc, ComplexState>(
         'emits [ComplexStateA] when [ComplexEventB, ComplexEventA] '
         'is added and skip: 1',
-        build: () async => ComplexBloc(),
+        build: () => ComplexBloc(),
         act: (bloc) async => bloc..add(ComplexEventB())..add(ComplexEventA()),
         skip: 1,
         expect: <Matcher>[isA<ComplexStateA>()],
@@ -188,59 +244,56 @@ void main() {
     group('ExceptionCounterBloc', () {
       blocTest<ExceptionCounterBloc, int>(
         'emits [] when nothing is added',
-        build: () async => ExceptionCounterBloc(),
+        build: () => ExceptionCounterBloc(),
         expect: const <int>[],
       );
 
       blocTest<ExceptionCounterBloc, int>(
         'emits [2] when increment is added twice and skip: 1',
-        build: () async => ExceptionCounterBloc(),
-        act: (bloc) async => bloc
-          ..add(ExceptionCounterEvent.increment)
-          ..add(ExceptionCounterEvent.increment),
+        build: () => ExceptionCounterBloc(),
+        act: (bloc) async =>
+            bloc..add(CounterEvent.increment)..add(CounterEvent.increment),
         skip: 1,
         expect: const <int>[2],
       );
 
       blocTest<ExceptionCounterBloc, int>(
         'emits [1] when increment is added',
-        build: () async => ExceptionCounterBloc(),
-        act: (bloc) async => bloc.add(ExceptionCounterEvent.increment),
+        build: () => ExceptionCounterBloc(),
+        act: (bloc) async => bloc.add(CounterEvent.increment),
         expect: const <int>[1],
       );
 
       blocTest<ExceptionCounterBloc, int>(
         'throws ExceptionCounterBlocException when increment is added',
-        build: () async => ExceptionCounterBloc(),
-        act: (bloc) async => bloc.add(ExceptionCounterEvent.increment),
+        build: () => ExceptionCounterBloc(),
+        act: (bloc) async => bloc.add(CounterEvent.increment),
         errors: <Matcher>[isA<ExceptionCounterBlocException>()],
       );
 
       blocTest<ExceptionCounterBloc, int>(
         'emits [1] and throws ExceptionCounterBlocException '
         'when increment is added',
-        build: () async => ExceptionCounterBloc(),
-        act: (bloc) async => bloc.add(ExceptionCounterEvent.increment),
+        build: () => ExceptionCounterBloc(),
+        act: (bloc) async => bloc.add(CounterEvent.increment),
         expect: const <int>[1],
         errors: <Matcher>[isA<ExceptionCounterBlocException>()],
       );
 
       blocTest<ExceptionCounterBloc, int>(
         'emits [1, 2] when increment is added twice',
-        build: () async => ExceptionCounterBloc(),
-        act: (bloc) async => bloc
-          ..add(ExceptionCounterEvent.increment)
-          ..add(ExceptionCounterEvent.increment),
+        build: () => ExceptionCounterBloc(),
+        act: (bloc) async =>
+            bloc..add(CounterEvent.increment)..add(CounterEvent.increment),
         expect: const <int>[1, 2],
       );
 
       blocTest<ExceptionCounterBloc, int>(
         'throws two ExceptionCounterBlocExceptions '
         'when increment is added twice',
-        build: () async => ExceptionCounterBloc(),
-        act: (bloc) async => bloc
-          ..add(ExceptionCounterEvent.increment)
-          ..add(ExceptionCounterEvent.increment),
+        build: () => ExceptionCounterBloc(),
+        act: (bloc) async =>
+            bloc..add(CounterEvent.increment)..add(CounterEvent.increment),
         errors: <Matcher>[
           isA<ExceptionCounterBlocException>(),
           isA<ExceptionCounterBlocException>(),
@@ -250,10 +303,9 @@ void main() {
       blocTest<ExceptionCounterBloc, int>(
         'emits [1, 2] and throws two ExceptionCounterBlocException '
         'when increment is added twice',
-        build: () async => ExceptionCounterBloc(),
-        act: (bloc) async => bloc
-          ..add(ExceptionCounterEvent.increment)
-          ..add(ExceptionCounterEvent.increment),
+        build: () => ExceptionCounterBloc(),
+        act: (bloc) async =>
+            bloc..add(CounterEvent.increment)..add(CounterEvent.increment),
         expect: const <int>[1, 2],
         errors: <Matcher>[
           isA<ExceptionCounterBlocException>(),
@@ -271,14 +323,14 @@ void main() {
 
       blocTest<SideEffectCounterBloc, int>(
         'emits [] when nothing is added',
-        build: () async => SideEffectCounterBloc(repository),
+        build: () => SideEffectCounterBloc(repository),
         expect: const <int>[],
       );
 
       blocTest<SideEffectCounterBloc, int>(
-        'emits [1] when SideEffectCounterEvent.increment is added',
-        build: () async => SideEffectCounterBloc(repository),
-        act: (bloc) async => bloc.add(SideEffectCounterEvent.increment),
+        'emits [1] when CounterEvent.increment is added',
+        build: () => SideEffectCounterBloc(repository),
+        act: (bloc) async => bloc.add(CounterEvent.increment),
         expect: const <int>[1],
         verify: (_) async {
           verify(repository.sideEffect()).called(1);
@@ -286,20 +338,19 @@ void main() {
       );
 
       blocTest<SideEffectCounterBloc, int>(
-        'emits [2] when SideEffectCounterEvent.increment '
+        'emits [2] when CounterEvent.increment '
         'is added twice and skip: 1',
-        build: () async => SideEffectCounterBloc(repository),
-        act: (bloc) async => bloc
-          ..add(SideEffectCounterEvent.increment)
-          ..add(SideEffectCounterEvent.increment),
+        build: () => SideEffectCounterBloc(repository),
+        act: (bloc) async =>
+            bloc..add(CounterEvent.increment)..add(CounterEvent.increment),
         skip: 1,
         expect: const <int>[2],
       );
 
       blocTest<SideEffectCounterBloc, int>(
         'does not require an expect',
-        build: () async => SideEffectCounterBloc(repository),
-        act: (bloc) async => bloc.add(SideEffectCounterEvent.increment),
+        build: () => SideEffectCounterBloc(repository),
+        act: (bloc) async => bloc.add(CounterEvent.increment),
         verify: (_) async {
           verify(repository.sideEffect()).called(1);
         },

--- a/packages/bloc_test/test/bloc_bloc_test_test.dart
+++ b/packages/bloc_test/test/bloc_bloc_test_test.dart
@@ -179,6 +179,13 @@ void main() {
         skip: 2,
         expect: const <int>[3],
       );
+
+      blocTest<InstantEmitBloc, int>(
+        'emits [11, 12] when CounterEvent.increment is added and emitted 10',
+        build: () => InstantEmitBloc()..emit(10),
+        act: (bloc) async => bloc.add(CounterEvent.increment),
+        expect: const <int>[11, 12],
+      );
     });
 
     group('MultiCounterBloc', () {
@@ -214,6 +221,13 @@ void main() {
             bloc..add(CounterEvent.increment)..add(CounterEvent.increment),
         skip: 3,
         expect: const <int>[4],
+      );
+
+      blocTest<MultiCounterBloc, int>(
+        'emits [11, 12] when CounterEvent.increment is added and emitted 10',
+        build: () => MultiCounterBloc()..emit(10),
+        act: (bloc) async => bloc.add(CounterEvent.increment),
+        expect: const <int>[11, 12],
       );
     });
 

--- a/packages/bloc_test/test/bloc_bloc_test_test.dart
+++ b/packages/bloc_test/test/bloc_bloc_test_test.dart
@@ -20,7 +20,7 @@ void main() {
       blocTest<CounterBloc, int>(
         'emits [1] when CounterEvent.increment is added',
         build: () => CounterBloc(),
-        act: (bloc) async => bloc.add(CounterEvent.increment),
+        act: (bloc) => bloc.add(CounterEvent.increment),
         expect: const <int>[1],
       );
 
@@ -49,7 +49,7 @@ void main() {
       blocTest<CounterBloc, int>(
         'emits [2] when CounterEvent.increment is added twice and skip: 1',
         build: () => CounterBloc(),
-        act: (bloc) async {
+        act: (bloc) {
           bloc..add(CounterEvent.increment)..add(CounterEvent.increment);
         },
         skip: 1,
@@ -59,7 +59,7 @@ void main() {
       blocTest<CounterBloc, int>(
         'emits [11] when CounterEvent.increment is added and emitted 10',
         build: () => CounterBloc()..emit(10),
-        act: (bloc) async => bloc.add(CounterEvent.increment),
+        act: (bloc) => bloc.add(CounterEvent.increment),
         expect: const <int>[11],
       );
     });
@@ -74,7 +74,7 @@ void main() {
       blocTest<AsyncCounterBloc, int>(
         'emits [1] when CounterEvent.increment is added',
         build: () => AsyncCounterBloc(),
-        act: (bloc) async => bloc.add(CounterEvent.increment),
+        act: (bloc) => bloc.add(CounterEvent.increment),
         expect: const <int>[1],
       );
 
@@ -93,7 +93,7 @@ void main() {
       blocTest<AsyncCounterBloc, int>(
         'emits [2] when CounterEvent.increment is added twice and skip: 1',
         build: () => AsyncCounterBloc(),
-        act: (bloc) async =>
+        act: (bloc) =>
             bloc..add(CounterEvent.increment)..add(CounterEvent.increment),
         skip: 1,
         expect: const <int>[2],
@@ -102,7 +102,7 @@ void main() {
       blocTest<AsyncCounterBloc, int>(
         'emits [11] when CounterEvent.increment is added and emitted 10',
         build: () => AsyncCounterBloc()..emit(10),
-        act: (bloc) async => bloc.add(CounterEvent.increment),
+        act: (bloc) => bloc.add(CounterEvent.increment),
         expect: const <int>[11],
       );
     });
@@ -117,7 +117,7 @@ void main() {
       blocTest<DebounceCounterBloc, int>(
         'emits [1] when CounterEvent.increment is added',
         build: () => DebounceCounterBloc(),
-        act: (bloc) async => bloc.add(CounterEvent.increment),
+        act: (bloc) => bloc.add(CounterEvent.increment),
         wait: const Duration(milliseconds: 300),
         expect: const <int>[1],
       );
@@ -139,7 +139,7 @@ void main() {
       blocTest<DebounceCounterBloc, int>(
         'emits [11] when CounterEvent.increment is added and emitted 10',
         build: () => DebounceCounterBloc()..emit(10),
-        act: (bloc) async => bloc.add(CounterEvent.increment),
+        act: (bloc) => bloc.add(CounterEvent.increment),
         wait: const Duration(milliseconds: 300),
         expect: const <int>[11],
       );
@@ -155,7 +155,7 @@ void main() {
       blocTest<InstantEmitBloc, int>(
         'emits [1, 2] when CounterEvent.increment is added',
         build: () => InstantEmitBloc(),
-        act: (bloc) async => bloc.add(CounterEvent.increment),
+        act: (bloc) => bloc.add(CounterEvent.increment),
         expect: const <int>[1, 2],
       );
 
@@ -174,7 +174,7 @@ void main() {
       blocTest<InstantEmitBloc, int>(
         'emits [3] when CounterEvent.increment is added twice and skip: 2',
         build: () => InstantEmitBloc(),
-        act: (bloc) async =>
+        act: (bloc) =>
             bloc..add(CounterEvent.increment)..add(CounterEvent.increment),
         skip: 2,
         expect: const <int>[3],
@@ -183,7 +183,7 @@ void main() {
       blocTest<InstantEmitBloc, int>(
         'emits [11, 12] when CounterEvent.increment is added and emitted 10',
         build: () => InstantEmitBloc()..emit(10),
-        act: (bloc) async => bloc.add(CounterEvent.increment),
+        act: (bloc) => bloc.add(CounterEvent.increment),
         expect: const <int>[11, 12],
       );
     });
@@ -198,7 +198,7 @@ void main() {
       blocTest<MultiCounterBloc, int>(
         'emits [1, 2] when CounterEvent.increment is added',
         build: () => MultiCounterBloc(),
-        act: (bloc) async => bloc.add(CounterEvent.increment),
+        act: (bloc) => bloc.add(CounterEvent.increment),
         expect: const <int>[1, 2],
       );
 
@@ -217,7 +217,7 @@ void main() {
       blocTest<MultiCounterBloc, int>(
         'emits [4] when CounterEvent.increment is added twice and skip: 3',
         build: () => MultiCounterBloc(),
-        act: (bloc) async =>
+        act: (bloc) =>
             bloc..add(CounterEvent.increment)..add(CounterEvent.increment),
         skip: 3,
         expect: const <int>[4],
@@ -226,7 +226,7 @@ void main() {
       blocTest<MultiCounterBloc, int>(
         'emits [11, 12] when CounterEvent.increment is added and emitted 10',
         build: () => MultiCounterBloc()..emit(10),
-        act: (bloc) async => bloc.add(CounterEvent.increment),
+        act: (bloc) => bloc.add(CounterEvent.increment),
         expect: const <int>[11, 12],
       );
     });
@@ -241,7 +241,7 @@ void main() {
       blocTest<ComplexBloc, ComplexState>(
         'emits [ComplexStateB] when ComplexEventB is added',
         build: () => ComplexBloc(),
-        act: (bloc) async => bloc.add(ComplexEventB()),
+        act: (bloc) => bloc.add(ComplexEventB()),
         expect: <Matcher>[isA<ComplexStateB>()],
       );
 
@@ -249,7 +249,7 @@ void main() {
         'emits [ComplexStateA] when [ComplexEventB, ComplexEventA] '
         'is added and skip: 1',
         build: () => ComplexBloc(),
-        act: (bloc) async => bloc..add(ComplexEventB())..add(ComplexEventA()),
+        act: (bloc) => bloc..add(ComplexEventB())..add(ComplexEventA()),
         skip: 1,
         expect: <Matcher>[isA<ComplexStateA>()],
       );
@@ -265,7 +265,7 @@ void main() {
       blocTest<ExceptionCounterBloc, int>(
         'emits [2] when increment is added twice and skip: 1',
         build: () => ExceptionCounterBloc(),
-        act: (bloc) async =>
+        act: (bloc) =>
             bloc..add(CounterEvent.increment)..add(CounterEvent.increment),
         skip: 1,
         expect: const <int>[2],
@@ -274,14 +274,14 @@ void main() {
       blocTest<ExceptionCounterBloc, int>(
         'emits [1] when increment is added',
         build: () => ExceptionCounterBloc(),
-        act: (bloc) async => bloc.add(CounterEvent.increment),
+        act: (bloc) => bloc.add(CounterEvent.increment),
         expect: const <int>[1],
       );
 
       blocTest<ExceptionCounterBloc, int>(
         'throws ExceptionCounterBlocException when increment is added',
         build: () => ExceptionCounterBloc(),
-        act: (bloc) async => bloc.add(CounterEvent.increment),
+        act: (bloc) => bloc.add(CounterEvent.increment),
         errors: <Matcher>[isA<ExceptionCounterBlocException>()],
       );
 
@@ -289,7 +289,7 @@ void main() {
         'emits [1] and throws ExceptionCounterBlocException '
         'when increment is added',
         build: () => ExceptionCounterBloc(),
-        act: (bloc) async => bloc.add(CounterEvent.increment),
+        act: (bloc) => bloc.add(CounterEvent.increment),
         expect: const <int>[1],
         errors: <Matcher>[isA<ExceptionCounterBlocException>()],
       );
@@ -297,7 +297,7 @@ void main() {
       blocTest<ExceptionCounterBloc, int>(
         'emits [1, 2] when increment is added twice',
         build: () => ExceptionCounterBloc(),
-        act: (bloc) async =>
+        act: (bloc) =>
             bloc..add(CounterEvent.increment)..add(CounterEvent.increment),
         expect: const <int>[1, 2],
       );
@@ -306,7 +306,7 @@ void main() {
         'throws two ExceptionCounterBlocExceptions '
         'when increment is added twice',
         build: () => ExceptionCounterBloc(),
-        act: (bloc) async =>
+        act: (bloc) =>
             bloc..add(CounterEvent.increment)..add(CounterEvent.increment),
         errors: <Matcher>[
           isA<ExceptionCounterBlocException>(),
@@ -318,7 +318,7 @@ void main() {
         'emits [1, 2] and throws two ExceptionCounterBlocException '
         'when increment is added twice',
         build: () => ExceptionCounterBloc(),
-        act: (bloc) async =>
+        act: (bloc) =>
             bloc..add(CounterEvent.increment)..add(CounterEvent.increment),
         expect: const <int>[1, 2],
         errors: <Matcher>[
@@ -344,9 +344,9 @@ void main() {
       blocTest<SideEffectCounterBloc, int>(
         'emits [1] when CounterEvent.increment is added',
         build: () => SideEffectCounterBloc(repository),
-        act: (bloc) async => bloc.add(CounterEvent.increment),
+        act: (bloc) => bloc.add(CounterEvent.increment),
         expect: const <int>[1],
-        verify: (_) async {
+        verify: (_) {
           verify(repository.sideEffect()).called(1);
         },
       );
@@ -355,7 +355,7 @@ void main() {
         'emits [2] when CounterEvent.increment '
         'is added twice and skip: 1',
         build: () => SideEffectCounterBloc(repository),
-        act: (bloc) async =>
+        act: (bloc) =>
             bloc..add(CounterEvent.increment)..add(CounterEvent.increment),
         skip: 1,
         expect: const <int>[2],
@@ -364,8 +364,18 @@ void main() {
       blocTest<SideEffectCounterBloc, int>(
         'does not require an expect',
         build: () => SideEffectCounterBloc(repository),
-        act: (bloc) async => bloc.add(CounterEvent.increment),
+        act: (bloc) => bloc.add(CounterEvent.increment),
+        verify: (_) {
+          verify(repository.sideEffect()).called(1);
+        },
+      );
+
+      blocTest<SideEffectCounterBloc, int>(
+        'async verify',
+        build: () => SideEffectCounterBloc(repository),
+        act: (bloc) => bloc.add(CounterEvent.increment),
         verify: (_) async {
+          await Future<void>.delayed(Duration.zero);
           verify(repository.sideEffect()).called(1);
         },
       );

--- a/packages/bloc_test/test/blocs/async_counter_bloc.dart
+++ b/packages/bloc_test/test/blocs/async_counter_bloc.dart
@@ -2,17 +2,15 @@ import 'dart:async';
 
 import 'package:bloc/bloc.dart';
 
-enum AsyncCounterEvent { increment }
+import 'blocs.dart';
 
-class AsyncCounterBloc extends Bloc<AsyncCounterEvent, int> {
+class AsyncCounterBloc extends Bloc<CounterEvent, int> {
   AsyncCounterBloc() : super(0);
 
   @override
-  Stream<int> mapEventToState(
-    AsyncCounterEvent event,
-  ) async* {
+  Stream<int> mapEventToState(CounterEvent event) async* {
     switch (event) {
-      case AsyncCounterEvent.increment:
+      case CounterEvent.increment:
         await Future<void>.delayed(const Duration(microseconds: 1));
         yield state + 1;
         break;

--- a/packages/bloc_test/test/blocs/blocs.dart
+++ b/packages/bloc_test/test/blocs/blocs.dart
@@ -3,6 +3,7 @@ export 'complex_bloc.dart';
 export 'counter_bloc.dart';
 export 'debounce_counter_bloc.dart';
 export 'exception_counter_bloc.dart';
+export 'instant_emit_bloc.dart';
 export 'multi_counter_bloc.dart';
 export 'side_effect_counter_bloc.dart';
 export 'sum_bloc.dart';

--- a/packages/bloc_test/test/blocs/complex_bloc.dart
+++ b/packages/bloc_test/test/blocs/complex_bloc.dart
@@ -18,9 +18,7 @@ class ComplexBloc extends Bloc<ComplexEvent, ComplexState> {
   ComplexBloc() : super(ComplexStateA());
 
   @override
-  Stream<ComplexState> mapEventToState(
-    ComplexEvent event,
-  ) async* {
+  Stream<ComplexState> mapEventToState(ComplexEvent event) async* {
     if (event is ComplexEventA) {
       yield ComplexStateA();
     } else if (event is ComplexEventB) {

--- a/packages/bloc_test/test/blocs/counter_bloc.dart
+++ b/packages/bloc_test/test/blocs/counter_bloc.dart
@@ -8,9 +8,7 @@ class CounterBloc extends Bloc<CounterEvent, int> {
   CounterBloc() : super(0);
 
   @override
-  Stream<int> mapEventToState(
-    CounterEvent event,
-  ) async* {
+  Stream<int> mapEventToState(CounterEvent event) async* {
     switch (event) {
       case CounterEvent.increment:
         yield state + 1;

--- a/packages/bloc_test/test/blocs/debounce_counter_bloc.dart
+++ b/packages/bloc_test/test/blocs/debounce_counter_bloc.dart
@@ -3,15 +3,15 @@ import 'dart:async';
 import 'package:bloc/bloc.dart';
 import 'package:rxdart/rxdart.dart';
 
-enum DebounceCounterEvent { increment }
+import 'blocs.dart';
 
-class DebounceCounterBloc extends Bloc<DebounceCounterEvent, int> {
+class DebounceCounterBloc extends Bloc<CounterEvent, int> {
   DebounceCounterBloc() : super(0);
 
   @override
-  Stream<Transition<DebounceCounterEvent, int>> transformEvents(
-    Stream<DebounceCounterEvent> events,
-    TransitionFunction<DebounceCounterEvent, int> transitionFn,
+  Stream<Transition<CounterEvent, int>> transformEvents(
+    Stream<CounterEvent> events,
+    TransitionFunction<CounterEvent, int> transitionFn,
   ) {
     return events
         .debounceTime(const Duration(milliseconds: 300))
@@ -19,11 +19,9 @@ class DebounceCounterBloc extends Bloc<DebounceCounterEvent, int> {
   }
 
   @override
-  Stream<int> mapEventToState(
-    DebounceCounterEvent event,
-  ) async* {
+  Stream<int> mapEventToState(CounterEvent event) async* {
     switch (event) {
-      case DebounceCounterEvent.increment:
+      case CounterEvent.increment:
         yield state + 1;
         break;
     }

--- a/packages/bloc_test/test/blocs/exception_counter_bloc.dart
+++ b/packages/bloc_test/test/blocs/exception_counter_bloc.dart
@@ -2,19 +2,17 @@ import 'dart:async';
 
 import 'package:bloc/bloc.dart';
 
+import 'blocs.dart';
+
 class ExceptionCounterBlocException implements Exception {}
 
-enum ExceptionCounterEvent { increment }
-
-class ExceptionCounterBloc extends Bloc<ExceptionCounterEvent, int> {
+class ExceptionCounterBloc extends Bloc<CounterEvent, int> {
   ExceptionCounterBloc() : super(0);
 
   @override
-  Stream<int> mapEventToState(
-    ExceptionCounterEvent event,
-  ) async* {
+  Stream<int> mapEventToState(CounterEvent event) async* {
     switch (event) {
-      case ExceptionCounterEvent.increment:
+      case CounterEvent.increment:
         yield state + 1;
         throw ExceptionCounterBlocException();
         break;

--- a/packages/bloc_test/test/blocs/instant_emit_bloc.dart
+++ b/packages/bloc_test/test/blocs/instant_emit_bloc.dart
@@ -1,17 +1,16 @@
-import 'dart:async';
-
 import 'package:bloc/bloc.dart';
 
 import 'blocs.dart';
 
-class MultiCounterBloc extends Bloc<CounterEvent, int> {
-  MultiCounterBloc() : super(0);
+class InstantEmitBloc extends Bloc<CounterEvent, int> {
+  InstantEmitBloc() : super(0) {
+    add(CounterEvent.increment);
+  }
 
   @override
   Stream<int> mapEventToState(CounterEvent event) async* {
     switch (event) {
       case CounterEvent.increment:
-        yield state + 1;
         yield state + 1;
         break;
     }

--- a/packages/bloc_test/test/blocs/side_effect_counter_bloc.dart
+++ b/packages/bloc_test/test/blocs/side_effect_counter_bloc.dart
@@ -2,23 +2,21 @@ import 'dart:async';
 
 import 'package:bloc/bloc.dart';
 
-enum SideEffectCounterEvent { increment }
+import 'blocs.dart';
 
 class Repository {
   void sideEffect() {}
 }
 
-class SideEffectCounterBloc extends Bloc<SideEffectCounterEvent, int> {
+class SideEffectCounterBloc extends Bloc<CounterEvent, int> {
   SideEffectCounterBloc(this.repository) : super(0);
 
   final Repository repository;
 
   @override
-  Stream<int> mapEventToState(
-    SideEffectCounterEvent event,
-  ) async* {
+  Stream<int> mapEventToState(CounterEvent event) async* {
     switch (event) {
-      case SideEffectCounterEvent.increment:
+      case CounterEvent.increment:
         repository.sideEffect();
         yield state + 1;
         break;

--- a/packages/bloc_test/test/cubit_bloc_test_test.dart
+++ b/packages/bloc_test/test/cubit_bloc_test_test.dart
@@ -11,20 +11,20 @@ void main() {
     group('CounterCubit', () {
       blocTest<CounterCubit, int>(
         'emits [] when nothing is called',
-        build: () async => CounterCubit(),
+        build: () => CounterCubit(),
         expect: <int>[],
       );
 
       blocTest<CounterCubit, int>(
         'emits [1] when increment is called',
-        build: () async => CounterCubit(),
+        build: () => CounterCubit(),
         act: (cubit) async => cubit.increment(),
         expect: <int>[1],
       );
 
       blocTest<CounterCubit, int>(
         'emits [1] when increment is called with async act',
-        build: () async => CounterCubit(),
+        build: () => CounterCubit(),
         act: (cubit) async => cubit.increment(),
         expect: <int>[1],
       );
@@ -32,7 +32,7 @@ void main() {
       blocTest<CounterCubit, int>(
         'emits [1, 2] when increment is called multiple times'
         'with async act',
-        build: () async => CounterCubit(),
+        build: () => CounterCubit(),
         act: (cubit) async => cubit..increment()..increment(),
         expect: <int>[1, 2],
       );
@@ -41,13 +41,13 @@ void main() {
     group('AsyncCounterCubit', () {
       blocTest<AsyncCounterCubit, int>(
         'emits [] when nothing is called',
-        build: () async => AsyncCounterCubit(),
+        build: () => AsyncCounterCubit(),
         expect: <int>[],
       );
 
       blocTest<AsyncCounterCubit, int>(
         'emits [1] when increment is called',
-        build: () async => AsyncCounterCubit(),
+        build: () => AsyncCounterCubit(),
         act: (cubit) async => cubit.increment(),
         expect: <int>[1],
       );
@@ -55,7 +55,7 @@ void main() {
       blocTest<AsyncCounterCubit, int>(
         'emits [1, 2] when increment is called multiple'
         'times with async act',
-        build: () async => AsyncCounterCubit(),
+        build: () => AsyncCounterCubit(),
         act: (cubit) async {
           await cubit.increment();
           await cubit.increment();
@@ -67,36 +67,59 @@ void main() {
     group('DelayedCounterCubit', () {
       blocTest<DelayedCounterCubit, int>(
         'emits [] when nothing is called',
-        build: () async => DelayedCounterCubit(),
+        build: () => DelayedCounterCubit(),
         expect: <int>[],
       );
 
       blocTest<DelayedCounterCubit, int>(
         'emits [] when increment is called without wait',
-        build: () async => DelayedCounterCubit(),
+        build: () => DelayedCounterCubit(),
         act: (cubit) async => cubit.increment(),
         expect: <int>[],
       );
 
       blocTest<DelayedCounterCubit, int>(
         'emits [1] when increment is called with wait',
-        build: () async => DelayedCounterCubit(),
+        build: () => DelayedCounterCubit(),
         act: (cubit) async => cubit.increment(),
         wait: const Duration(milliseconds: 300),
         expect: <int>[1],
       );
     });
 
+    group('InstantEmitCubit', () {
+      blocTest<InstantEmitCubit, int>(
+        'emits [] when nothing is called',
+        build: () => InstantEmitCubit(),
+        expect: <int>[],
+      );
+
+      blocTest<InstantEmitCubit, int>(
+        'emits [2] when increment is called',
+        build: () => InstantEmitCubit(),
+        act: (cubit) async => cubit.increment(),
+        expect: <int>[2],
+      );
+
+      blocTest<InstantEmitCubit, int>(
+        'emits [2, 3] when increment is called'
+        'multiple times with async act',
+        build: () => InstantEmitCubit(),
+        act: (cubit) async => cubit..increment()..increment(),
+        expect: <int>[2, 3],
+      );
+    });
+
     group('MultiCounterCubit', () {
       blocTest<MultiCounterCubit, int>(
         'emits [] when nothing is called',
-        build: () async => MultiCounterCubit(),
+        build: () => MultiCounterCubit(),
         expect: <int>[],
       );
 
       blocTest<MultiCounterCubit, int>(
         'emits [1, 2] when increment is called',
-        build: () async => MultiCounterCubit(),
+        build: () => MultiCounterCubit(),
         act: (cubit) async => cubit.increment(),
         expect: <int>[1, 2],
       );
@@ -104,7 +127,7 @@ void main() {
       blocTest<MultiCounterCubit, int>(
         'emits [1, 2, 3, 4] when increment is called'
         'multiple times with async act',
-        build: () async => MultiCounterCubit(),
+        build: () => MultiCounterCubit(),
         act: (cubit) async => cubit..increment()..increment(),
         expect: <int>[1, 2, 3, 4],
       );
@@ -113,13 +136,13 @@ void main() {
     group('ComplexCubit', () {
       blocTest<ComplexCubit, ComplexState>(
         'emits [] when nothing is called',
-        build: () async => ComplexCubit(),
+        build: () => ComplexCubit(),
         expect: <Matcher>[],
       );
 
       blocTest<ComplexCubit, ComplexState>(
         'emits [ComplexStateB] when emitB is called',
-        build: () async => ComplexCubit(),
+        build: () => ComplexCubit(),
         act: (cubit) async => cubit.emitB(),
         expect: <Matcher>[isA<ComplexStateB>()],
       );
@@ -134,13 +157,13 @@ void main() {
 
       blocTest<SideEffectCounterCubit, int>(
         'emits [] when nothing is called',
-        build: () async => SideEffectCounterCubit(repository),
+        build: () => SideEffectCounterCubit(repository),
         expect: <int>[],
       );
 
       blocTest<SideEffectCounterCubit, int>(
         'emits [1] when SideEffectCounterEvent.increment is called',
-        build: () async => SideEffectCounterCubit(repository),
+        build: () => SideEffectCounterCubit(repository),
         act: (cubit) async => cubit.increment(),
         expect: <int>[1],
         verify: (_) async {
@@ -150,7 +173,7 @@ void main() {
 
       blocTest<SideEffectCounterCubit, int>(
         'does not require an expect',
-        build: () async => SideEffectCounterCubit(repository),
+        build: () => SideEffectCounterCubit(repository),
         act: (cubit) async => cubit.increment(),
         verify: (_) async {
           verify(repository.sideEffect()).called(1);

--- a/packages/bloc_test/test/cubit_bloc_test_test.dart
+++ b/packages/bloc_test/test/cubit_bloc_test_test.dart
@@ -18,14 +18,14 @@ void main() {
       blocTest<CounterCubit, int>(
         'emits [1] when increment is called',
         build: () => CounterCubit(),
-        act: (cubit) async => cubit.increment(),
+        act: (cubit) => cubit.increment(),
         expect: <int>[1],
       );
 
       blocTest<CounterCubit, int>(
         'emits [1] when increment is called with async act',
         build: () => CounterCubit(),
-        act: (cubit) async => cubit.increment(),
+        act: (cubit) => cubit.increment(),
         expect: <int>[1],
       );
 
@@ -33,7 +33,7 @@ void main() {
         'emits [1, 2] when increment is called multiple times'
         'with async act',
         build: () => CounterCubit(),
-        act: (cubit) async => cubit..increment()..increment(),
+        act: (cubit) => cubit..increment()..increment(),
         expect: <int>[1, 2],
       );
     });
@@ -48,7 +48,7 @@ void main() {
       blocTest<AsyncCounterCubit, int>(
         'emits [1] when increment is called',
         build: () => AsyncCounterCubit(),
-        act: (cubit) async => cubit.increment(),
+        act: (cubit) => cubit.increment(),
         expect: <int>[1],
       );
 
@@ -74,14 +74,14 @@ void main() {
       blocTest<DelayedCounterCubit, int>(
         'emits [] when increment is called without wait',
         build: () => DelayedCounterCubit(),
-        act: (cubit) async => cubit.increment(),
+        act: (cubit) => cubit.increment(),
         expect: <int>[],
       );
 
       blocTest<DelayedCounterCubit, int>(
         'emits [1] when increment is called with wait',
         build: () => DelayedCounterCubit(),
-        act: (cubit) async => cubit.increment(),
+        act: (cubit) => cubit.increment(),
         wait: const Duration(milliseconds: 300),
         expect: <int>[1],
       );
@@ -97,7 +97,7 @@ void main() {
       blocTest<InstantEmitCubit, int>(
         'emits [2] when increment is called',
         build: () => InstantEmitCubit(),
-        act: (cubit) async => cubit.increment(),
+        act: (cubit) => cubit.increment(),
         expect: <int>[2],
       );
 
@@ -105,7 +105,7 @@ void main() {
         'emits [2, 3] when increment is called'
         'multiple times with async act',
         build: () => InstantEmitCubit(),
-        act: (cubit) async => cubit..increment()..increment(),
+        act: (cubit) => cubit..increment()..increment(),
         expect: <int>[2, 3],
       );
     });
@@ -120,7 +120,7 @@ void main() {
       blocTest<MultiCounterCubit, int>(
         'emits [1, 2] when increment is called',
         build: () => MultiCounterCubit(),
-        act: (cubit) async => cubit.increment(),
+        act: (cubit) => cubit.increment(),
         expect: <int>[1, 2],
       );
 
@@ -128,7 +128,7 @@ void main() {
         'emits [1, 2, 3, 4] when increment is called'
         'multiple times with async act',
         build: () => MultiCounterCubit(),
-        act: (cubit) async => cubit..increment()..increment(),
+        act: (cubit) => cubit..increment()..increment(),
         expect: <int>[1, 2, 3, 4],
       );
     });
@@ -143,7 +143,7 @@ void main() {
       blocTest<ComplexCubit, ComplexState>(
         'emits [ComplexStateB] when emitB is called',
         build: () => ComplexCubit(),
-        act: (cubit) async => cubit.emitB(),
+        act: (cubit) => cubit.emitB(),
         expect: <Matcher>[isA<ComplexStateB>()],
       );
     });
@@ -164,7 +164,7 @@ void main() {
       blocTest<SideEffectCounterCubit, int>(
         'emits [1] when SideEffectCounterEvent.increment is called',
         build: () => SideEffectCounterCubit(repository),
-        act: (cubit) async => cubit.increment(),
+        act: (cubit) => cubit.increment(),
         expect: <int>[1],
         verify: (_) async {
           verify(repository.sideEffect()).called(1);
@@ -174,7 +174,7 @@ void main() {
       blocTest<SideEffectCounterCubit, int>(
         'does not require an expect',
         build: () => SideEffectCounterCubit(repository),
-        act: (cubit) async => cubit.increment(),
+        act: (cubit) => cubit.increment(),
         verify: (_) async {
           verify(repository.sideEffect()).called(1);
         },

--- a/packages/bloc_test/test/cubits/cubits.dart
+++ b/packages/bloc_test/test/cubits/cubits.dart
@@ -2,6 +2,7 @@ export 'async_counter_cubit.dart';
 export 'complex_cubit.dart';
 export 'counter_cubit.dart';
 export 'delayed_counter_cubit.dart';
+export 'instant_emit_cubit.dart';
 export 'multi_counter_cubit.dart';
 export 'side_effect_counter_cubit.dart';
 export 'sum_cubit.dart';

--- a/packages/bloc_test/test/cubits/instant_emit_cubit.dart
+++ b/packages/bloc_test/test/cubits/instant_emit_cubit.dart
@@ -1,0 +1,9 @@
+import 'package:bloc/bloc.dart';
+
+class InstantEmitCubit extends Cubit<int> {
+  InstantEmitCubit() : super(0) {
+    emit(1);
+  }
+
+  void increment() => emit(state + 1);
+}

--- a/packages/bloc_test/test/emits_exactly_test.dart
+++ b/packages/bloc_test/test/emits_exactly_test.dart
@@ -76,15 +76,15 @@ void main() {
 
     group('AsyncCounterBloc', () {
       test('emits [1] when CounterEvent.increment is added', () async {
-        final bloc = AsyncCounterBloc()..add(AsyncCounterEvent.increment);
+        final bloc = AsyncCounterBloc()..add(CounterEvent.increment);
         await emitsExactly<AsyncCounterBloc, int>(bloc, const <int>[1]);
       });
 
       test('emits [2] when CounterEvent.increment is added twice and skip: 1',
           () async {
         final bloc = AsyncCounterBloc()
-          ..add(AsyncCounterEvent.increment)
-          ..add(AsyncCounterEvent.increment);
+          ..add(CounterEvent.increment)
+          ..add(CounterEvent.increment);
         await emitsExactly<AsyncCounterBloc, int>(
           bloc,
           const <int>[2],
@@ -111,7 +111,7 @@ void main() {
 
       test('fails if bloc does not emit correct states', () async {
         try {
-          final bloc = AsyncCounterBloc()..add(AsyncCounterEvent.increment);
+          final bloc = AsyncCounterBloc()..add(CounterEvent.increment);
           await emitsExactly<AsyncCounterBloc, int>(bloc, const <int>[2]);
           fail('should throw');
         } on TestFailure catch (error) {
@@ -127,7 +127,7 @@ void main() {
 
       test('fails if expecting extra states', () async {
         try {
-          final bloc = AsyncCounterBloc()..add(AsyncCounterEvent.increment);
+          final bloc = AsyncCounterBloc()..add(CounterEvent.increment);
           await emitsExactly<AsyncCounterBloc, int>(bloc, const <int>[1, 2]);
           fail('should throw');
         } on TestFailure catch (error) {
@@ -144,16 +144,16 @@ void main() {
 
     group('DebounceCounterBloc', () {
       test('emits [1] when CounterEvent.increment is added', () async {
-        final bloc = DebounceCounterBloc()..add(DebounceCounterEvent.increment);
+        final bloc = DebounceCounterBloc()..add(CounterEvent.increment);
         await emitsExactly<DebounceCounterBloc, int>(bloc, const <int>[1],
             duration: const Duration(milliseconds: 305));
       });
 
       test('emits [2] when CounterEvent.increment is added twice and skip: 0',
           () async {
-        final bloc = DebounceCounterBloc()..add(DebounceCounterEvent.increment);
+        final bloc = DebounceCounterBloc()..add(CounterEvent.increment);
         await Future<void>.delayed(const Duration(milliseconds: 305));
-        bloc.add(DebounceCounterEvent.increment);
+        bloc.add(CounterEvent.increment);
         await emitsExactly<DebounceCounterBloc, int>(
           bloc,
           const <int>[2],
@@ -181,8 +181,7 @@ void main() {
 
       test('fails if bloc does not emit correct states', () async {
         try {
-          final bloc = DebounceCounterBloc()
-            ..add(DebounceCounterEvent.increment);
+          final bloc = DebounceCounterBloc()..add(CounterEvent.increment);
           await emitsExactly<DebounceCounterBloc, int>(
             bloc,
             const <int>[2],
@@ -202,8 +201,7 @@ void main() {
 
       test('fails if expecting extra states', () async {
         try {
-          final bloc = DebounceCounterBloc()
-            ..add(DebounceCounterEvent.increment);
+          final bloc = DebounceCounterBloc()..add(CounterEvent.increment);
           await emitsExactly<DebounceCounterBloc, int>(
             bloc,
             const <int>[1, 2],
@@ -222,16 +220,21 @@ void main() {
       });
     });
 
-    group('MultiCounterBloc', () {
+    group('InstantEmitBloc', () {
+      test('emits [1] when nothing is added', () async {
+        final bloc = InstantEmitBloc();
+        await emitsExactly<InstantEmitBloc, int>(bloc, const <int>[1]);
+      });
+
       test('emits [1, 2] when CounterEvent.increment is added', () async {
-        final bloc = MultiCounterBloc()..add(MultiCounterEvent.increment);
-        await emitsExactly<MultiCounterBloc, int>(bloc, const <int>[1, 2]);
+        final bloc = InstantEmitBloc()..add(CounterEvent.increment);
+        await emitsExactly<InstantEmitBloc, int>(bloc, const <int>[1, 2]);
       });
 
       test('emits [2] when CounterEvent.increment is added and skip: 1',
           () async {
-        final bloc = MultiCounterBloc()..add(MultiCounterEvent.increment);
-        await emitsExactly<MultiCounterBloc, int>(
+        final bloc = InstantEmitBloc()..add(CounterEvent.increment);
+        await emitsExactly<InstantEmitBloc, int>(
           bloc,
           const <int>[2],
           skip: 1,
@@ -240,131 +243,169 @@ void main() {
 
       test('fails if bloc does not emit all states', () async {
         try {
-          await emitsExactly<MultiCounterBloc, int>(
-            MultiCounterBloc(),
-            const <int>[1],
+          await emitsExactly<InstantEmitBloc, int>(
+            InstantEmitBloc(),
+            const <int>[2],
           );
           fail('should throw');
         } on TestFailure catch (error) {
           expect(
               error.message,
-              'Expected: [1]\n'
-              '  Actual: []\n'
-              '   Which: at location [0] is [] which shorter than expected\n'
+              'Expected: [2]\n'
+              '  Actual: [1]\n'
+              '   Which: at location [0] is <1> instead of <2>\n'
               '');
         }
       });
 
-      test('fails if bloc does not emit correct states', () async {
-        try {
-          final bloc = MultiCounterBloc()..add(MultiCounterEvent.increment);
-          await emitsExactly<MultiCounterBloc, int>(bloc, const <int>[2]);
-          fail('should throw');
-        } on TestFailure catch (error) {
-          expect(
-            error.message,
-            'Expected: [2]\n'
-            '  Actual: [1, 2]\n'
-            '   Which: at location [0] is <1> instead of <2>\n'
-            '',
-          );
-        }
-      });
+      group('MultiCounterBloc', () {
+        test('emits [1, 2] when CounterEvent.increment is added', () async {
+          final bloc = MultiCounterBloc()..add(CounterEvent.increment);
+          await emitsExactly<MultiCounterBloc, int>(bloc, const <int>[1, 2]);
+        });
 
-      test('fails if expecting extra states', () async {
-        try {
-          final bloc = MultiCounterBloc()..add(MultiCounterEvent.increment);
-          await emitsExactly<MultiCounterBloc, int>(bloc, const <int>[1, 2, 3]);
-          fail('should throw');
-        } on TestFailure catch (error) {
-          expect(
-            error.message,
-            'Expected: [1, 2, 3]\n'
-            '  Actual: [1, 2]\n'
-            '   Which: at location [2] is [1, 2] which shorter than expected\n'
-            '',
-          );
-        }
-      });
-    });
-
-    group('ComplexBloc', () {
-      test('emits [ComplexStateB] when ComplexEventB is added', () async {
-        final bloc = ComplexBloc()..add(ComplexEventB());
-        await emitsExactly<ComplexBloc, ComplexState>(
-          bloc,
-          <Matcher>[isA<ComplexStateB>()],
-        );
-      });
-
-      test(
-          'emits [ComplexStateA] when [ComplexEventB, ComplexEventA] '
-          'is added and skip: 1', () async {
-        final bloc = ComplexBloc()..add(ComplexEventB())..add(ComplexEventA());
-        await emitsExactly<ComplexBloc, ComplexState>(
-          bloc,
-          <Matcher>[isA<ComplexStateA>()],
-          skip: 1,
-        );
-      });
-
-      test('fails if bloc does not emit all states', () async {
-        try {
-          await emitsExactly<ComplexBloc, ComplexState>(
-            ComplexBloc(),
-            <Matcher>[isA<ComplexStateB>()],
-          );
-          fail('should throw');
-        } on TestFailure catch (error) {
-          expect(
-            error.message,
-            'Expected: [<<Instance of \'ComplexStateB\'>>]\n'
-            '  Actual: []\n'
-            '   Which: at location [0] is [] which shorter than expected\n'
-            '',
-          );
-        }
-      });
-
-      test('fails if bloc does not emit correct states', () async {
-        try {
-          final bloc = ComplexBloc()..add(ComplexEventA());
-          await emitsExactly<ComplexBloc, ComplexState>(
+        test('emits [2] when CounterEvent.increment is added and skip: 1',
+            () async {
+          final bloc = MultiCounterBloc()..add(CounterEvent.increment);
+          await emitsExactly<MultiCounterBloc, int>(
             bloc,
-            <Matcher>[isA<ComplexStateB>()],
+            const <int>[2],
+            skip: 1,
           );
-          fail('should throw');
-        } on TestFailure catch (error) {
-          expect(
-            error.message,
-            'Expected: [<<Instance of \'ComplexStateB\'>>]\n'
-            '  Actual: [Instance of \'ComplexStateA\']\n'
-            // ignore: lines_longer_than_80_chars
-            '   Which: at location [0] is <Instance of \'ComplexStateA\'> which is not an instance of \'ComplexStateB\'\n'
-            '',
-          );
-        }
+        });
+
+        test('fails if bloc does not emit all states', () async {
+          try {
+            await emitsExactly<MultiCounterBloc, int>(
+              MultiCounterBloc(),
+              const <int>[1],
+            );
+            fail('should throw');
+          } on TestFailure catch (error) {
+            expect(
+                error.message,
+                'Expected: [1]\n'
+                '  Actual: []\n'
+                '   Which: at location [0] is [] which shorter than expected\n'
+                '');
+          }
+        });
+
+        test('fails if bloc does not emit correct states', () async {
+          try {
+            final bloc = MultiCounterBloc()..add(CounterEvent.increment);
+            await emitsExactly<MultiCounterBloc, int>(bloc, const <int>[2]);
+            fail('should throw');
+          } on TestFailure catch (error) {
+            expect(
+              error.message,
+              'Expected: [2]\n'
+              '  Actual: [1, 2]\n'
+              '   Which: at location [0] is <1> instead of <2>\n'
+              '',
+            );
+          }
+        });
+
+        test('fails if expecting extra states', () async {
+          try {
+            final bloc = MultiCounterBloc()..add(CounterEvent.increment);
+            await emitsExactly<MultiCounterBloc, int>(
+                bloc, const <int>[1, 2, 3]);
+            fail('should throw');
+          } on TestFailure catch (error) {
+            expect(
+              error.message,
+              'Expected: [1, 2, 3]\n'
+              '  Actual: [1, 2]\n'
+              // ignore: lines_longer_than_80_chars
+              '   Which: at location [2] is [1, 2] which shorter than expected\n'
+              '',
+            );
+          }
+        });
       });
 
-      test('fails if expecting extra states', () async {
-        try {
+      group('ComplexBloc', () {
+        test('emits [ComplexStateB] when ComplexEventB is added', () async {
           final bloc = ComplexBloc()..add(ComplexEventB());
           await emitsExactly<ComplexBloc, ComplexState>(
             bloc,
-            <Matcher>[isA<ComplexStateB>(), isA<ComplexStateA>()],
+            <Matcher>[isA<ComplexStateB>()],
           );
-          fail('should throw');
-        } on TestFailure catch (error) {
-          expect(
-            error.message,
-            // ignore: lines_longer_than_80_chars
-            'Expected: [<<Instance of \'ComplexStateB\'>>, <<Instance of \'ComplexStateA\'>>]\n'
-            '  Actual: [Instance of \'ComplexStateB\']\n'
-            // ignore: lines_longer_than_80_chars
-            '   Which: at location [1] is [Instance of \'ComplexStateB\'] which shorter than expected\n'
-            '',
+        });
+
+        test(
+            'emits [ComplexStateA] when [ComplexEventB, ComplexEventA] '
+            'is added and skip: 1', () async {
+          final bloc = ComplexBloc()
+            ..add(ComplexEventB())
+            ..add(ComplexEventA());
+          await emitsExactly<ComplexBloc, ComplexState>(
+            bloc,
+            <Matcher>[isA<ComplexStateA>()],
+            skip: 1,
           );
-        }
+        });
+
+        test('fails if bloc does not emit all states', () async {
+          try {
+            await emitsExactly<ComplexBloc, ComplexState>(
+              ComplexBloc(),
+              <Matcher>[isA<ComplexStateB>()],
+            );
+            fail('should throw');
+          } on TestFailure catch (error) {
+            expect(
+              error.message,
+              'Expected: [<<Instance of \'ComplexStateB\'>>]\n'
+              '  Actual: []\n'
+              '   Which: at location [0] is [] which shorter than expected\n'
+              '',
+            );
+          }
+        });
+
+        test('fails if bloc does not emit correct states', () async {
+          try {
+            final bloc = ComplexBloc()..add(ComplexEventA());
+            await emitsExactly<ComplexBloc, ComplexState>(
+              bloc,
+              <Matcher>[isA<ComplexStateB>()],
+            );
+            fail('should throw');
+          } on TestFailure catch (error) {
+            expect(
+              error.message,
+              'Expected: [<<Instance of \'ComplexStateB\'>>]\n'
+              '  Actual: [Instance of \'ComplexStateA\']\n'
+              // ignore: lines_longer_than_80_chars
+              '   Which: at location [0] is <Instance of \'ComplexStateA\'> which is not an instance of \'ComplexStateB\'\n'
+              '',
+            );
+          }
+        });
+
+        test('fails if expecting extra states', () async {
+          try {
+            final bloc = ComplexBloc()..add(ComplexEventB());
+            await emitsExactly<ComplexBloc, ComplexState>(
+              bloc,
+              <Matcher>[isA<ComplexStateB>(), isA<ComplexStateA>()],
+            );
+            fail('should throw');
+          } on TestFailure catch (error) {
+            expect(
+              error.message,
+              // ignore: lines_longer_than_80_chars
+              'Expected: [<<Instance of \'ComplexStateB\'>>, <<Instance of \'ComplexStateA\'>>]\n'
+              '  Actual: [Instance of \'ComplexStateB\']\n'
+              // ignore: lines_longer_than_80_chars
+              '   Which: at location [1] is [Instance of \'ComplexStateB\'] which shorter than expected\n'
+              '',
+            );
+          }
+        });
       });
     });
   });


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

YES

## Description

<!--- Describe your changes in detail -->

- **BREAKING**: `blocTest` make `build` synchronous
- fix: `blocTest` improve `wait` behavior when debouncing, etc...
- feat: `blocTest` do not require `async` on `act` and `verify`

### Context

The `build` parameter of `blocTest` was made asynchronous due to https://github.com/felangel/bloc/issues/910 in order to accommodate for cases where a bloc needed to be "prefilled" before executing act. This is no longer necessary because we can simply chain `emit` with the desired prefilled/seeded bloc state.

Previously if we had something like:

```dart
Future<void> prefillWithValidEmailAndPassword() async {
  signInFormBloc.add(const SignInFormEvent.emailChanged('abc@gmail.com'));
  signInFormBloc.add(const SignInFormEvent.passwordChanged('pazzwrd'));
  await signInFormBloc.take(3).last;
}

blocTest(
  "should register using IAuthFacade if email and password are valid",
  build: () async {
    arrangeAuthFacadeSuccess();
    await prefillWithValidEmailAndPassword();
    return signInFormBloc;
  },
  act: (bloc) async =>
      bloc.add(const SignInFormEvent.registerWithEmailAndPasswordPressed()),
  verify: (SignInFormBloc bloc) async {
    verify(mockAuthFacade.registerWithEmailAndPassword(
      emailAddress: argThat(
        equals(bloc.state.validatedEmailAddress),
        named: 'emailAddress',
      ),
      password: argThat(
        equals(bloc.state.validatedPassword),
        named: 'password',
      ),
    ));
  },
);
```

We can instead avoid needing to `prefillWithValidEmailAndPassword` and just prep the bloc state like:

```dart
blocTest(
  "should register using IAuthFacade if email and password are valid",
  build: () {
    arrangeAuthFacadeSuccess();
    return signInFormBloc..emit(ValidEmailAndPasswordState());
  },
  act: (bloc) async =>
      bloc.add(const SignInFormEvent.registerWithEmailAndPasswordPressed()),
  verify: (SignInFormBloc bloc) async {
    verify(mockAuthFacade.registerWithEmailAndPassword(
      emailAddress: argThat(
        equals(bloc.state.validatedEmailAddress),
        named: 'emailAddress',
      ),
      password: argThat(
        equals(bloc.state.validatedPassword),
        named: 'password',
      ),
    ));
  },
);
```

@ResoDev what are your thoughts on this? Would there be any use-cases for keeping an async build knowing that you can seed the bloc state as needed now?

Also related to https://github.com/felangel/bloc/issues/945

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [X] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
