### PR TITLE
fix(flutter_bloc): remove context.watch from BlocConsumer

### DIFF
--- a/packages/flutter_bloc/CHANGELOG.md
+++ b/packages/flutter_bloc/CHANGELOG.md
@@ -1,12 +1,16 @@
+# 6.1.1
+
+- fix: `BlocConsumer` does not respect `buildWhen` and results in unnecessary rebuilds
+
 # 6.1.0
 
 - feat: add optional `listen` to `BlocProvider` and `RepositoryProvider`
-- feat: add `context.select<T, R>(R Function(T value))` which allows widgets to listen to only a small part of the state of `T` (`R`).
+- feat: add `context.select<T, R>(R Function(T value))` which allows widgets to listen to only a small part of the state of `T` (`R`)
 - feat: add `context.watch<T>()` which allows widgets to listen to changes in the state of `T`
 - feat: add `context.read<T>()` which allows widgets to access `T` without listening for changes
 - deprecated: `context.bloc` in favor of `context.read` and `context.watch`
 - deprecated: `context.repository` in favor of `context.read` and `context.watch`
-- fix: rethrow `ProviderNotFoundException` from `RepositoryProvider` for external dependencies 
+- fix: rethrow `ProviderNotFoundException` from `RepositoryProvider` for external dependencies
 - docs: improve inline documentation for `BlocProvider` and `RepositoryProvider`
 - docs: update list of examples in `README`
 
@@ -24,7 +28,7 @@
 
 # 6.0.3
 
-- refactor: `BlocConsumer` requires a single subscriptionpwd
+- refactor: `BlocConsumer` requires a single subscription
 - refactor: `BlocBuilder` extends `BlocListener`
 - refactor: `MultiRepositoryProvider` extends `MultiProvider`
 

--- a/packages/flutter_bloc/lib/src/bloc_consumer.dart
+++ b/packages/flutter_bloc/lib/src/bloc_consumer.dart
@@ -62,7 +62,7 @@ import 'bloc_listener.dart';
 /// )
 /// ```
 /// {@endtemplate}
-class BlocConsumer<C extends Cubit<S>, S> extends StatelessWidget {
+class BlocConsumer<C extends Cubit<S>, S> extends StatefulWidget {
   /// {@macro bloc_consumer}
   const BlocConsumer({
     Key key,
@@ -101,16 +101,39 @@ class BlocConsumer<C extends Cubit<S>, S> extends StatelessWidget {
   final BlocListenerCondition<S> listenWhen;
 
   @override
+  State<BlocConsumer<C, S>> createState() => _BlocConsumerState<C, S>();
+}
+
+class _BlocConsumerState<C extends Cubit<S>, S>
+    extends State<BlocConsumer<C, S>> {
+  C _cubit;
+
+  @override
+  void initState() {
+    super.initState();
+    _cubit = widget.cubit ?? context.read<C>();
+  }
+
+  @override
+  void didUpdateWidget(BlocConsumer<C, S> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final oldCubit = oldWidget.cubit ?? context.read<C>();
+    final currentCubit = widget.cubit ?? oldCubit;
+    if (oldCubit != currentCubit) {
+      _cubit = currentCubit;
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final cubit = this.cubit ?? context.watch<C>();
     return BlocBuilder<C, S>(
-      cubit: cubit,
-      builder: builder,
+      cubit: _cubit,
+      builder: widget.builder,
       buildWhen: (previous, current) {
-        if (listenWhen?.call(previous, current) ?? true) {
-          listener(context, current);
+        if (widget.listenWhen?.call(previous, current) ?? true) {
+          widget.listener(context, current);
         }
-        return buildWhen?.call(previous, current) ?? true;
+        return widget.buildWhen?.call(previous, current) ?? true;
       },
     );
   }

--- a/packages/flutter_bloc/pubspec.yaml
+++ b/packages/flutter_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_bloc
 description: Flutter Widgets that make it easy to implement the BLoC (Business Logic Component) design pattern. Built to be used with the bloc state management package.
-version: 6.1.0
+version: 6.1.1
 repository: https://github.com/felangel/bloc/tree/master/packages/flutter_bloc
 issue_tracker: https://github.com/felangel/bloc/issues
 homepage: https://bloclibrary.dev


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->
- - fix: `BlocConsumer` does not respect `buildWhen` and results in unnecessary rebuilds (closes #1914)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
