### PR TITLE
Remove @visibleForTesting annotation on emit

### DIFF
--- a/docs/coreconcepts.md
+++ b/docs/coreconcepts.md
@@ -334,7 +334,7 @@ In the above snippet, we are switching on the incoming event and if it is an inc
 
 ?> **Note**: Since the `Bloc` class extends `Cubit`, we have access to the current state of the bloc at any point in time via the `state` getter.
 
-!> Blocs should never directly `emit` new states. Instead every state change must be output in response to an incoming event within `mapEventToState`.
+!> Code that uses Blocs should never directly invoke `emit()` to emit new states. Instead every state change must be output in response to an incoming event within `mapEventToState` or in response to an internal state change (e.g.: the user signed in or out).
 
 !> Both blocs and cubits will ignore duplicate states. If we yield or emit `State nextState` where `state == nextState`, then no state change will occur.
 

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -215,12 +215,12 @@ abstract class Bloc<Event, State> extends Cubit<State>
     return super.close();
   }
 
-  /// **[emit] should never be used outside of tests.**
+  /// **[emit] should only be used inside a bloc.**
   ///
   /// Updates the state of the bloc to the provided [state].
   /// A bloc's state should only be updated by `yielding` a new `state`
-  /// from `mapEventToState` in response to an event.
-  @visibleForTesting
+  /// from `mapEventToState` in response to an event, or if an underlying state
+  /// (e.g.: authentication state) changes.
   @override
   void emit(State state) => super.emit(state);
 

--- a/packages/bloc/lib/src/cubit.dart
+++ b/packages/bloc/lib/src/cubit.dart
@@ -77,7 +77,6 @@ abstract class Cubit<State> extends Stream<State> {
   /// as it is the first thing emitted by the [Cubit].
   /// {@endtemplate}
   @protected
-  @visibleForTesting
   void emit(State state) {
     _controller ??= StreamController<State>.broadcast();
     if (_controller.isClosed) return;


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

As discussed in #1980 . I think that `emit()` should only be `@protected` and not `@visibleForTesting` since there are cases where emitting a state without being a direct response of a user event is perfectly reasonable.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [x] 🗑️ Chore
