### PR TITLE
Exporting mocktail from bloc_test

### DIFF
--- a/packages/bloc_test/lib/bloc_test.dart
+++ b/packages/bloc_test/lib/bloc_test.dart
@@ -1,5 +1,7 @@
 library bloc_test;
 
+export 'package:mocktail/mocktail.dart';
+
 export 'src/bloc_test.dart';
 export 'src/mock_bloc.dart';
 export 'src/when_listen.dart';

--- a/packages/bloc_test/pubspec.yaml
+++ b/packages/bloc_test/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   bloc: ^7.0.0
   meta: ^1.3.0
-  mocktail: ^0.1.0
+  mocktail: ^0.1.1
   test: ^1.16.0
 
 dev_dependencies:


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

I have simply added the `export 'package:mocktail/mocktail.dart';` in the `bloc_test` package because when writing tests for a bloc, you need (for example) to call `registerFallbackValue` (which is part of mocktail). In this way:

  - you can only use `import 'package:bloc_test/bloc_test.dart';` and Dart will automatically import mocktail too
  - the developer has only 1 dependency to update (bloc_test) rather than 2 (bloc_test AND mocktail)

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
