### PR TITLE
docs: update fluttertodostutorial.md to fix typo

### DIFF
--- a/docs/fluttertodostutorial.md
+++ b/docs/fluttertodostutorial.md
@@ -81,7 +81,7 @@ Next, let's implement the events we will need to handle.
 The events we will need to handle in our `TodosBloc` are:
 
 - `TodosLoadSuccess` - tells the bloc that it needs to load the todos from the `TodosRepository`.
-- `TodoAdded` - tells the bloc that it needs to add an new todo to the list of todos.
+- `TodoAdded` - tells the bloc that it needs to add a new todo to the list of todos.
 - `TodoUpdated` - tells the bloc that it needs to update an existing todo.
 - `TodoDeleted` - tells the bloc that it needs to remove an existing todo.
 - `ClearCompleted` - tells the bloc that it needs to remove all completed todos.


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

Fixed a typo where 'an' is used before a noun starting with a consonant sound.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
