### PR TITLE
Event from bloc added to chapter state changes in docs

### DIFF
--- a/docs/coreconcepts.md
+++ b/docs/coreconcepts.md
@@ -336,6 +336,8 @@ In the above snippet, we are switching on the incoming event and if it is an inc
 
 !> Blocs should never directly `emit` new states. Instead every state change must be output in response to an incoming event within `mapEventToState`.
 
+?> **Tip**: It is possible to add events inside the block. The authentication state from `authenticationRepository` is listened on in the constructor of `AuthenticationBloc` and adds events to change the state in the following example: [Firebase Login, Authentication Bloc](flutterfirebaselogintutorial.md#bloc). Adding events instead of states from a stream can solve issues with `yeld* _longStream();` blocking `mapEventToState` from emitting states until `_longStream();` is done.
+
 !> Both blocs and cubits will ignore duplicate states. If we yield or emit `State nextState` where `state == nextState`, then no state change will occur.
 
 ### Using a Bloc


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

This is just a proposal for how to make it easier for other new persons in similar a situations situation as me. I don't know if there is a need for it or if I'm right about number two. 

1. I got the impression that events only can be sent from the UI when i read the docs. Then I joined discord and realized that events can be sent from Bloc. I did not do the examples so this may not be a real issue.

2. I also added that `yield*` blocks `mapEventToState` from emitting states until the stream is done. I was playing around with `_mapLoadTodosToState()` in  [Firestore Todos](https://bloclibrary.dev/#/flutterfirestoretodostutorial?id=todos-bloc) and it looked like no states was emitted until the function returned `add(TodosUpdated(todos))`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
