### PR TITLE
docs: [CONTRIBUTING.md] http.server instead of SimpleHTTPServer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ that your changes look good by running the docs locally.
 cd ./docs
 
 # run a local http server on port 8080
-python -m SimpleHTTPServer 8080 .
+python -m http.server 8080 .
 
 # navigate to http://localhost:8080
 ```


### PR DESCRIPTION
## Status

READY

## Breaking Changes

NO

## Description

The SimpleHTTPServer module has been merged into http.server in Python 3.0. The Python 3 equivalent of SimpleHTTPServer is http.server

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
