### PR TITLE
feature(vscode): change name of the generated folder when creating a bloc/cubit

### DIFF
--- a/extensions/vscode/src/commands/new-bloc.command.ts
+++ b/extensions/vscode/src/commands/new-bloc.command.ts
@@ -72,7 +72,7 @@ async function generateBlocCode(
   targetDirectory: string,
   type: BlocType
 ) {
-  const blocDirectoryPath = `${targetDirectory}/bloc`;
+  const blocDirectoryPath = `${targetDirectory}/${blocName}`;
   if (!existsSync(blocDirectoryPath)) {
     await createDirectory(blocDirectoryPath);
   }

--- a/extensions/vscode/src/commands/new-cubit.command.ts
+++ b/extensions/vscode/src/commands/new-cubit.command.ts
@@ -68,7 +68,7 @@ async function generateCubitCode(
   targetDirectory: string,
   type: BlocType
 ) {
-  const cubitDirectoryPath = `${targetDirectory}/cubit`;
+  const cubitDirectoryPath = `${targetDirectory}/${cubitName}`;
   if (!existsSync(cubitDirectoryPath)) {
     await createDirectory(cubitDirectoryPath);
   }


### PR DESCRIPTION
## Status

READY

## Breaking Changes

 NO

## Description

Change the name of the generated folder (when creating a block/cubit) by the extension of vscode by the name of the cubit/block.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
