### PR TITLE
docs(bloc): fix onError BlocObserver usage in README

### DIFF
--- a/packages/bloc/README.md
+++ b/packages/bloc/README.md
@@ -120,7 +120,7 @@ class MyBlocObserver extends BlocObserver {
   @override
   void onError(Cubit cubit, Object error, StackTrace stackTrace) {
     print('$error, $stackTrace');
-    super.onChange(cubit, error, stackTrace);
+    super.onError(cubit, error, stackTrace);
   }
 }
 ```
@@ -264,7 +264,7 @@ class MyBlocObserver extends BlocObserver {
   @override
   void onError(Cubit cubit, Object error, StackTrace stackTrace) {
     print('$error, $stackTrace');
-    super.onChange(cubit, error, stackTrace);
+    super.onError(cubit, error, stackTrace);
   }
 }
 ```


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->
Docs were using `onChange` instead of `onError` when overriding `onError` in the Bloc and BlocObserver

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
