### PR TITLE
WIP: test should fail when verify throws an exception

### DIFF
--- a/packages/bloc_test/lib/src/bloc_test.dart
+++ b/packages/bloc_test/lib/src/bloc_test.dart
@@ -140,7 +140,7 @@ void blocTest<C extends Cubit<State>, State>(
         await subscription.cancel();
         try {
           await verify?.call(cubit);
-        } catch(error) {
+        } catch (error) {
           verifyError += error.toString();
         }
       },

--- a/packages/bloc_test/lib/src/bloc_test.dart
+++ b/packages/bloc_test/lib/src/bloc_test.dart
@@ -119,6 +119,7 @@ void blocTest<C extends Cubit<State>, State>(
   Iterable errors,
 }) {
   test.test(description, () async {
+    var verifyError = "Verify Error: ";
     final unhandledErrors = <Object>[];
     await runZoned(
       () async {
@@ -137,7 +138,11 @@ void blocTest<C extends Cubit<State>, State>(
         await cubit.close();
         if (expect != null) test.expect(states, expect);
         await subscription.cancel();
-        await verify?.call(cubit);
+        try {
+          await verify?.call(cubit);
+        } catch(error) {
+          verifyError += error.toString();
+        }
       },
       onError: (Object error) {
         unhandledErrors.add(
@@ -146,5 +151,6 @@ void blocTest<C extends Cubit<State>, State>(
       },
     );
     if (errors != null) test.expect(unhandledErrors, errors);
+    if (verifyError != null) test.fail(verifyError);
   });
 }

--- a/packages/bloc_test/test/bloc_bloc_test_test.dart
+++ b/packages/bloc_test/test/bloc_bloc_test_test.dart
@@ -379,6 +379,15 @@ void main() {
           verify(repository.sideEffect()).called(1);
         },
       );
+      
+      blocTest<SideEffectCounterBloc, int>(
+        'verify should fail',
+        build: () => SideEffectCounterBloc(repository),
+        act: (bloc) => bloc.add(CounterEvent.increment),
+        verify: (_) {
+          verify(repository.sideEffect()).called(2);
+        },
+      );
     });
   });
 }

--- a/packages/bloc_test/test/bloc_bloc_test_test.dart
+++ b/packages/bloc_test/test/bloc_bloc_test_test.dart
@@ -379,7 +379,7 @@ void main() {
           verify(repository.sideEffect()).called(1);
         },
       );
-      
+
       blocTest<SideEffectCounterBloc, int>(
         'verify should fail',
         build: () => SideEffectCounterBloc(repository),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**IN DEVELOPMENT**

## Breaking Changes

NO

## Description

I've added the ability to bubble up `verify` errors so that is possible to debug when there are some unexpected failures.

Fixes https://github.com/felangel/bloc/issues/1639

## Help Needed

The tests are not passing, because I need to find a way to say that is ok that `blocTest` fails, I've tried wrapping it inside a `test` bloc, but it seems not to be possible, since `blocTest` is calling `test` internally. Therefore I've been given this error `StateError:<Bad state: Can't call test() once tests have begun running.>` which is not the one that I expect.

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
