### PR TITLE
Improved PostState log info

### DIFF
--- a/examples/flutter_infinite_list/lib/posts/bloc/post_state.dart
+++ b/examples/flutter_infinite_list/lib/posts/bloc/post_state.dart
@@ -27,4 +27,9 @@ class PostState extends Equatable {
 
   @override
   List<Object> get props => [status, posts, hasReachedMax];
+
+
+  @override
+  String toString() =>
+      'PostState { status: $status, posts lenght: ${posts.length}, hasReachedMax: $hasReachedMax }';
 }


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

In the infinite list example, just overriding PostState toString to clarify logs printed by BlocObserver. Now logs are cut off because it prints all the content of the posts list. 

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
