### PR TITLE
fix(extensions): Update override props method to have return type List of nullable objects.

### DIFF
--- a/extensions/intellij/intellij_generator_plugin/src/main/resources/liveTemplates/Bloc.xml
+++ b/extensions/intellij/intellij_generator_plugin/src/main/resources/liveTemplates/Bloc.xml
@@ -87,7 +87,7 @@
         </context>
     </template>
     <template name="blocevent"
-              value="class $Subject$$Noun$$Verb$ extends $Subject$Event {&#10;  const $Subject$$Noun$$Verb$();&#10;&#10;  &#10;&#10;  @override&#10;  List&lt;Object&gt; get props =&gt; [];&#10;}"
+              value="class $Subject$$Noun$$Verb$ extends $Subject$Event {&#10;  const $Subject$$Noun$$Verb$();&#10;&#10;  &#10;&#10;  @override&#10;  List&lt;Object?&gt; get props =&gt; [];&#10;}"
               description="bloc event class" toReformat="true" toShortenFQNames="true">
         <variable name="Subject" expression="" defaultValue="&quot;Subject&quot;" alwaysStopAt="true"/>
         <variable name="Noun" expression="" defaultValue="&quot;Noun&quot;" alwaysStopAt="true"/>
@@ -105,7 +105,7 @@
         </context>
     </template>
     <template name="blocstate"
-              value="class $Subject$$Verb$State extends $Subject$State {&#10;  const $Subject$$Verb$State();&#10;&#10;  &#10;&#10;  @override&#10;  List&lt;Object&gt; get props =&gt; [];&#10;}"
+              value="class $Subject$$Verb$State extends $Subject$State {&#10;  const $Subject$$Verb$State();&#10;&#10;  &#10;&#10;  @override&#10;  List&lt;Object?&gt; get props =&gt; [];&#10;}"
               description="bloc state class" toReformat="true" toShortenFQNames="true">
         <variable name="Subject" expression="" defaultValue="&quot;Subject&quot;" alwaysStopAt="true"/>
         <variable name="Verb" expression="" defaultValue="&quot;Verb&quot;" alwaysStopAt="true"/>

--- a/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/bloc_with_equatable/bloc_state.dart.template
+++ b/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/bloc_with_equatable/bloc_state.dart.template
@@ -6,5 +6,5 @@ abstract class ${bloc_pascal_case}State extends Equatable {
 
 class ${bloc_pascal_case}Initial extends ${bloc_pascal_case}State {
   @override
-  List<Object> get props => [];
+  List<Object?> get props => [];
 }

--- a/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/cubit_with_equatable/cubit_state.dart.template
+++ b/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/cubit_with_equatable/cubit_state.dart.template
@@ -6,5 +6,5 @@ abstract class ${cubit_pascal_case}State extends Equatable {
 
 class ${cubit_pascal_case}Initial extends ${cubit_pascal_case}State {
   @override
-  List<Object> get props => [];
+  List<Object?> get props => [];
 }

--- a/extensions/vscode/snippets/bloc.json
+++ b/extensions/vscode/snippets/bloc.json
@@ -61,7 +61,7 @@
       "\t$4",
       "",
       "\t@override",
-      "\tList<Object> get props => [$6];",
+      "\tList<Object?> get props => [$6];",
       "}"
     ],
     "description": "Subject + Verb (action) + State"
@@ -75,7 +75,7 @@
       "\t$4",
       "",
       "\t@override",
-      "\tList<Object> get props => [$6];",
+      "\tList<Object?> get props => [$6];",
       "}"
     ],
     "description": "Subject + Noun (optional) + Verb (event)"

--- a/extensions/vscode/src/templates/bloc-event.template.ts
+++ b/extensions/vscode/src/templates/bloc-event.template.ts
@@ -21,7 +21,7 @@ abstract class ${pascalCaseBlocName}Event extends Equatable {
   const ${pascalCaseBlocName}Event();
 
   @override
-  List<Object> get props => [];
+  List<Object?> get props => [];
 }
 `;
 }

--- a/extensions/vscode/src/templates/bloc-state.template.ts
+++ b/extensions/vscode/src/templates/bloc-state.template.ts
@@ -21,7 +21,7 @@ abstract class ${pascalCaseBlocName}State extends Equatable {
   const ${pascalCaseBlocName}State();
   
   @override
-  List<Object> get props => [];
+  List<Object?> get props => [];
 }
 
 class ${pascalCaseBlocName}Initial extends ${pascalCaseBlocName}State {}

--- a/extensions/vscode/src/templates/cubit-state.template.ts
+++ b/extensions/vscode/src/templates/cubit-state.template.ts
@@ -24,7 +24,7 @@ abstract class ${pascalCaseCubitName}State extends Equatable {
   const ${pascalCaseCubitName}State();
 
   @override
-  List<Object> get props => [];
+  List<Object?> get props => [];
 }
 
 class ${pascalCaseCubitName}Initial extends ${pascalCaseCubitName}State {}


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

 The snippet/templates of bloc events and bloc state has the method overriding props with return type List<Object>. I change it to List<Object?> because the props can be null sometimes. 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
