### PR TITLE
docs: fix onError override in flutter weather tutorial

### DIFF
--- a/docs/_snippets/flutter_weather_tutorial/simple_bloc_observer.dart.md
+++ b/docs/_snippets/flutter_weather_tutorial/simple_bloc_observer.dart.md
@@ -15,9 +15,9 @@ class SimpleBlocObserver extends BlocObserver {
   }
 
   @override
-  void onError(Bloc bloc, Object error, StackTrace stackTrace) {
+  void onError(Cubit cubit, Object error, StackTrace stackTrace) {
     print('onError $error');
-    super.onError(bloc, error, stackTrace);
+    super.onError(cubit, error, stackTrace);
   }
 }
 ```


### PR DESCRIPTION
Change bloc to cubit in onError override, as per https://github.com/felangel/bloc/issues/1579#issuecomment-669449515



## Status

**READY**

## Breaking Changes

YES 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
