### PR TITLE
feat(bloc_test): add seed property to blocTest

### DIFF
--- a/packages/bloc_test/README.md
+++ b/packages/bloc_test/README.md
@@ -55,6 +55,8 @@ expect(counterBloc.state, equals(3));
 
 `build` should be used for all `cubit` initialization and preparation and must return the `cubit` under test.
 
+`seed` is an optional state which will be used to seed the `cubit` before `act` is called.
+
 `act` is an optional callback which will be invoked with the `cubit` under test and should be used to `add` events to the `cubit`.
 
 `skip` is an optional `int` which can be used to skip any number of states and defaults to `0`.
@@ -82,6 +84,18 @@ group('CounterBloc', () {
     expect: [1],
   );
 });
+```
+
+`blocTest` can optionally be used with a seeded state.
+
+```dart
+blocTest(
+  'CounterCubit emits [10] when seeded with 9',
+  build: () => CounterCubit(),
+  seed: 9,
+  act: (cubit) => cubit.increment(),
+  expect: [10],
+);
 ```
 
 `blocTest` can also be used to `skip` any number of emitted states before asserting against the expected states. The default value is 0.

--- a/packages/bloc_test/lib/src/bloc_test.dart
+++ b/packages/bloc_test/lib/src/bloc_test.dart
@@ -13,6 +13,9 @@ import 'package:test/test.dart' as test;
 /// [build] should be used for all `cubit` initialization and preparation
 /// and must return the `cubit` under test.
 ///
+/// [seed] is an optional state which will be used to seed the `cubit` before
+/// [act] is called.
+///
 /// [act] is an optional callback which will be invoked with the `cubit` under
 /// test and should be used to interact with the `cubit`.
 ///
@@ -39,14 +42,15 @@ import 'package:test/test.dart' as test;
 /// );
 /// ```
 ///
-/// [blocTest] can also be used to test the initial state of the `cubit`
-/// by omitting [act].
+/// [blocTest] can optionally be used with a seeded state.
 ///
 /// ```dart
 /// blocTest(
-///   'CounterCubit emits [] when nothing is called',
+///   'CounterCubit emits [10] when seeded with 9',
 ///   build: () => CounterCubit(),
-///   expect: [],
+///   seed: 9,
+///   act: (cubit) => cubit.increment(),
+///   expect: [10],
 /// );
 /// ```
 ///
@@ -111,6 +115,7 @@ import 'package:test/test.dart' as test;
 void blocTest<C extends Cubit<State>, State>(
   String description, {
   @required C Function() build,
+  State seed,
   Function(C cubit) act,
   Duration wait,
   int skip = 0,
@@ -122,6 +127,7 @@ void blocTest<C extends Cubit<State>, State>(
     await runBlocTest<C, State>(
       description,
       build: build,
+      seed: seed,
       act: act,
       wait: wait,
       skip: skip,
@@ -138,6 +144,7 @@ void blocTest<C extends Cubit<State>, State>(
 Future<void> runBlocTest<C extends Cubit<State>, State>(
   String description, {
   @required C Function() build,
+  State seed,
   Function(C cubit) act,
   Duration wait,
   int skip = 0,
@@ -151,6 +158,8 @@ Future<void> runBlocTest<C extends Cubit<State>, State>(
     () async {
       final states = <State>[];
       final cubit = build();
+      // ignore: invalid_use_of_visible_for_testing_member, invalid_use_of_protected_member
+      if (seed != null) cubit.emit(seed);
       final subscription = cubit.skip(skip).listen(states.add);
       try {
         await act?.call(cubit);

--- a/packages/bloc_test/test/bloc_bloc_test_test.dart
+++ b/packages/bloc_test/test/bloc_bloc_test_test.dart
@@ -64,6 +64,14 @@ void main() {
         expect: const <int>[11],
       );
 
+      blocTest<CounterBloc, int>(
+        'emits [11] when CounterEvent.increment is added and seed 10',
+        build: () => CounterBloc(),
+        seed: 10,
+        act: (bloc) => bloc.add(CounterEvent.increment),
+        expect: const <int>[11],
+      );
+
       test('fails immediately when expectation is incorrect', () async {
         const expectedError = '''Expected: [2]
   Actual: [1]

--- a/packages/bloc_test/test/cubit_bloc_test_test.dart
+++ b/packages/bloc_test/test/cubit_bloc_test_test.dart
@@ -36,6 +36,15 @@ void main() {
         act: (cubit) => cubit..increment()..increment(),
         expect: <int>[1, 2],
       );
+
+      blocTest<CounterCubit, int>(
+        'emits [3] when increment is called and seed is 2'
+        'with async act',
+        build: () => CounterCubit(),
+        seed: 2,
+        act: (cubit) => cubit.increment(),
+        expect: <int>[3],
+      );
     });
 
     group('AsyncCounterCubit', () {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->
- feat(bloc_test): add `seed` property to `blocTest`

### Usage

```dart
blocTest<CounterBloc, int>(
  'emits [42] when CounterEvent.increment is added and seed is 41',
  build: () => CounterBloc(),
  seed: 41
  act: (bloc) => bloc.add(CounterEvent.increment),
  expect: const <int>[42],
);
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
