### PR TITLE
fix(flutter_bloc): BlocBuilder builder and buildWhen state synchronization fix

### DIFF
--- a/packages/flutter_bloc/lib/src/bloc_builder.dart
+++ b/packages/flutter_bloc/lib/src/bloc_builder.dart
@@ -133,8 +133,12 @@ class _BlocBuilderBaseState<C extends Cubit<S>, S>
   @override
   void didUpdateWidget(BlocBuilderBase<C, S> oldWidget) {
     super.didUpdateWidget(oldWidget);
-    _cubit = widget.cubit ?? context.bloc<C>();
-    _state = _cubit.state;
+    final oldCubit = oldWidget.cubit ?? context.bloc<C>();
+    final currentCubit = widget.cubit ?? oldCubit;
+    if (oldCubit != currentCubit) {
+      _cubit = currentCubit;
+      _state = _cubit.state;
+    }
   }
 
   @override

--- a/packages/flutter_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/bloc_listener.dart
@@ -152,7 +152,7 @@ class _BlocListenerBaseState<C extends Cubit<S>, S>
   void initState() {
     super.initState();
     _cubit = widget.cubit ?? context.bloc<C>();
-    _previousState = _cubit?.state;
+    _previousState = _cubit.state;
     _subscribe();
   }
 
@@ -164,8 +164,8 @@ class _BlocListenerBaseState<C extends Cubit<S>, S>
     if (oldCubit != currentCubit) {
       if (_subscription != null) {
         _unsubscribe();
-        _cubit = widget.cubit ?? context.bloc<C>();
-        _previousState = _cubit?.state;
+        _cubit = currentCubit;
+        _previousState = _cubit.state;
       }
       _subscribe();
     }

--- a/packages/flutter_bloc/test/bloc_builder_test.dart
+++ b/packages/flutter_bloc/test/bloc_builder_test.dart
@@ -275,7 +275,7 @@ void main() {
     });
 
     testWidgets(
-        'updates when the cubit is changed at runtime to a different cubit and'
+        'updates when the cubit is changed at runtime to a different cubit and '
         'unsubscribes from old cubit', (tester) async {
       final themeCubit = ThemeCubit();
       var numBuilds = 0;
@@ -454,6 +454,40 @@ void main() {
       expect(states, [0, 2]);
       expect(buildWhenPreviousState, [1]);
       expect(buildWhenCurrentState, [2]);
+    });
+
+    testWidgets(
+        'does not rebuild with latest state when '
+        'buildWhen is false and widget is updated', (tester) async {
+      const key = Key('__target__');
+      final states = <int>[];
+      final counterCubit = CounterCubit();
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: StatefulBuilder(
+            builder: (context, setState) => BlocBuilder<CounterCubit, int>(
+              cubit: counterCubit,
+              buildWhen: (previous, state) => state % 2 == 0,
+              builder: (_, state) {
+                states.add(state);
+                return RaisedButton(
+                  key: key,
+                  onPressed: () => setState(() {}),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      counterCubit..increment()..increment()..increment();
+      await tester.pumpAndSettle();
+      expect(states, [0, 2]);
+
+      await tester.tap(find.byKey(key));
+      await tester.pumpAndSettle();
+      expect(states, [0, 2, 2]);
     });
   });
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->

- fix(flutter_bloc): BlocBuilder builder and buildWhen state synchronization fix (closes #1696)
  - `builder` should not be triggered with state when `buildWhen` returns `false`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
