### PR TITLE
feat: add confirm password to flutter_firebase_login example

### DIFF
--- a/examples/flutter_firebase_login/lib/sign_up/cubit/sign_up_cubit.dart
+++ b/examples/flutter_firebase_login/lib/sign_up/cubit/sign_up_cubit.dart
@@ -17,15 +17,29 @@ class SignUpCubit extends Cubit<SignUpState> {
     final email = Email.dirty(value);
     emit(state.copyWith(
       email: email,
-      status: Formz.validate([email, state.password]),
+      status: Formz.validate([email, state.password, state.confirmPassword]),
     ));
   }
 
   void passwordChanged(String value) {
     final password = Password.dirty(value);
+    final passwordMatch = (password == state.confirmPassword) ? FormzStatus.valid : FormzStatus.invalid;
+    final status = (Formz.validate([state.email, password, state.confirmPassword]).isValid && passwordMatch.isValid) ? FormzStatus.valid : FormzStatus.invalid;
     emit(state.copyWith(
       password: password,
-      status: Formz.validate([state.email, password]),
+      passwordMatch: passwordMatch,
+      status: status,
+    ));
+  }
+
+  void confirmPasswordChanged(String value) {
+    final confirmPassword = Password.dirty(value);
+    final passwordMatch = (state.password == confirmPassword) ? FormzStatus.valid : FormzStatus.invalid;
+    final status = (Formz.validate([state.email, state.password, confirmPassword]).isValid && passwordMatch.isValid) ? FormzStatus.valid : FormzStatus.invalid;
+    emit(state.copyWith(
+      confirmPassword: confirmPassword,
+      passwordMatch: passwordMatch,
+      status: status,
     ));
   }
 

--- a/examples/flutter_firebase_login/lib/sign_up/cubit/sign_up_state.dart
+++ b/examples/flutter_firebase_login/lib/sign_up/cubit/sign_up_state.dart
@@ -4,24 +4,32 @@ class SignUpState extends Equatable {
   const SignUpState({
     this.email = const Email.pure(),
     this.password = const Password.pure(),
+    this.confirmPassword = const Password.pure(),
+    this.passwordMatch = FormzStatus.pure,
     this.status = FormzStatus.pure,
   });
 
   final Email email;
   final Password password;
+  final Password confirmPassword;
+  final FormzStatus passwordMatch;
   final FormzStatus status;
 
   @override
-  List<Object> get props => [email, password, status];
+  List<Object> get props => [email, password, status, confirmPassword, passwordMatch];
 
   SignUpState copyWith({
     Email email,
     Password password,
+    Password confirmPassword,
+    FormzStatus passwordMatch,
     FormzStatus status,
   }) {
     return SignUpState(
       email: email ?? this.email,
       password: password ?? this.password,
+      confirmPassword: confirmPassword ?? this.confirmPassword,
+      passwordMatch: passwordMatch ?? this.passwordMatch,
       status: status ?? this.status,
     );
   }

--- a/examples/flutter_firebase_login/lib/sign_up/view/sign_up_form.dart
+++ b/examples/flutter_firebase_login/lib/sign_up/view/sign_up_form.dart
@@ -25,6 +25,8 @@ class SignUpForm extends StatelessWidget {
             const SizedBox(height: 8.0),
             _PasswordInput(),
             const SizedBox(height: 8.0),
+            _ConfirmPasswordInput(),
+            const SizedBox(height: 8.0),
             _SignUpButton(),
           ],
         ),
@@ -69,6 +71,30 @@ class _PasswordInput extends StatelessWidget {
             labelText: 'password',
             helperText: '',
             errorText: state.password.invalid ? 'invalid password' : null,
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _ConfirmPasswordInput extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<SignUpCubit, SignUpState>(
+      buildWhen: (previous, current) =>
+      previous.confirmPassword != current.confirmPassword ||
+          previous.passwordMatch != current.passwordMatch,
+      builder: (context, state) {
+        return TextField(
+          key: const Key('signUpForm_confirmPasswordInput_textField'),
+          onChanged: (confirmPassword) =>
+              context.bloc<SignUpCubit>().confirmPasswordChanged(confirmPassword),
+          obscureText: true,
+          decoration: InputDecoration(
+            labelText: 'confirm password',
+            helperText: '',
+            errorText: state.passwordMatch.isInvalid ? 'passwords do not match' : state.confirmPassword.invalid ? 'invalid password' : null,
           ),
         );
       },


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

Addition of a "Confirm Password" field to the SignIn screen. This is the cleanest implementation I could come up with, in respect to the best practices of the library and the bloc design pattern. Reach me up if you have any question!

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
