### PR TITLE
fix(flutter_bloc): Add dependency to bloc instance for BlocBuilder/BlocListener/BlocConsumer

### DIFF
--- a/packages/flutter_bloc/lib/src/bloc_builder.dart
+++ b/packages/flutter_bloc/lib/src/bloc_builder.dart
@@ -135,10 +135,9 @@ class _BlocBuilderBaseState<B extends BlocBase<S>, S>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    final newBloc = widget.bloc ?? context.read<B>();
-    if (_bloc != newBloc) {
-      _bloc = newBloc;
+    final bloc = widget.bloc ?? context.read<B>();
+    if (_bloc != bloc) {
+      _bloc = bloc;
       _state = _bloc.state;
     }
   }
@@ -156,10 +155,7 @@ class _BlocBuilderBaseState<B extends BlocBase<S>, S>
 
   @override
   Widget build(BuildContext context) {
-    if (widget.bloc == null) {
-      context.select<B, int>((bloc) => bloc.hashCode);
-    }
-
+    if (widget.bloc == null) context.select<B, int>(identityHashCode);
     return BlocListener<B, S>(
       bloc: _bloc,
       listenWhen: widget.buildWhen,

--- a/packages/flutter_bloc/lib/src/bloc_builder.dart
+++ b/packages/flutter_bloc/lib/src/bloc_builder.dart
@@ -136,7 +136,7 @@ class _BlocBuilderBaseState<B extends BlocBase<S>, S>
   void didChangeDependencies() {
     super.didChangeDependencies();
 
-    final newBloc = widget.bloc ?? context.watch<B>();
+    final newBloc = widget.bloc ?? context.read<B>();
     if (_bloc != newBloc) {
       _bloc = newBloc;
       _state = _bloc.state;
@@ -146,7 +146,7 @@ class _BlocBuilderBaseState<B extends BlocBase<S>, S>
   @override
   void didUpdateWidget(BlocBuilderBase<B, S> oldWidget) {
     super.didUpdateWidget(oldWidget);
-    final oldBloc = oldWidget.bloc ?? context.watch<B>();
+    final oldBloc = oldWidget.bloc ?? context.read<B>();
     final currentBloc = widget.bloc ?? oldBloc;
     if (oldBloc != currentBloc) {
       _bloc = currentBloc;
@@ -156,6 +156,10 @@ class _BlocBuilderBaseState<B extends BlocBase<S>, S>
 
   @override
   Widget build(BuildContext context) {
+    if (widget.bloc == null) {
+      context.select<B, int>((bloc) => bloc.hashCode);
+    }
+
     return BlocListener<B, S>(
       bloc: _bloc,
       listenWhen: widget.buildWhen,

--- a/packages/flutter_bloc/lib/src/bloc_builder.dart
+++ b/packages/flutter_bloc/lib/src/bloc_builder.dart
@@ -133,9 +133,20 @@ class _BlocBuilderBaseState<B extends BlocBase<S>, S>
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    final newBloc = widget.bloc ?? context.watch<B>();
+    if (_bloc != newBloc) {
+      _bloc = newBloc;
+      _state = _bloc.state;
+    }
+  }
+
+  @override
   void didUpdateWidget(BlocBuilderBase<B, S> oldWidget) {
     super.didUpdateWidget(oldWidget);
-    final oldBloc = oldWidget.bloc ?? context.read<B>();
+    final oldBloc = oldWidget.bloc ?? context.watch<B>();
     final currentBloc = widget.bloc ?? oldBloc;
     if (oldBloc != currentBloc) {
       _bloc = currentBloc;

--- a/packages/flutter_bloc/lib/src/bloc_consumer.dart
+++ b/packages/flutter_bloc/lib/src/bloc_consumer.dart
@@ -115,27 +115,19 @@ class _BlocConsumerState<B extends BlocBase<S>, S>
     super.didUpdateWidget(oldWidget);
     final oldBloc = oldWidget.bloc ?? context.read<B>();
     final currentBloc = widget.bloc ?? oldBloc;
-    if (oldBloc != currentBloc) {
-      _bloc = currentBloc;
-    }
+    if (oldBloc != currentBloc) _bloc = currentBloc;
   }
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    final newBloc = widget.bloc ?? context.read<B>();
-    if (_bloc != newBloc) {
-      _bloc = newBloc;
-    }
+    final bloc = widget.bloc ?? context.read<B>();
+    if (_bloc != bloc) _bloc = bloc;
   }
 
   @override
   Widget build(BuildContext context) {
-    if (widget.bloc == null) {
-      context.select<B, int>((bloc) => bloc.hashCode);
-    }
-
+    if (widget.bloc == null) context.select<B, int>(identityHashCode);
     return BlocBuilder<B, S>(
       bloc: _bloc,
       builder: widget.builder,

--- a/packages/flutter_bloc/lib/src/bloc_consumer.dart
+++ b/packages/flutter_bloc/lib/src/bloc_consumer.dart
@@ -113,10 +113,20 @@ class _BlocConsumerState<B extends BlocBase<S>, S>
   @override
   void didUpdateWidget(BlocConsumer<B, S> oldWidget) {
     super.didUpdateWidget(oldWidget);
-    final oldBloc = oldWidget.bloc ?? context.read<B>();
+    final oldBloc = oldWidget.bloc ?? context.watch<B>();
     final currentBloc = widget.bloc ?? oldBloc;
     if (oldBloc != currentBloc) {
       _bloc = currentBloc;
+    }
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    final newBloc = widget.bloc ?? context.watch<B>();
+    if (_bloc != newBloc) {
+      _bloc = newBloc;
     }
   }
 

--- a/packages/flutter_bloc/lib/src/bloc_consumer.dart
+++ b/packages/flutter_bloc/lib/src/bloc_consumer.dart
@@ -113,7 +113,7 @@ class _BlocConsumerState<B extends BlocBase<S>, S>
   @override
   void didUpdateWidget(BlocConsumer<B, S> oldWidget) {
     super.didUpdateWidget(oldWidget);
-    final oldBloc = oldWidget.bloc ?? context.watch<B>();
+    final oldBloc = oldWidget.bloc ?? context.read<B>();
     final currentBloc = widget.bloc ?? oldBloc;
     if (oldBloc != currentBloc) {
       _bloc = currentBloc;
@@ -124,7 +124,7 @@ class _BlocConsumerState<B extends BlocBase<S>, S>
   void didChangeDependencies() {
     super.didChangeDependencies();
 
-    final newBloc = widget.bloc ?? context.watch<B>();
+    final newBloc = widget.bloc ?? context.read<B>();
     if (_bloc != newBloc) {
       _bloc = newBloc;
     }
@@ -132,6 +132,10 @@ class _BlocConsumerState<B extends BlocBase<S>, S>
 
   @override
   Widget build(BuildContext context) {
+    if (widget.bloc == null) {
+      context.select<B, int>((bloc) => bloc.hashCode);
+    }
+
     return BlocBuilder<B, S>(
       bloc: _bloc,
       builder: widget.builder,

--- a/packages/flutter_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/bloc_listener.dart
@@ -154,12 +154,11 @@ class _BlocListenerBaseState<B extends BlocBase<S>, S>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    final newBloc = widget.bloc ?? context.read<B>();
-    if (_bloc != newBloc) {
+    final bloc = widget.bloc ?? context.read<B>();
+    if (_bloc != bloc) {
       if (_subscription != null) {
         _unsubscribe();
-        _bloc = newBloc;
+        _bloc = bloc;
         _previousState = _bloc.state;
       }
       _subscribe();
@@ -183,10 +182,7 @@ class _BlocListenerBaseState<B extends BlocBase<S>, S>
 
   @override
   Widget buildWithChild(BuildContext context, Widget? child) {
-    if (widget.bloc == null) {
-      context.select<B, int>((bloc) => bloc.hashCode);
-    }
-
+    if (widget.bloc == null) context.select<B, int>(identityHashCode);
     return child!;
   }
 

--- a/packages/flutter_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/bloc_listener.dart
@@ -152,9 +152,24 @@ class _BlocListenerBaseState<B extends BlocBase<S>, S>
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    final newBloc = widget.bloc ?? context.watch<B>();
+    if (_bloc != newBloc) {
+      if (_subscription != null) {
+        _unsubscribe();
+        _bloc = newBloc;
+        _previousState = _bloc.state;
+      }
+      _subscribe();
+    }
+  }
+
+  @override
   void didUpdateWidget(BlocListenerBase<B, S> oldWidget) {
     super.didUpdateWidget(oldWidget);
-    final oldBloc = oldWidget.bloc ?? context.read<B>();
+    final oldBloc = oldWidget.bloc ?? context.watch<B>();
     final currentBloc = widget.bloc ?? oldBloc;
     if (oldBloc != currentBloc) {
       if (_subscription != null) {

--- a/packages/flutter_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/bloc_listener.dart
@@ -155,7 +155,7 @@ class _BlocListenerBaseState<B extends BlocBase<S>, S>
   void didChangeDependencies() {
     super.didChangeDependencies();
 
-    final newBloc = widget.bloc ?? context.watch<B>();
+    final newBloc = widget.bloc ?? context.read<B>();
     if (_bloc != newBloc) {
       if (_subscription != null) {
         _unsubscribe();
@@ -169,7 +169,7 @@ class _BlocListenerBaseState<B extends BlocBase<S>, S>
   @override
   void didUpdateWidget(BlocListenerBase<B, S> oldWidget) {
     super.didUpdateWidget(oldWidget);
-    final oldBloc = oldWidget.bloc ?? context.watch<B>();
+    final oldBloc = oldWidget.bloc ?? context.read<B>();
     final currentBloc = widget.bloc ?? oldBloc;
     if (oldBloc != currentBloc) {
       if (_subscription != null) {
@@ -182,7 +182,13 @@ class _BlocListenerBaseState<B extends BlocBase<S>, S>
   }
 
   @override
-  Widget buildWithChild(BuildContext context, Widget? child) => child!;
+  Widget buildWithChild(BuildContext context, Widget? child) {
+    if (widget.bloc == null) {
+      context.select<B, int>((bloc) => bloc.hashCode);
+    }
+
+    return child!;
+  }
 
   @override
   void dispose() {

--- a/packages/flutter_bloc/test/bloc_builder_test.dart
+++ b/packages/flutter_bloc/test/bloc_builder_test.dart
@@ -467,5 +467,42 @@ void main() {
       await tester.pumpAndSettle();
       expect(states, [0, 2, 2]);
     });
+
+    testWidgets('rebuilds when provided bloc is changed', (tester) async {
+      final firstCounterCubit = CounterCubit();
+      final secondCounterCubit = CounterCubit()..emit(100);
+
+      await tester.pumpWidget(
+        Directionality(
+            textDirection: TextDirection.ltr,
+            child: BlocProvider.value(
+              value: firstCounterCubit,
+              child: BlocBuilder<CounterCubit, int>(
+                builder: (context, state) => Text('This is $state'),
+              ),
+            )),
+      );
+
+      expect(find.text('This is 0'), findsOneWidget);
+
+      await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: BlocProvider.value(
+          value: secondCounterCubit,
+          child: BlocBuilder<CounterCubit, int>(
+            builder: (context, state) => Text('This is $state'),
+          ),
+        ),
+      ));
+
+      expect(find.text('This is 100'), findsOneWidget);
+      expect(find.text('This is 0'), findsNothing);
+
+      secondCounterCubit.increment();
+      await tester.pumpAndSettle();
+
+      expect(find.text('This is 101'), findsOneWidget);
+      expect(find.text('This is 0'), findsNothing);
+    });
   });
 }

--- a/packages/flutter_bloc/test/bloc_builder_test.dart
+++ b/packages/flutter_bloc/test/bloc_builder_test.dart
@@ -486,6 +486,11 @@ void main() {
 
       expect(find.text('Count 0'), findsOneWidget);
 
+      firstCounterCubit.increment();
+      await tester.pumpAndSettle();
+      expect(find.text('Count 1'), findsOneWidget);
+      expect(find.text('Count 0'), findsNothing);
+
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
@@ -499,7 +504,7 @@ void main() {
       );
 
       expect(find.text('Count 100'), findsOneWidget);
-      expect(find.text('Count 0'), findsNothing);
+      expect(find.text('Count 1'), findsNothing);
 
       secondCounterCubit.increment();
       await tester.pumpAndSettle();

--- a/packages/flutter_bloc/test/bloc_builder_test.dart
+++ b/packages/flutter_bloc/test/bloc_builder_test.dart
@@ -474,35 +474,37 @@ void main() {
 
       await tester.pumpWidget(
         Directionality(
-            textDirection: TextDirection.ltr,
-            child: BlocProvider.value(
-              value: firstCounterCubit,
-              child: BlocBuilder<CounterCubit, int>(
-                builder: (context, state) => Text('This is $state'),
-              ),
-            )),
-      );
-
-      expect(find.text('This is 0'), findsOneWidget);
-
-      await tester.pumpWidget(Directionality(
-        textDirection: TextDirection.ltr,
-        child: BlocProvider.value(
-          value: secondCounterCubit,
-          child: BlocBuilder<CounterCubit, int>(
-            builder: (context, state) => Text('This is $state'),
+          textDirection: TextDirection.ltr,
+          child: BlocProvider.value(
+            value: firstCounterCubit,
+            child: BlocBuilder<CounterCubit, int>(
+              builder: (context, state) => Text('Count $state'),
+            ),
           ),
         ),
-      ));
+      );
 
-      expect(find.text('This is 100'), findsOneWidget);
-      expect(find.text('This is 0'), findsNothing);
+      expect(find.text('Count 0'), findsOneWidget);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: BlocProvider.value(
+            value: secondCounterCubit,
+            child: BlocBuilder<CounterCubit, int>(
+              builder: (context, state) => Text('Count $state'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Count 100'), findsOneWidget);
+      expect(find.text('Count 0'), findsNothing);
 
       secondCounterCubit.increment();
       await tester.pumpAndSettle();
 
-      expect(find.text('This is 101'), findsOneWidget);
-      expect(find.text('This is 0'), findsNothing);
+      expect(find.text('Count 101'), findsOneWidget);
     });
   });
 }

--- a/packages/flutter_bloc/test/bloc_consumer_test.dart
+++ b/packages/flutter_bloc/test/bloc_consumer_test.dart
@@ -346,8 +346,9 @@ void main() {
       expect(listenWhenCurrentState, [3]);
     });
 
-    testWidgets('rebuilds and resubscribes when provided bloc is changed',
-        (tester) async {
+    testWidgets(
+        'rebuilds and updates subscription '
+        'when provided bloc is changed', (tester) async {
       final firstCounterCubit = CounterCubit();
       final secondCounterCubit = CounterCubit()..emit(100);
 
@@ -373,6 +374,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Count 1'), findsOneWidget);
+      expect(find.text('Count 0'), findsNothing);
 
       await tester.pumpWidget(
         Directionality(

--- a/packages/flutter_bloc/test/bloc_consumer_test.dart
+++ b/packages/flutter_bloc/test/bloc_consumer_test.dart
@@ -345,5 +345,56 @@ void main() {
       expect(listenWhenPreviousState, [2]);
       expect(listenWhenCurrentState, [3]);
     });
+
+    testWidgets('rebuilds and resubscribes when provided bloc is changed',
+        (tester) async {
+      final firstCounterCubit = CounterCubit();
+      final secondCounterCubit = CounterCubit()..emit(100);
+
+      final states = <int>[];
+      const expectedStates = [1, 101];
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: BlocProvider.value(
+            value: firstCounterCubit,
+            child: BlocConsumer<CounterCubit, int>(
+              listener: (_, state) => states.add(state),
+              builder: (context, state) => Text('Count $state'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Count 0'), findsOneWidget);
+
+      firstCounterCubit.increment();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Count 1'), findsOneWidget);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: BlocProvider.value(
+            value: secondCounterCubit,
+            child: BlocConsumer<CounterCubit, int>(
+              listener: (_, state) => states.add(state),
+              builder: (context, state) => Text('Count $state'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Count 100'), findsOneWidget);
+      expect(find.text('Count 1'), findsNothing);
+
+      secondCounterCubit.increment();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Count 101'), findsOneWidget);
+      expect(states, expectedStates);
+    });
   });
 }

--- a/packages/flutter_bloc/test/bloc_listener_test.dart
+++ b/packages/flutter_bloc/test/bloc_listener_test.dart
@@ -439,5 +439,42 @@ void main() {
 
       expect(states, expectedStates);
     });
+
+    testWidgets('resubscribes when provided bloc is changed', (tester) async {
+      final firstCounterCubit = CounterCubit();
+      final secondCounterCubit = CounterCubit()..emit(100);
+
+      final states = <int>[];
+      const expectedStates = [1, 101];
+
+      await tester.pumpWidget(
+        BlocProvider.value(
+          value: firstCounterCubit,
+          child: BlocListener<CounterCubit, int>(
+            listener: (_, state) => states.add(state),
+            child: const SizedBox(),
+          ),
+        ),
+      );
+
+      firstCounterCubit.increment();
+
+      await tester.pumpWidget(
+        BlocProvider.value(
+          value: secondCounterCubit,
+          child: BlocListener<CounterCubit, int>(
+            listener: (_, state) => states.add(state),
+            child: const SizedBox(),
+          ),
+        ),
+      );
+
+      secondCounterCubit.increment();
+      await tester.pump();
+      firstCounterCubit.increment();
+      await tester.pump();
+
+      expect(states, expectedStates);
+    });
   });
 }

--- a/packages/flutter_bloc/test/bloc_listener_test.dart
+++ b/packages/flutter_bloc/test/bloc_listener_test.dart
@@ -440,7 +440,9 @@ void main() {
       expect(states, expectedStates);
     });
 
-    testWidgets('resubscribes when provided bloc is changed', (tester) async {
+    testWidgets(
+        'updates subscription '
+        'when provided bloc is changed', (tester) async {
       final firstCounterCubit = CounterCubit();
       final secondCounterCubit = CounterCubit()..emit(100);
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description
Fixes #2127
Closes https://github.com/felangel/bloc/pull/2181

To make a builder, listener or consumer update when the instance is changed we need a context dependency. However we can't use normal `context.watch` because BlocProvider uses a custom provider which also updates dependents when state is changed, therefore it would make `buildWhen` useless. Ideally we would reverse that, but that would also break compatibility. Adding another "normal" provider is also not an option since provider does not allow it and integrating special InheritedWidget is tricky.

There is a concept of "aspect" when it comes to dependencies. Provider exposes it by `context.select`, but it is a bit different   and it can't be used in `didUpdateDependencies`, but we can put it in build and use it to target only the changes of the instance by retrieving hashCode.

I think for people who doesn't change instances in the runtime this makes almost no difference apart from dependency.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
