### PR TITLE
Allow user to force emit a new state

### DIFF
--- a/packages/bloc/lib/src/cubit.dart
+++ b/packages/bloc/lib/src/cubit.dart
@@ -78,7 +78,7 @@ abstract class Cubit<State> extends Stream<State> {
   /// {@endtemplate}
   @protected
   @visibleForTesting
-  void emit(State state,{bool force = false}) {
+  void emit(State state, {bool force = true}) {
     _controller ??= StreamController<State>.broadcast();
     if (_controller.isClosed) return;
     if (!force && state == _state && _emitted) return;

--- a/packages/bloc/lib/src/cubit.dart
+++ b/packages/bloc/lib/src/cubit.dart
@@ -78,10 +78,10 @@ abstract class Cubit<State> extends Stream<State> {
   /// {@endtemplate}
   @protected
   @visibleForTesting
-  void emit(State state) {
+  void emit(State state,{bool force = false}) {
     _controller ??= StreamController<State>.broadcast();
     if (_controller.isClosed) return;
-    if (state == _state && _emitted) return;
+    if (!force && state == _state && _emitted) return;
     onChange(Change<State>(currentState: this.state, nextState: state));
     _state = state;
     _controller.add(_state);


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

A new state will not be emitted if the previous_state == new_state. While this is usually the desired behavior. This doesn't work when I am using the super_enum package (https://pub.dev/packages/super_enum) to represent my different states.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
