### PR TITLE
feat(flutter_bloc): context.read, context.watch, context.select

### DIFF
--- a/examples/flutter_bloc_with_stream/lib/main.dart
+++ b/examples/flutter_bloc_with_stream/lib/main.dart
@@ -51,7 +51,7 @@ class TickerPage extends StatelessWidget {
         },
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () => context.bloc<TickerBloc>().add(TickerStarted()),
+        onPressed: () => context.read<TickerBloc>().add(TickerStarted()),
         tooltip: 'Start',
         child: const Icon(Icons.timer),
       ),

--- a/examples/flutter_complex_list/lib/list/view/list_page.dart
+++ b/examples/flutter_complex_list/lib/list/view/list_page.dart
@@ -37,7 +37,7 @@ class _ListView extends StatelessWidget {
               return _ItemTile(
                 item: items[index],
                 onDeletePressed: (id) {
-                  context.bloc<ListCubit>().deleteItem(id);
+                  context.read<ListCubit>().deleteItem(id);
                 },
               );
             },

--- a/examples/flutter_dynamic_form/lib/main.dart
+++ b/examples/flutter_dynamic_form/lib/main.dart
@@ -25,13 +25,13 @@ class MyForm extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     void _onBrandChanged(String brand) =>
-        context.bloc<NewCarBloc>().add(NewCarBrandChanged(brand: brand));
+        context.read<NewCarBloc>().add(NewCarBrandChanged(brand: brand));
 
     void _onModelChanged(String model) =>
-        context.bloc<NewCarBloc>().add(NewCarModelChanged(model: model));
+        context.read<NewCarBloc>().add(NewCarModelChanged(model: model));
 
     void _onYearChanged(String year) =>
-        context.bloc<NewCarBloc>().add(NewCarYearChanged(year: year));
+        context.read<NewCarBloc>().add(NewCarYearChanged(year: year));
 
     void _onFormSubmitted({String brand, String model, String year}) {
       Scaffold.of(context)

--- a/examples/flutter_form_validation/lib/main.dart
+++ b/examples/flutter_form_validation/lib/main.dart
@@ -74,7 +74,7 @@ class EmailInput extends StatelessWidget {
           ),
           keyboardType: TextInputType.emailAddress,
           onChanged: (value) {
-            context.bloc<MyFormBloc>().add(EmailChanged(email: value));
+            context.read<MyFormBloc>().add(EmailChanged(email: value));
           },
         );
       },
@@ -97,7 +97,7 @@ class PasswordInput extends StatelessWidget {
           ),
           obscureText: true,
           onChanged: (value) {
-            context.bloc<MyFormBloc>().add(PasswordChanged(password: value));
+            context.read<MyFormBloc>().add(PasswordChanged(password: value));
           },
         );
       },
@@ -113,7 +113,7 @@ class SubmitButton extends StatelessWidget {
       builder: (context, state) {
         return RaisedButton(
           onPressed: state.status.isValidated
-              ? () => context.bloc<MyFormBloc>().add(FormSubmitted())
+              ? () => context.read<MyFormBloc>().add(FormSubmitted())
               : null,
           child: const Text('Submit'),
         );

--- a/examples/flutter_infinite_list/lib/posts/view/posts_list.dart
+++ b/examples/flutter_infinite_list/lib/posts/view/posts_list.dart
@@ -15,7 +15,7 @@ class _PostsListState extends State<PostsList> {
   void initState() {
     super.initState();
     _scrollController.addListener(_onScroll);
-    _postBloc = context.bloc<PostBloc>();
+    _postBloc = context.read<PostBloc>();
   }
 
   @override

--- a/examples/flutter_wizard/lib/main.dart
+++ b/examples/flutter_wizard/lib/main.dart
@@ -119,7 +119,7 @@ class _ProfileNameFormState extends State<ProfileNameForm> {
               child: const Text('Continue'),
               onPressed: _name.isNotEmpty
                   ? () => context
-                      .bloc<ProfileWizardBloc>()
+                      .read<ProfileWizardBloc>()
                       .add(ProfileWizardNameSubmitted(_name))
                   : null,
             )
@@ -161,7 +161,7 @@ class _ProfileAgeFormState extends State<ProfileAgeForm> {
               child: const Text('Continue'),
               onPressed: _age != null
                   ? () => context
-                      .bloc<ProfileWizardBloc>()
+                      .read<ProfileWizardBloc>()
                       .add(ProfileWizardAgeSubmitted(_age))
                   : null,
             )

--- a/packages/flutter_bloc/CHANGELOG.md
+++ b/packages/flutter_bloc/CHANGELOG.md
@@ -1,11 +1,11 @@
 # 6.1.0
 
 - feat: add optional `listen` to `BlocProvider` and `RepositoryProvider`
-- feat: add `context.select` extension
-- feat: add `context.watch` extension
-- feat: add `context.read` extension
-  - deprecated: `context.bloc` extension
-  - deprecated: `context.repository` extension
+- feat: add `context.select<T, R>(R Function(T value))` which allows widgets to listen to only a small part of the state of `T` (`R`).
+- feat: add `context.watch<T>()` which allows widgets to listen to changes in the state of `T`
+- feat: add `context.read<T>()` which allows widgets to access `T` without listening for changes
+- deprecated: `context.bloc` in favor of `context.read` and `context.watch`
+- deprecated: `context.repository` in favor of `context.read` and `context.watch`
 - docs: improve inline documentation for `BlocProvider` and `RepositoryProvider`
 
 # 6.0.6

--- a/packages/flutter_bloc/CHANGELOG.md
+++ b/packages/flutter_bloc/CHANGELOG.md
@@ -6,6 +6,7 @@
 - feat: add `context.read<T>()` which allows widgets to access `T` without listening for changes
 - deprecated: `context.bloc` in favor of `context.read` and `context.watch`
 - deprecated: `context.repository` in favor of `context.read` and `context.watch`
+- fix: rethrow `ProviderNotFoundException` from `RepositoryProvider` for external dependencies 
 - docs: improve inline documentation for `BlocProvider` and `RepositoryProvider`
 
 # 6.0.6

--- a/packages/flutter_bloc/CHANGELOG.md
+++ b/packages/flutter_bloc/CHANGELOG.md
@@ -1,8 +1,11 @@
-# 7.0.0-dev.1
+# 6.1.0
 
-- **BREAKING**: remove dependency on `package:provider`
 - feat: add optional `listen` to `BlocProvider`
-- feat: add `ListenProviderExtension`
+- feat: add `context.select` extension
+- feat: add `context.watch` extension
+- feat: add `context.read` extension
+  - deprecated: `context.bloc` extension
+  - deprecated: `context.repository` extension
 - docs: improve inline documentation for `BlocProvider` and `RepositoryProvider`
 
 # 6.0.6

--- a/packages/flutter_bloc/CHANGELOG.md
+++ b/packages/flutter_bloc/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 6.1.0
 
-- feat: add optional `listen` to `BlocProvider`
+- feat: add optional `listen` to `BlocProvider` and `RepositoryProvider`
 - feat: add `context.select` extension
 - feat: add `context.watch` extension
 - feat: add `context.read` extension

--- a/packages/flutter_bloc/README.md
+++ b/packages/flutter_bloc/README.md
@@ -26,7 +26,7 @@ Widgets that make it easy to integrate blocs and cubits into [Flutter](https://f
 
 **Learn more at [bloclibrary.dev](https://bloclibrary.dev)!**
 
-_*Note: All widgets exported by the `flutter_bloc` package integrate with both `Cubit` and `Bloc` instances._
+_\*Note: All widgets exported by the `flutter_bloc` package integrate with both `Cubit` and `Bloc` instances._
 
 ## Usage
 
@@ -62,14 +62,14 @@ class CounterPage extends StatelessWidget {
             padding: const EdgeInsets.symmetric(vertical: 5.0),
             child: FloatingActionButton(
               child: const Icon(Icons.add),
-              onPressed: () => context.bloc<CounterCubit>().increment(),
+              onPressed: () => context.read<CounterCubit>().increment(),
             ),
           ),
           Padding(
             padding: const EdgeInsets.symmetric(vertical: 5.0),
             child: FloatingActionButton(
               child: const Icon(Icons.remove),
-              onPressed: () => context.bloc<CounterCubit>().decrement(),
+              onPressed: () => context.read<CounterCubit>().decrement(),
             ),
           ),
         ],
@@ -82,6 +82,8 @@ class CounterPage extends StatelessWidget {
 At this point we have successfully separated our presentational layer from our business logic layer. Notice that the `CounterPage` widget knows nothing about what happens when a user taps the buttons. The widget simply tells the `CounterCubit` that the user has pressed either the increment or decrement button.
 
 ## Bloc Widgets
+
+### BlocBuilder
 
 **BlocBuilder** is a Flutter widget which requires a `cubit` and a `builder` function. `BlocBuilder` handles building the widget in response to new states. `BlocBuilder` is very similar to `StreamBuilder` but has a more simple API to reduce the amount of boilerplate code needed. The `builder` function will potentially be called many times and should be a [pure function](https://en.wikipedia.org/wiki/Pure_function) that returns a widget in response to the state.
 
@@ -122,6 +124,8 @@ BlocBuilder<BlocA, BlocAState>(
 )
 ```
 
+### BlocProvider
+
 **BlocProvider** is a Flutter widget which provides a cubit to its children via `BlocProvider.of<T>(context)`. It is used as a dependency injection (DI) widget so that a single instance of a cubit can be provided to multiple widgets within a subtree.
 
 In most cases, `BlocProvider` should be used to create new cubits which will be made available to the rest of the subtree. In this case, since `BlocProvider` is responsible for creating the cubit, it will automatically handle closing it.
@@ -158,11 +162,31 @@ then from either `ChildA`, or `ScreenA` we can retrieve `BlocA` with:
 
 ```dart
 // with extensions
-context.bloc<BlocA>();
+context.read<BlocA>();
 
 // without extensions
-BlocProvider.of<BlocA>(context)
+BlocProvider.of<BlocA>(context);
 ```
+
+The above snippets result in a one time lookup and the widget will not be notified of changes. To retrieve the instance and subscribe to subsequent state changes use:
+
+```dart
+// with extensions
+context.watch<BlocA>();
+
+// without extensions
+BlocProvider.of<BlocA>(context, listen: true);
+```
+
+In addition, `context.select` can be used to retrieve part of a state and react to changes only when the selected part changes.
+
+```dart
+final isPositive = context.select((CounterBloc b) => b.state >= 0);
+```
+
+The snippet above will only rebuild if the state of the `CounterBloc` changes from positive to negative or vice versa.
+
+### MultiBlocProvider
 
 **MultiBlocProvider** is a Flutter widget that merges multiple `BlocProvider` widgets into one.
 `MultiBlocProvider` improves the readability and eliminates the need to nest multiple `BlocProviders`.
@@ -199,6 +223,8 @@ MultiBlocProvider(
   child: ChildA(),
 )
 ```
+
+### BlocListener
 
 **BlocListener** is a Flutter widget which takes a `BlocWidgetListener` and an optional `cubit` and invokes the `listener` in response to state changes in the cubit. It should be used for functionality that needs to occur once per state change such as navigation, showing a `SnackBar`, showing a `Dialog`, etc...
 
@@ -241,6 +267,8 @@ BlocListener<BlocA, BlocAState>(
 )
 ```
 
+### MultiBlocListener
+
 **MultiBlocListener** is a Flutter widget that merges multiple `BlocListener` widgets into one.
 `MultiBlocListener` improves the readability and eliminates the need to nest multiple `BlocListeners`.
 By using `MultiBlocListener` we can go from:
@@ -276,6 +304,8 @@ MultiBlocListener(
   child: ChildA(),
 )
 ```
+
+### BlocConsumer
 
 **BlocConsumer** exposes a `builder` and `listener` in order react to new states. `BlocConsumer` is analogous to a nested `BlocListener` and `BlocBuilder` but reduces the amount of boilerplate needed. `BlocConsumer` should only be used when it is necessary to both rebuild UI and execute other reactions to state changes in the `cubit`. `BlocConsumer` takes a required `BlocWidgetBuilder` and `BlocWidgetListener` and an optional `cubit`, `BlocBuilderCondition`, and `BlocListenerCondition`.
 
@@ -314,6 +344,8 @@ BlocConsumer<BlocA, BlocAState>(
 )
 ```
 
+### RepositoryProvider
+
 **RepositoryProvider** is a Flutter widget which provides a repository to its children via `RepositoryProvider.of<T>(context)`. It is used as a dependency injection (DI) widget so that a single instance of a repository can be provided to multiple widgets within a subtree. `BlocProvider` should be used to provide blocs whereas `RepositoryProvider` should only be used for repositories.
 
 ```dart
@@ -327,11 +359,13 @@ then from `ChildA` we can retrieve the `Repository` instance with:
 
 ```dart
 // with extensions
-context.repository<RepositoryA>();
+context.read<RepositoryA>();
 
 // without extensions
 RepositoryProvider.of<RepositoryA>(context)
 ```
+
+### MultiRepositoryProvider
 
 **MultiRepositoryProvider** is a Flutter widget that merges multiple `RepositoryProvider` widgets into one.
 `MultiRepositoryProvider` improves the readability and eliminates the need to nest multiple `RepositoryProvider`.

--- a/packages/flutter_bloc/example/lib/main.dart
+++ b/packages/flutter_bloc/example/lib/main.dart
@@ -83,7 +83,7 @@ class CounterPage extends StatelessWidget {
             child: FloatingActionButton(
               child: const Icon(Icons.add),
               onPressed: () =>
-                  context.bloc<CounterBloc>().add(CounterEvent.increment),
+                  context.read<CounterBloc>().add(CounterEvent.increment),
             ),
           ),
           Padding(
@@ -91,14 +91,14 @@ class CounterPage extends StatelessWidget {
             child: FloatingActionButton(
               child: const Icon(Icons.remove),
               onPressed: () =>
-                  context.bloc<CounterBloc>().add(CounterEvent.decrement),
+                  context.read<CounterBloc>().add(CounterEvent.decrement),
             ),
           ),
           Padding(
             padding: const EdgeInsets.symmetric(vertical: 5.0),
             child: FloatingActionButton(
               child: const Icon(Icons.brightness_6),
-              onPressed: () => context.bloc<ThemeCubit>().toggleTheme(),
+              onPressed: () => context.read<ThemeCubit>().toggleTheme(),
             ),
           ),
           Padding(
@@ -106,7 +106,7 @@ class CounterPage extends StatelessWidget {
             child: FloatingActionButton(
               backgroundColor: Colors.red,
               child: const Icon(Icons.error),
-              onPressed: () => context.bloc<CounterBloc>().add(null),
+              onPressed: () => context.read<CounterBloc>().add(null),
             ),
           ),
         ],

--- a/packages/flutter_bloc/lib/flutter_bloc.dart
+++ b/packages/flutter_bloc/lib/flutter_bloc.dart
@@ -1,6 +1,8 @@
 library flutter_bloc;
 
 export 'package:bloc/bloc.dart';
+export 'package:provider/provider.dart'
+    show ReadContext, SelectContext, WatchContext;
 
 export './src/bloc_builder.dart';
 export './src/bloc_consumer.dart';

--- a/packages/flutter_bloc/lib/src/bloc_builder.dart
+++ b/packages/flutter_bloc/lib/src/bloc_builder.dart
@@ -1,5 +1,6 @@
 import 'package:bloc/bloc.dart';
 import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
 
 import 'bloc_listener.dart';
 import 'bloc_provider.dart';
@@ -128,14 +129,14 @@ class _BlocBuilderBaseState<C extends Cubit<S>, S>
   @override
   void initState() {
     super.initState();
-    _cubit = widget.cubit ?? context.bloc<C>();
+    _cubit = widget.cubit ?? context.read<C>();
     _state = _cubit.state;
   }
 
   @override
   void didUpdateWidget(BlocBuilderBase<C, S> oldWidget) {
     super.didUpdateWidget(oldWidget);
-    final oldCubit = oldWidget.cubit ?? context.bloc<C>();
+    final oldCubit = oldWidget.cubit ?? context.read<C>();
     final currentCubit = widget.cubit ?? oldCubit;
     if (oldCubit != currentCubit) {
       _cubit = currentCubit;

--- a/packages/flutter_bloc/lib/src/bloc_consumer.dart
+++ b/packages/flutter_bloc/lib/src/bloc_consumer.dart
@@ -1,7 +1,9 @@
 import 'package:bloc/bloc.dart';
 import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
 
-import '../flutter_bloc.dart';
+import 'bloc_builder.dart';
+import 'bloc_listener.dart';
 
 /// {@template bloc_consumer}
 /// [BlocConsumer] exposes a [builder] and [listener] in order react to new
@@ -100,7 +102,7 @@ class BlocConsumer<C extends Cubit<S>, S> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final cubit = this.cubit ?? context.bloc<C>();
+    final cubit = this.cubit ?? context.watch<C>();
     return BlocBuilder<C, S>(
       cubit: cubit,
       builder: builder,

--- a/packages/flutter_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/bloc_listener.dart
@@ -2,7 +2,8 @@ import 'dart:async';
 
 import 'package:bloc/bloc.dart';
 import 'package:flutter/widgets.dart';
-import 'package:nested/nested.dart';
+import 'package:provider/provider.dart';
+import 'package:provider/single_child_widget.dart';
 
 import 'bloc_provider.dart';
 
@@ -146,7 +147,7 @@ class _BlocListenerBaseState<C extends Cubit<S>, S>
   @override
   void initState() {
     super.initState();
-    _cubit = widget.cubit ?? context.bloc<C>();
+    _cubit = widget.cubit ?? context.read<C>();
     _previousState = _cubit.state;
     _subscribe();
   }
@@ -154,7 +155,7 @@ class _BlocListenerBaseState<C extends Cubit<S>, S>
   @override
   void didUpdateWidget(BlocListenerBase<C, S> oldWidget) {
     super.didUpdateWidget(oldWidget);
-    final oldCubit = oldWidget.cubit ?? context.bloc<C>();
+    final oldCubit = oldWidget.cubit ?? context.read<C>();
     final currentCubit = widget.cubit ?? oldCubit;
     if (oldCubit != currentCubit) {
       if (_subscription != null) {

--- a/packages/flutter_bloc/lib/src/bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/bloc_provider.dart
@@ -150,6 +150,7 @@ class BlocProvider<T extends Cubit<Object>> extends SingleChildStatelessWidget
     final subscription = value.listen(
       (Object _) => e.markNeedsNotifyDependents(),
     );
+    if (subscription == null) return () {};
     return subscription.cancel;
   }
 }

--- a/packages/flutter_bloc/lib/src/bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/bloc_provider.dart
@@ -166,6 +166,8 @@ extension BlocProviderExtension on BuildContext {
   /// ```dart
   /// BlocProvider.of<C>(context)
   /// ```
-  @Deprecated('Use context.read instead. Will be removed in v7.0.0')
+  @Deprecated(
+    'Use context.read or context.watch instead. Will be removed in v7.0.0',
+  )
   C bloc<C extends Cubit<Object>>() => BlocProvider.of<C>(this);
 }

--- a/packages/flutter_bloc/lib/src/bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/bloc_provider.dart
@@ -1,20 +1,15 @@
-import 'dart:async';
-
 import 'package:flutter/widgets.dart';
 
 import 'package:bloc/bloc.dart';
-import 'package:inherited_stream/inherited_stream.dart';
-import 'package:nested/nested.dart';
-
-/// Function that creates a [Bloc] or [Cubit] of type [T].
-typedef _Create<T extends Cubit<Object>> = T Function(BuildContext context);
+import 'package:provider/provider.dart';
+import 'package:provider/single_child_widget.dart';
 
 /// Mixin which allows `MultiBlocProvider` to infer the types
 /// of multiple [BlocProvider]s.
 mixin BlocProviderSingleChildWidget on SingleChildWidget {}
 
 /// {@template bloc_provider}
-/// Takes a [create] function that is responsible for
+/// Takes a [Create] function that is responsible for
 /// creating the [Bloc] or [Cubit] and a [child] which will have access
 /// to the instance via `BlocProvider.of(context)`.
 /// It is used as a dependency injection (DI) widget so that a single instance
@@ -27,8 +22,8 @@ mixin BlocProviderSingleChildWidget on SingleChildWidget {}
 /// );
 /// ```
 ///
-/// It automatically handles closing the instance when used with [create].
-/// By default, [create] is called only when the instance is accessed.
+/// It automatically handles closing the instance when used with [Create].
+/// By default, [Create] is called only when the instance is accessed.
 /// To override this behavior, set [lazy] to `false`.
 ///
 /// ```dart
@@ -40,16 +35,21 @@ mixin BlocProviderSingleChildWidget on SingleChildWidget {}
 /// ```
 ///
 /// {@endtemplate}
-class BlocProvider<T extends Cubit<Object>> extends SingleChildStatefulWidget
+class BlocProvider<T extends Cubit<Object>> extends SingleChildStatelessWidget
     with BlocProviderSingleChildWidget {
   /// {@macro bloc_provider}
-  const BlocProvider({
+  BlocProvider({
     Key key,
-    @required this.create,
-    this.child,
-    this.lazy = true,
-  })  : assert(create != null),
-        super(key: key);
+    @required Create<T> create,
+    Widget child,
+    bool lazy,
+  }) : this._(
+          key: key,
+          create: create,
+          dispose: (_, bloc) => bloc?.close(),
+          child: child,
+          lazy: lazy,
+        );
 
   /// Takes a [value] and a [child] which will have access to the [value] via
   /// `BlocProvider.of(context)`.
@@ -60,7 +60,7 @@ class BlocProvider<T extends Cubit<Object>> extends SingleChildStatefulWidget
   ///
   /// A new [Bloc] or [Cubit] should not be created in `BlocProvider.value`.
   /// New instances should always be created using the
-  /// default constructor within the [create] function.
+  /// default constructor within the [Create] function.
   ///
   /// ```dart
   /// BlocProvider.value(
@@ -72,10 +72,23 @@ class BlocProvider<T extends Cubit<Object>> extends SingleChildStatefulWidget
     Key key,
     @required T value,
     Widget child,
-  }) : this(key: key, create: (_) => value, child: child);
+  }) : this._(
+          key: key,
+          create: (_) => value,
+          child: child,
+        );
 
-  /// Creates a [Bloc] or [Cubit] of type [T].
-  final _Create<T> create;
+  /// Internal constructor responsible for creating the [BlocProvider].
+  /// Used by the [BlocProvider] default and value constructors.
+  BlocProvider._({
+    Key key,
+    @required Create<T> create,
+    Dispose<T> dispose,
+    this.child,
+    this.lazy,
+  })  : _create = create,
+        _dispose = dispose,
+        super(key: key, child: child);
 
   /// Widget which will have access to the [Bloc] or [Cubit].
   final Widget child;
@@ -84,8 +97,9 @@ class BlocProvider<T extends Cubit<Object>> extends SingleChildStatefulWidget
   /// Defaults to `true`.
   final bool lazy;
 
-  @override
-  _BlocProviderState<T> createState() => _BlocProviderState<T>();
+  final Dispose<T> _dispose;
+
+  final Create<T> _create;
 
   /// Method that allows widgets to access a [Bloc] or [Cubit] instance
   /// as long as their `BuildContext` contains a [BlocProvider] instance.
@@ -100,14 +114,10 @@ class BlocProvider<T extends Cubit<Object>> extends SingleChildStatefulWidget
     BuildContext context, {
     bool listen = false,
   }) {
-    final provider = listen
-        ? context
-            .dependOnInheritedWidgetOfExactType<_InheritedBlocProvider<T>>()
-        : context
-            .getElementForInheritedWidgetOfExactType<
-                _InheritedBlocProvider<T>>()
-            ?.widget as _InheritedBlocProvider<T>;
-    if (provider == null) {
+    try {
+      return Provider.of<T>(context, listen: listen);
+    } on ProviderNotFoundException catch (e) {
+      if (e.valueType != T) rethrow;
       throw FlutterError(
         '''
         BlocProvider.of() called with a context that does not contain a Bloc/Cubit of type $T.
@@ -119,84 +129,42 @@ class BlocProvider<T extends Cubit<Object>> extends SingleChildStatefulWidget
         ''',
       );
     }
-    return provider.value();
-  }
-}
-
-/// Extends the [BuildContext] class with the ability
-/// to perform a lookup based on a [Bloc] or [Cubit] type.
-extension BlocProviderExtension on BuildContext {
-  /// Performs a lookup using the [BuildContext] to obtain
-  /// the nearest ancestor [Bloc] or [Cubit] of type [T].
-  ///
-  /// Calling this method is equivalent to calling:
-  ///
-  /// ```dart
-  /// BlocProvider.of<T>(context);
-  /// ```
-  T bloc<T extends Cubit<Object>>() => BlocProvider.of<T>(this);
-}
-
-/// Extends the [BuildContext] class with the ability
-/// to listen to state changes given a [Bloc] or [Cubit] type.
-extension ListenProviderExtension on BuildContext {
-  /// Registers the [BuildContext] as a dependent and returns the
-  /// state of the [Bloc] or [Cubit].
-  ///
-  /// Calling this method is equivalent to calling:
-  ///
-  /// ```dart
-  /// BlocProvider.of<T>(context, listen: true).state;
-  /// ```
-  S listen<T extends Cubit<S>, S>() {
-    return BlocProvider.of<T>(this, listen: true).state;
-  }
-}
-
-class _BlocProviderState<T extends Cubit<Object>>
-    extends SingleChildState<BlocProvider<T>> {
-  final _completer = Completer<T>();
-  T _bloc;
-
-  @override
-  void initState() {
-    super.initState();
-    if (!widget.lazy) {
-      _bloc = widget.create(context);
-      _completer.complete(_bloc);
-    }
-  }
-
-  @override
-  void dispose() {
-    _bloc?.close();
-    super.dispose();
   }
 
   @override
   Widget buildWithChild(BuildContext context, Widget child) {
-    return _InheritedBlocProvider(
-      child: child ?? widget.child,
-      deferredBloc: _completer.future,
-      value: () {
-        if (!_completer.isCompleted) {
-          _bloc = widget.create(context);
-          _completer.complete(_bloc);
-        }
-        return _bloc;
-      },
+    return InheritedProvider<T>(
+      create: _create,
+      dispose: _dispose,
+      startListening: _startListening,
+      child: child,
+      lazy: lazy,
     );
+  }
+
+  static VoidCallback _startListening(
+    InheritedContext<Cubit> e,
+    Cubit value,
+  ) {
+    if (value == null) return () {};
+    final subscription = value.listen(
+      (Object _) => e.markNeedsNotifyDependents(),
+    );
+    return subscription.cancel;
   }
 }
 
-class _InheritedBlocProvider<T extends Cubit<Object>>
-    extends DeferredInheritedStream<T> {
-  _InheritedBlocProvider({
-    Key key,
-    @required Future<T> deferredBloc,
-    @required this.value,
-    Widget child,
-  }) : super(key: key, deferredStream: deferredBloc, child: child);
-
-  final ValueGetter<T> value;
+/// Extends the `BuildContext` class with the ability
+/// to perform a lookup based on a `Bloc` type.
+extension BlocProviderExtension on BuildContext {
+  /// Performs a lookup using the `BuildContext` to obtain
+  /// the nearest ancestor `Cubit` of type [C].
+  ///
+  /// Calling this method is equivalent to calling:
+  ///
+  /// ```dart
+  /// BlocProvider.of<C>(context)
+  /// ```
+  @Deprecated('Use context.read instead. Will be removed in v7.0.0')
+  C bloc<C extends Cubit<Object>>() => BlocProvider.of<C>(this);
 }

--- a/packages/flutter_bloc/lib/src/multi_bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/multi_bloc_listener.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/widgets.dart';
-import 'package:nested/nested.dart';
+import 'package:provider/provider.dart';
 
 import 'bloc_listener.dart';
 
@@ -48,7 +48,7 @@ import 'bloc_listener.dart';
 /// As a result, the only advantage of using [MultiBlocListener] is improved
 /// readability due to the reduction in nesting and boilerplate.
 /// {@endtemplate}
-class MultiBlocListener extends Nested {
+class MultiBlocListener extends MultiProvider {
   /// {@macro multi_bloc_listener}
   MultiBlocListener({
     Key key,
@@ -56,5 +56,5 @@ class MultiBlocListener extends Nested {
     @required Widget child,
   })  : assert(listeners != null),
         assert(child != null),
-        super(key: key, children: listeners, child: child);
+        super(key: key, providers: listeners, child: child);
 }

--- a/packages/flutter_bloc/lib/src/multi_bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/multi_bloc_provider.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/widgets.dart';
-import 'package:nested/nested.dart';
+import 'package:provider/provider.dart';
 
 import 'bloc_provider.dart';
 
@@ -48,7 +48,7 @@ import 'bloc_provider.dart';
 /// As a result, the only advantage of using [MultiBlocProvider] is improved
 /// readability due to the reduction in nesting and boilerplate.
 /// {@endtemplate}
-class MultiBlocProvider extends Nested {
+class MultiBlocProvider extends MultiProvider {
   /// {@macro multi_bloc_provider}
   MultiBlocProvider({
     Key key,
@@ -56,5 +56,5 @@ class MultiBlocProvider extends Nested {
     @required Widget child,
   })  : assert(providers != null),
         assert(child != null),
-        super(key: key, children: providers, child: child);
+        super(key: key, providers: providers, child: child);
 }

--- a/packages/flutter_bloc/lib/src/multi_repository_provider.dart
+++ b/packages/flutter_bloc/lib/src/multi_repository_provider.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/widgets.dart';
-import 'package:nested/nested.dart';
+import 'package:provider/provider.dart';
 
 import 'repository_provider.dart';
 
@@ -42,7 +42,7 @@ import 'repository_provider.dart';
 /// As a result, the only advantage of using [MultiRepositoryProvider] is
 /// improved readability due to the reduction in nesting and boilerplate.
 /// {@endtemplate}
-class MultiRepositoryProvider extends Nested {
+class MultiRepositoryProvider extends MultiProvider {
   /// {@macro multi_repository_provider}
   MultiRepositoryProvider({
     Key key,
@@ -50,5 +50,5 @@ class MultiRepositoryProvider extends Nested {
     @required Widget child,
   })  : assert(providers != null),
         assert(child != null),
-        super(key: key, children: providers, child: child);
+        super(key: key, providers: providers, child: child);
 }

--- a/packages/flutter_bloc/lib/src/repository_provider.dart
+++ b/packages/flutter_bloc/lib/src/repository_provider.dart
@@ -91,6 +91,8 @@ extension RepositoryProviderExtension on BuildContext {
   /// ```dart
   /// RepositoryProvider.of<T>(context)
   /// ```
-  @Deprecated('Use context.read instead. Will be removed in v7.0.0')
+  @Deprecated(
+    'Use context.read or context.watch instead. Will be removed in v7.0.0',
+  )
   T repository<T>() => RepositoryProvider.of<T>(this);
 }

--- a/packages/flutter_bloc/lib/src/repository_provider.dart
+++ b/packages/flutter_bloc/lib/src/repository_provider.dart
@@ -62,9 +62,9 @@ class RepositoryProvider<T> extends Provider<T>
 
   /// Method that allows widgets to access a repository instance as long as
   /// their `BuildContext` contains a [RepositoryProvider] instance.
-  static T of<T>(BuildContext context) {
+  static T of<T>(BuildContext context, {bool listen = false}) {
     try {
-      return Provider.of<T>(context, listen: false);
+      return Provider.of<T>(context, listen: listen);
     } on ProviderNotFoundException catch (_) {
       throw FlutterError(
         '''

--- a/packages/flutter_bloc/lib/src/repository_provider.dart
+++ b/packages/flutter_bloc/lib/src/repository_provider.dart
@@ -1,17 +1,13 @@
-import 'dart:async';
-
 import 'package:flutter/widgets.dart';
-import 'package:nested/nested.dart';
-
-/// Function that creates a repository of type [T].
-typedef _Create<T> = T Function(BuildContext);
+import 'package:provider/provider.dart';
+import 'package:provider/single_child_widget.dart';
 
 /// Mixin which allows `MultiRepositoryProvider` to infer the types
 /// of multiple [RepositoryProvider]s.
 mixin RepositoryProviderSingleChildWidget on SingleChildWidget {}
 
 /// {@template repository_provider}
-/// Takes a [create] function that is responsible for creating the repository
+/// Takes a [Create] function that is responsible for creating the repository
 /// and a `child` which will have access to the repository via
 /// `RepositoryProvider.of(context)`.
 /// It is used as a dependency injection (DI) widget so that a single instance
@@ -24,7 +20,7 @@ mixin RepositoryProviderSingleChildWidget on SingleChildWidget {}
 /// );
 /// ```
 ///
-/// Lazily creates the repository unless [lazy] is set to `false`.
+/// Lazily creates the repository unless `lazy` is set to `false`.
 ///
 /// ```dart
 /// RepositoryProvider(
@@ -34,48 +30,42 @@ mixin RepositoryProviderSingleChildWidget on SingleChildWidget {}
 /// );
 /// ```
 /// {@endtemplate}
-class RepositoryProvider<T> extends SingleChildStatefulWidget
+class RepositoryProvider<T> extends Provider<T>
     with RepositoryProviderSingleChildWidget {
   /// {@macro repository_provider}
   RepositoryProvider({
     Key key,
-    @required this.create,
-    this.child,
-    this.lazy = true,
-  })  : assert(create != null),
-        super(key: key);
+    @required Create<T> create,
+    Widget child,
+    bool lazy,
+  }) : super(
+          key: key,
+          create: create,
+          dispose: (_, __) {},
+          child: child,
+          lazy: lazy,
+        );
 
   /// Takes a repository and a [child] which will have access to the repository.
   /// A new repository should not be created in `RepositoryProvider.value`.
   /// Repositories should always be created using the default constructor
-  /// within the [create] function.
+  /// within the [Create] function.
   RepositoryProvider.value({
     Key key,
     @required T value,
     Widget child,
-  }) : this(
+  }) : super.value(
           key: key,
-          create: (_) => value,
+          value: value,
           child: child,
         );
-
-  /// Creates the repository of type [T].
-  final _Create<T> create;
-
-  /// Widget which will have access to the repository.
-  final Widget child;
-
-  /// Whether the repository should be created lazily.
-  /// Defaults to `true`.
-  final bool lazy;
 
   /// Method that allows widgets to access a repository instance as long as
   /// their `BuildContext` contains a [RepositoryProvider] instance.
   static T of<T>(BuildContext context) {
-    final provider = context
-        .getElementForInheritedWidgetOfExactType<_InheritedRepository<T>>()
-        ?.widget as _InheritedRepository<T>;
-    if (provider == null) {
+    try {
+      return Provider.of<T>(context, listen: false);
+    } on ProviderNotFoundException catch (_) {
       throw FlutterError(
         '''
         RepositoryProvider.of() called with a context that does not contain a repository of type $T.
@@ -87,40 +77,6 @@ class RepositoryProvider<T> extends SingleChildStatefulWidget
         ''',
       );
     }
-    return provider.value();
-  }
-
-  @override
-  _RepositoryProviderState<T> createState() => _RepositoryProviderState<T>();
-}
-
-class _RepositoryProviderState<T>
-    extends SingleChildState<RepositoryProvider<T>> {
-  T _repository;
-  final _completer = Completer<T>();
-
-  @override
-  void initState() {
-    super.initState();
-    if (!widget.lazy) {
-      _repository = widget.create(context);
-      _completer.complete(_repository);
-    }
-  }
-
-  @override
-  Widget buildWithChild(BuildContext context, Widget child) {
-    return _InheritedRepository(
-      value: () {
-        if (!_completer.isCompleted) {
-          _repository = widget.create(context);
-          _completer.complete(_repository);
-        }
-        return _repository;
-      },
-      future: _completer.future,
-      child: child ?? widget.child,
-    );
   }
 }
 
@@ -135,61 +91,6 @@ extension RepositoryProviderExtension on BuildContext {
   /// ```dart
   /// RepositoryProvider.of<T>(context)
   /// ```
+  @Deprecated('Use context.read instead. Will be removed in v7.0.0')
   T repository<T>() => RepositoryProvider.of<T>(this);
-}
-
-class _InheritedRepository<T> extends InheritedWidget {
-  const _InheritedRepository({
-    Key key,
-    this.future,
-    this.value,
-    @required Widget child,
-  })  : assert(child != null),
-        super(key: key, child: child);
-
-  final Future<void> future;
-  final ValueGetter<T> value;
-
-  @override
-  bool updateShouldNotify(_InheritedRepository<T> oldWidget) {
-    return oldWidget.future != future;
-  }
-
-  @override
-  _InheritedRepositoryElement<T> createElement() =>
-      _InheritedRepositoryElement<T>(this);
-}
-
-class _InheritedRepositoryElement<T> extends InheritedElement {
-  _InheritedRepositoryElement(_InheritedRepository<T> widget) : super(widget) {
-    widget.future?.then((_) => _handleUpdate());
-  }
-
-  @override
-  _InheritedRepository<T> get widget => super.widget as _InheritedRepository<T>;
-
-  bool _dirty = false;
-
-  @override
-  void update(_InheritedRepository<T> newWidget) {
-    if (widget.value != newWidget.value) _handleUpdate();
-    super.update(newWidget);
-  }
-
-  @override
-  Widget build() {
-    if (_dirty) notifyClients(widget);
-    return super.build();
-  }
-
-  void _handleUpdate() {
-    _dirty = true;
-    markNeedsBuild();
-  }
-
-  @override
-  void notifyClients(_InheritedRepository<T> oldWidget) {
-    super.notifyClients(oldWidget);
-    _dirty = false;
-  }
 }

--- a/packages/flutter_bloc/lib/src/repository_provider.dart
+++ b/packages/flutter_bloc/lib/src/repository_provider.dart
@@ -65,7 +65,8 @@ class RepositoryProvider<T> extends Provider<T>
   static T of<T>(BuildContext context, {bool listen = false}) {
     try {
       return Provider.of<T>(context, listen: listen);
-    } on ProviderNotFoundException catch (_) {
+    } on ProviderNotFoundException catch (e) {
+      if (e.valueType != T) rethrow;
       throw FlutterError(
         '''
         RepositoryProvider.of() called with a context that does not contain a repository of type $T.

--- a/packages/flutter_bloc/pubspec.yaml
+++ b/packages/flutter_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_bloc
 description: Flutter Widgets that make it easy to implement the BLoC (Business Logic Component) design pattern. Built to be used with the bloc state management package.
-version: 7.0.0-dev.1
+version: 6.1.0
 repository: https://github.com/felangel/bloc/tree/master/packages/flutter_bloc
 issue_tracker: https://github.com/felangel/bloc/issues
 homepage: https://bloclibrary.dev
@@ -12,9 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  bloc: ^6.0.0
-  inherited_stream: ^1.1.0
-  nested: ^0.0.4
+  bloc: ^6.1.0
+  provider: ^4.3.2+2
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_bloc/test/bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/bloc_provider_test.dart
@@ -285,7 +285,7 @@ void main() {
                       RaisedButton(
                         key: const Key('increment_button'),
                         onPressed: () {
-                          context.bloc<CounterCubit>().increment();
+                          BlocProvider.of<CounterCubit>(context).increment();
                         },
                       ),
                     ],
@@ -412,6 +412,7 @@ void main() {
             home: Scaffold(
               body: Builder(
                 builder: (context) => Text(
+                  // ignore: deprecated_member_use_from_same_package
                   '${context.bloc<CounterCubit>().state}',
                   key: textKey,
                 ),
@@ -455,7 +456,7 @@ void main() {
                   floatingActionButton: FloatingActionButton(
                     key: buttonKey,
                     onPressed: () {
-                      context.bloc<CounterCubit>().increment();
+                      context.read<CounterCubit>().increment();
                     },
                   ),
                 ),
@@ -489,8 +490,7 @@ void main() {
       expect(textBuildCount, equals(3));
     });
 
-    testWidgets('context.listen registers context as dependent',
-        (tester) async {
+    testWidgets('context.watch registers context as dependent', (tester) async {
       const textKey = Key('__text__');
       const buttonKey = Key('__button__');
       var counterCubitCreateCount = 0;
@@ -510,14 +510,14 @@ void main() {
                   body: Builder(
                     builder: (context) {
                       textBuildCount++;
-                      final count = context.listen<CounterCubit, int>();
+                      final count = context.watch<CounterCubit>().state;
                       return Text('$count', key: textKey);
                     },
                   ),
                   floatingActionButton: FloatingActionButton(
                     key: buttonKey,
                     onPressed: () {
-                      context.bloc<CounterCubit>().increment();
+                      context.read<CounterCubit>().increment();
                     },
                   ),
                 ),

--- a/packages/flutter_bloc/test/bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/bloc_provider_test.dart
@@ -6,6 +6,20 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+class MockCubit<S> extends Cubit<S> {
+  MockCubit(S state) : super(state);
+
+  @override
+  StreamSubscription<S> listen(
+    void Function(S p1) onData, {
+    Function onError,
+    void Function() onDone,
+    bool cancelOnError,
+  }) {
+    return null;
+  }
+}
+
 class MyApp extends StatelessWidget {
   const MyApp({
     Key key,
@@ -549,6 +563,16 @@ void main() {
       expect(counterCubitCreateCount, equals(1));
       expect(materialBuildCount, equals(1));
       expect(textBuildCount, equals(3));
+    });
+
+    testWidgets('should not throw if listen returns null subscription',
+        (tester) async {
+      await tester.pumpWidget(BlocProvider(
+        lazy: false,
+        create: (_) => MockCubit(0),
+        child: const SizedBox(),
+      ));
+      expect(tester.takeException(), isNull);
     });
   });
 }

--- a/packages/flutter_bloc/test/bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/bloc_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:provider/provider.dart';
 
 class MockCubit<S> extends Cubit<S> {
   MockCubit(S state) : super(state);
@@ -397,11 +398,28 @@ void main() {
         BlocProvider<CounterCubit>(
           lazy: false,
           create: (_) => throw expectedException,
-          child: Container(),
+          child: const SizedBox(),
         ),
       );
       final dynamic exception = tester.takeException();
       expect(exception, expectedException);
+    });
+
+    testWidgets(
+        'should rethrow ProviderNotFound '
+        'if exception is for different provider', (tester) async {
+      await tester.pumpWidget(
+        BlocProvider<CounterCubit>(
+          lazy: false,
+          create: (context) {
+            context.read<int>();
+            return CounterCubit();
+          },
+          child: const SizedBox(),
+        ),
+      );
+      final exception = tester.takeException() as ProviderNotFoundException;
+      expect(exception.valueType, int);
     });
 
     testWidgets(

--- a/packages/flutter_bloc/test/repository_provider_test.dart
+++ b/packages/flutter_bloc/test/repository_provider_test.dart
@@ -246,6 +246,74 @@ void main() {
     });
 
     testWidgets(
+        'should rebuild widgets that inherited the value if the value is '
+        'changed with context.watch', (tester) async {
+      var numBuilds = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StatefulBuilder(
+            builder: (context, setState) {
+              var repository = const Repository(0);
+              return RepositoryProvider.value(
+                value: repository,
+                child: StatefulBuilder(
+                  builder: (context, _) {
+                    numBuilds++;
+                    final data = context.watch<Repository>().data;
+                    return TextButton(
+                      child: Text('Data: $data'),
+                      onPressed: () {
+                        setState(() => repository = const Repository(1));
+                      },
+                    );
+                  },
+                ),
+              );
+            },
+          ),
+        ),
+      );
+      await tester.tap(find.byType(TextButton));
+      await tester.pump();
+      expect(numBuilds, 2);
+    });
+
+    testWidgets(
+        'should rebuild widgets that inherited the value if the value is '
+        'changed with listen: true', (tester) async {
+      var numBuilds = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StatefulBuilder(
+            builder: (context, setState) {
+              var repository = const Repository(0);
+              return RepositoryProvider.value(
+                value: repository,
+                child: StatefulBuilder(
+                  builder: (context, _) {
+                    numBuilds++;
+                    final data =
+                        RepositoryProvider.of<Repository>(context, listen: true)
+                            .data;
+                    return TextButton(
+                      child: Text('Data: $data'),
+                      onPressed: () {
+                        setState(() => repository = const Repository(1));
+                      },
+                    );
+                  },
+                ),
+              );
+            },
+          ),
+        ),
+      );
+      await tester.tap(find.byType(TextButton));
+      await tester.pump();
+      expect(numBuilds, 2);
+    });
+
+    testWidgets(
         'should access repository instance'
         'via RepositoryProviderExtension', (tester) async {
       await tester.pumpWidget(

--- a/packages/flutter_bloc/test/repository_provider_test.dart
+++ b/packages/flutter_bloc/test/repository_provider_test.dart
@@ -256,6 +256,7 @@ void main() {
               body: Center(
                 child: Builder(
                   builder: (context) => Text(
+                    // ignore: deprecated_member_use_from_same_package
                     '${context.repository<Repository>().data}',
                     key: const Key('value_data'),
                   ),

--- a/packages/flutter_bloc/test/repository_provider_test.dart
+++ b/packages/flutter_bloc/test/repository_provider_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
 
 class MyApp extends StatelessWidget {
   const MyApp({
@@ -232,6 +233,23 @@ void main() {
       );
       final dynamic exception = tester.takeException();
       expect(exception, expectedException);
+    });
+
+    testWidgets(
+        'should rethrow ProviderNotFound '
+        'if exception is for different provider', (tester) async {
+      await tester.pumpWidget(
+        RepositoryProvider<Repository>(
+          lazy: false,
+          create: (context) {
+            context.read<int>();
+            return const Repository(0);
+          },
+          child: const SizedBox(),
+        ),
+      );
+      final exception = tester.takeException() as ProviderNotFoundException;
+      expect(exception.valueType, int);
     });
 
     testWidgets(

--- a/packages/hydrated_bloc/example/lib/main.dart
+++ b/packages/hydrated_bloc/example/lib/main.dart
@@ -57,7 +57,7 @@ class CounterPage extends StatelessWidget {
             child: FloatingActionButton(
               child: const Icon(Icons.brightness_6),
               onPressed: () {
-                context.bloc<BrightnessCubit>().toggleBrightness();
+                context.read<BrightnessCubit>().toggleBrightness();
               },
             ),
           ),
@@ -66,7 +66,7 @@ class CounterPage extends StatelessWidget {
             child: FloatingActionButton(
               child: const Icon(Icons.add),
               onPressed: () {
-                context.bloc<CounterBloc>().add(CounterEvent.increment);
+                context.read<CounterBloc>().add(CounterEvent.increment);
               },
             ),
           ),
@@ -75,7 +75,7 @@ class CounterPage extends StatelessWidget {
             child: FloatingActionButton(
               child: const Icon(Icons.remove),
               onPressed: () {
-                context.bloc<CounterBloc>().add(CounterEvent.decrement);
+                context.read<CounterBloc>().add(CounterEvent.decrement);
               },
             ),
           ),
@@ -84,7 +84,7 @@ class CounterPage extends StatelessWidget {
             child: FloatingActionButton(
               child: const Icon(Icons.delete_forever),
               onPressed: () async {
-                final counterBloc = context.bloc<CounterBloc>();
+                final counterBloc = context.read<CounterBloc>();
                 await counterBloc.clear();
                 counterBloc.add(CounterEvent.reset);
               },

--- a/packages/replay_bloc/example/lib/main.dart
+++ b/packages/replay_bloc/example/lib/main.dart
@@ -39,7 +39,7 @@ class CounterPage extends StatelessWidget {
         actions: [
           BlocBuilder<CounterBloc, int>(
             builder: (context, state) {
-              final bloc = context.bloc<CounterBloc>();
+              final bloc = context.read<CounterBloc>();
               return IconButton(
                 icon: const Icon(Icons.undo),
                 onPressed: bloc.canUndo ? bloc.undo : null,
@@ -48,7 +48,7 @@ class CounterPage extends StatelessWidget {
           ),
           BlocBuilder<CounterBloc, int>(
             builder: (context, state) {
-              final bloc = context.bloc<CounterBloc>();
+              final bloc = context.read<CounterBloc>();
               return IconButton(
                 icon: const Icon(Icons.redo),
                 onPressed: bloc.canRedo ? bloc.redo : null,
@@ -70,21 +70,21 @@ class CounterPage extends StatelessWidget {
             padding: const EdgeInsets.symmetric(vertical: 4.0),
             child: FloatingActionButton(
               child: const Icon(Icons.add),
-              onPressed: () => context.bloc<CounterBloc>().add(Increment()),
+              onPressed: () => context.read<CounterBloc>().add(Increment()),
             ),
           ),
           Padding(
             padding: const EdgeInsets.symmetric(vertical: 4.0),
             child: FloatingActionButton(
               child: const Icon(Icons.remove),
-              onPressed: () => context.bloc<CounterBloc>().add(Decrement()),
+              onPressed: () => context.read<CounterBloc>().add(Decrement()),
             ),
           ),
           Padding(
             padding: const EdgeInsets.symmetric(vertical: 4.0),
             child: FloatingActionButton(
               child: const Icon(Icons.delete_forever),
-              onPressed: () => context.bloc<CounterBloc>().add(Reset()),
+              onPressed: () => context.read<CounterBloc>().add(Reset()),
             ),
           ),
         ],


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->

- feat: add optional `listen` to `BlocProvider` and `RepositoryProvider`
- feat: add `context.select<T, R>(R Function(T value))` which allows widgets to listen to only a small part of the state of `T` (`R`).
- feat: add `context.watch<T>()` which allows widgets to listen to changes in the state of `T`
- feat: add `context.read<T>()` which allows widgets to access `T` without listening for changes
- deprecated: `context.bloc` in favor of `context.read` and `context.watch`
- deprecated: `context.repository` in favor of `context.read` and `context.watch`
- fix: rethrow `ProviderNotFoundException` from `RepositoryProvider` for external dependencies 
- docs: improve inline documentation for `BlocProvider` and `RepositoryProvider`

This closes #538 because `context.watch` with a `Builder` solves the `MultiBlocBuilder` issue

```dart
Builder(
  builder: (context) {
    final stateA = context.watch<BlocA>().state;
    final stateB = context.watch<BlocB>().state;
    final stateC = context.watch<BlocC>().state;

    // return a Widget which depends on the state of BlocA, BlocB, and BlocC
  }
);
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
