### PR TITLE
Update authentication_repository.dart comment

### DIFF
--- a/examples/flutter_firebase_login/packages/authentication_repository/lib/src/authentication_repository.dart
+++ b/examples/flutter_firebase_login/packages/authentication_repository/lib/src/authentication_repository.dart
@@ -62,7 +62,7 @@ class AuthenticationRepository {
 
   /// Starts the Sign In with Google Flow.
   ///
-  /// Throws a [LogInWithEmailAndPasswordFailure] if an exception occurs.
+  /// Throws a [LogInWithGoogleFailure] if an exception occurs.
   Future<void> logInWithGoogle() async {
     try {
       final googleUser = await _googleSignIn.signIn();


### PR DESCRIPTION
Fixes incorrect statement/doc-comment on what `Exception` is thrown on `logInWithGoogle`.

_This is my first PR! Hopefully I did this correctly. 👍🏻_

## Status

**READY**

## Breaking Changes

NO

## Description

Was following the [firebase_login guide](https://bloclibrary.dev/#/flutterfirebaselogintutorial?id=repository) and noticed the doc comment was incorrect for the `logInWithGoogle()` method on `AuthenticationRepository`. It throws a `LogInWithGoogleFailure` exception and the comment says otherwise.

The comment was:

```dart
   /// Throws a [LogInWithEmailAndPasswordFailure] if an exception occurs.
   Future<void> logInWithGoogle() async {
```

The comment should be:

```dart
   /// Throws a [LogInWithGoogleFailure] if an exception occurs.
   Future<void> logInWithGoogle() async {
```


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
