### PR TITLE
feat(replay_bloc): filter which states are saved to the undo stack

### DIFF
--- a/packages/replay_bloc/lib/src/change_stack.dart
+++ b/packages/replay_bloc/lib/src/change_stack.dart
@@ -45,12 +45,9 @@ class _ChangeStack<T> {
   void undo() {
     if (canUndo) {
       final change = _history.removeLast();
-      if (_shouldReplay(change._oldValue)) {
-        change.undo();
-        _redos.addFirst(change);
-      } else {
-        undo();
-      }
+      if (!_shouldReplay(change._oldValue)) return undo();
+      change.undo();
+      _redos.addFirst(change);
     }
   }
 }

--- a/packages/replay_bloc/lib/src/replay_bloc.dart
+++ b/packages/replay_bloc/lib/src/replay_bloc.dart
@@ -8,13 +8,13 @@ abstract class ReplayEvent {
   const ReplayEvent();
 }
 
-/// Notifies a [ReplayBloc] of a Redo
+/// Notifies a [ReplayBloc] of a Redo.
 class _Redo extends ReplayEvent {
   @override
   String toString() => 'Redo';
 }
 
-/// Notifies a [ReplayBloc] of an Undo
+/// Notifies a [ReplayBloc] of an Undo.
 class _Undo extends ReplayEvent {
   @override
   String toString() => 'Undo';
@@ -131,24 +131,24 @@ mixin ReplayBlocMixin<Event extends ReplayEvent, State> on Bloc<Event, State> {
     super.emit(state);
   }
 
-  /// Undo the last change
+  /// Undo the last change.
   void undo() => _changeStack.undo();
 
-  /// Redo the previous change
+  /// Redo the previous change.
   void redo() => _changeStack.redo();
 
-  /// Checks whether the undo/redo stack is empty
+  /// Checks whether the undo/redo stack is empty.
   bool get canUndo => _changeStack.canUndo;
 
-  /// Checks wether the undo/redo stack is at the current change
+  /// Checks wether the undo/redo stack is at the current change.
   bool get canRedo => _changeStack.canRedo;
 
-  /// Clear undo/redo history
+  /// Clear undo/redo history.
   void clearHistory() => _changeStack.clear();
 
-  /// Checks whether the given state should be replayed from the undo/redo stack
+  /// Checks whether the given state should be replayed from the undo/redo stack.
   ///
-  /// This is called at the time the state is being restored. By default
-  /// always returns `true`
+  /// This is called at the time the state is being restored.
+  /// By default [shouldReplay] always returns `true`.
   bool shouldReplay(State state) => true;
 }

--- a/packages/replay_bloc/lib/src/replay_bloc.dart
+++ b/packages/replay_bloc/lib/src/replay_bloc.dart
@@ -104,6 +104,7 @@ mixin ReplayBlocMixin<Event extends ReplayEvent, State> on Bloc<Event, State> {
   void emit(State state) {
     _changeStack.add(_Change<State>(
       this.state,
+      state,
       () {
         final event = _Redo();
         onEvent(event);

--- a/packages/replay_bloc/lib/src/replay_bloc.dart
+++ b/packages/replay_bloc/lib/src/replay_bloc.dart
@@ -102,31 +102,33 @@ mixin ReplayBlocMixin<Event extends ReplayEvent, State> on Bloc<Event, State> {
 
   @override
   void emit(State state) {
-    _changeStack.add(_Change<State>(
-      this.state,
-      () {
-        final event = _Redo();
-        onEvent(event);
-        onTransition(Transition(
-          currentState: this.state,
-          event: event,
-          nextState: state,
-        ));
-        // ignore: invalid_use_of_visible_for_testing_member
-        super.emit(state);
-      },
-      (val) {
-        final event = _Undo();
-        onEvent(event);
-        onTransition(Transition(
-          currentState: this.state,
-          event: event,
-          nextState: val,
-        ));
-        // ignore: invalid_use_of_visible_for_testing_member
-        super.emit(val);
-      },
-    ));
+    if (shouldReplay(this.state)) {
+      _changeStack.add(_Change<State>(
+        this.state,
+        () {
+          final event = _Redo();
+          onEvent(event);
+          onTransition(Transition(
+            currentState: this.state,
+            event: event,
+            nextState: state,
+          ));
+          // ignore: invalid_use_of_visible_for_testing_member
+          super.emit(state);
+        },
+        (val) {
+          final event = _Undo();
+          onEvent(event);
+          onTransition(Transition(
+            currentState: this.state,
+            event: event,
+            nextState: val,
+          ));
+          // ignore: invalid_use_of_visible_for_testing_member
+          super.emit(val);
+        },
+      ));
+    }
     // ignore: invalid_use_of_visible_for_testing_member
     super.emit(state);
   }
@@ -145,4 +147,9 @@ mixin ReplayBlocMixin<Event extends ReplayEvent, State> on Bloc<Event, State> {
 
   /// Clear undo/redo history
   void clearHistory() => _changeStack.clear();
+
+  /// Checks whether the given state should be saved to the undo/redo stack.
+  ///
+  /// By default always returns `true`.
+  bool shouldReplay(State state) => true;
 }

--- a/packages/replay_bloc/lib/src/replay_cubit.dart
+++ b/packages/replay_bloc/lib/src/replay_cubit.dart
@@ -56,7 +56,7 @@ abstract class ReplayCubit<State> extends Cubit<State>
 /// A mixin which enables `undo` and `redo` operations
 /// for [Cubit] classes.
 mixin ReplayCubitMixin<State> on Cubit<State> {
-  final _changeStack = _ChangeStack<State>();
+  late final _changeStack = _ChangeStack<State>(shouldReplay: shouldReplay);
 
   /// Sets the internal `undo`/`redo` size limit.
   /// By default there is no limit.
@@ -64,13 +64,11 @@ mixin ReplayCubitMixin<State> on Cubit<State> {
 
   @override
   void emit(State state) {
-    if (shouldReplay(this.state)) {
-      _changeStack.add(_Change<State>(
-        this.state,
-        () => super.emit(state),
-        (val) => super.emit(val),
-      ));
-    }
+    _changeStack.add(_Change<State>(
+      this.state,
+      () => super.emit(state),
+      (val) => super.emit(val),
+    ));
     super.emit(state);
   }
 
@@ -89,8 +87,9 @@ mixin ReplayCubitMixin<State> on Cubit<State> {
   /// Clear undo/redo history
   void clearHistory() => _changeStack.clear();
 
-  /// Checks whether the given state should be saved to the undo/redo stack.
+  /// Checks whether the given state should be replayed from the undo/redo stack
   ///
-  /// By default always returns `true`.
+  /// This is called at the time the state is being restored. By default
+  /// always returns `true`
   bool shouldReplay(State state) => true;
 }

--- a/packages/replay_bloc/lib/src/replay_cubit.dart
+++ b/packages/replay_bloc/lib/src/replay_cubit.dart
@@ -66,6 +66,7 @@ mixin ReplayCubitMixin<State> on Cubit<State> {
   void emit(State state) {
     _changeStack.add(_Change<State>(
       this.state,
+      state,
       () => super.emit(state),
       (val) => super.emit(val),
     ));

--- a/packages/replay_bloc/lib/src/replay_cubit.dart
+++ b/packages/replay_bloc/lib/src/replay_cubit.dart
@@ -64,11 +64,13 @@ mixin ReplayCubitMixin<State> on Cubit<State> {
 
   @override
   void emit(State state) {
-    _changeStack.add(_Change<State>(
-      this.state,
-      () => super.emit(state),
-      (val) => super.emit(val),
-    ));
+    if (shouldReplay(this.state)) {
+      _changeStack.add(_Change<State>(
+        this.state,
+        () => super.emit(state),
+        (val) => super.emit(val),
+      ));
+    }
     super.emit(state);
   }
 
@@ -81,9 +83,14 @@ mixin ReplayCubitMixin<State> on Cubit<State> {
   /// Checks whether the undo/redo stack is empty
   bool get canUndo => _changeStack.canUndo;
 
-  /// Checks wether the undo/redo stack is at the current change
+  /// Checks whether the undo/redo stack is at the current change
   bool get canRedo => _changeStack.canRedo;
 
   /// Clear undo/redo history
   void clearHistory() => _changeStack.clear();
+
+  /// Checks whether the given state should be saved to the undo/redo stack.
+  ///
+  /// By default always returns `true`.
+  bool shouldReplay(State state) => true;
 }

--- a/packages/replay_bloc/lib/src/replay_cubit.dart
+++ b/packages/replay_bloc/lib/src/replay_cubit.dart
@@ -72,24 +72,24 @@ mixin ReplayCubitMixin<State> on Cubit<State> {
     super.emit(state);
   }
 
-  /// Undo the last change
+  /// Undo the last change.
   void undo() => _changeStack.undo();
 
-  /// Redo the previous change
+  /// Redo the previous change.
   void redo() => _changeStack.redo();
 
-  /// Checks whether the undo/redo stack is empty
+  /// Checks whether the undo/redo stack is empty.
   bool get canUndo => _changeStack.canUndo;
 
-  /// Checks whether the undo/redo stack is at the current change
+  /// Checks whether the undo/redo stack is at the current change.
   bool get canRedo => _changeStack.canRedo;
 
-  /// Clear undo/redo history
+  /// Clear undo/redo history.
   void clearHistory() => _changeStack.clear();
 
-  /// Checks whether the given state should be replayed from the undo/redo stack
+  /// Checks whether the given state should be replayed from the undo/redo stack.
   ///
-  /// This is called at the time the state is being restored. By default
-  /// always returns `true`
+  /// This is called at the time the state is being restored.
+  /// By default [shouldReplay] always returns `true`.
   bool shouldReplay(State state) => true;
 }

--- a/packages/replay_bloc/test/blocs/counter_bloc.dart
+++ b/packages/replay_bloc/test/blocs/counter_bloc.dart
@@ -12,10 +12,12 @@ class CounterBloc extends ReplayBloc<CounterEvent, int> {
     int? limit,
     this.onEventCallback,
     this.onTransitionCallback,
+    this.shouldReplayCallback,
   }) : super(0, limit: limit);
 
   final void Function(ReplayEvent)? onEventCallback;
   final void Function(Transition<ReplayEvent, int>)? onTransitionCallback;
+  final bool Function(int)? shouldReplayCallback;
 
   @override
   Stream<int> mapEventToState(CounterEvent event) async* {
@@ -36,6 +38,11 @@ class CounterBloc extends ReplayBloc<CounterEvent, int> {
   void onTransition(Transition<ReplayEvent, int> transition) {
     onTransitionCallback?.call(transition);
     super.onTransition(transition);
+  }
+
+  @override
+  bool shouldReplay(int state) {
+    return shouldReplayCallback?.call(state) ?? super.shouldReplay(state);
   }
 }
 

--- a/packages/replay_bloc/test/cubits/counter_cubit.dart
+++ b/packages/replay_bloc/test/cubits/counter_cubit.dart
@@ -2,10 +2,20 @@ import 'package:bloc/bloc.dart';
 import 'package:replay_bloc/replay_bloc.dart';
 
 class CounterCubit extends ReplayCubit<int> {
-  CounterCubit({int? limit}) : super(0, limit: limit);
+  CounterCubit({
+    int? limit,
+    this.shouldReplayCallback,
+  }) : super(0, limit: limit);
+
+  final bool Function(int)? shouldReplayCallback;
 
   void increment() => emit(state + 1);
   void decrement() => emit(state - 1);
+
+  @override
+  bool shouldReplay(int state) {
+    return shouldReplayCallback?.call(state) ?? super.shouldReplay(state);
+  }
 }
 
 class CounterCubitMixin extends Cubit<int> with ReplayCubitMixin<int> {

--- a/packages/replay_bloc/test/replay_bloc_test.dart
+++ b/packages/replay_bloc/test/replay_bloc_test.dart
@@ -91,6 +91,18 @@ void main() {
         expect(states, const <int>[1]);
       });
 
+      test('skips states filtered out by shouldReplay', () async {
+        final states = <int>[];
+        final bloc = CounterBloc(shouldReplayCallback: (i) => i != 2);
+        final subscription = bloc.stream.listen(states.add);
+        bloc..add(Increment())..add(Increment())..add(Increment());
+        await Future<void>.delayed(Duration.zero);
+        bloc..undo()..undo()..undo();
+        await bloc.close();
+        await subscription.cancel();
+        expect(states, const <int>[1, 2, 3, 1, 0]);
+      });
+
       test('loses history outside of limit', () async {
         final states = <int>[];
         final bloc = CounterBloc(limit: 1);

--- a/packages/replay_bloc/test/replay_bloc_test.dart
+++ b/packages/replay_bloc/test/replay_bloc_test.dart
@@ -279,6 +279,26 @@ void main() {
         await subscription.cancel();
         expect(states, const <int>[1, 2, 1, 0]);
       });
+
+      test(
+          'redo does not redo states which were'
+          ' filtered out by shouldReplay at undo time', () async {
+        final states = <int>[];
+        final bloc = CounterBloc(shouldReplayCallback: (i) => !i.isEven);
+        final subscription = bloc.stream.listen(states.add);
+        bloc..add(Increment())..add(Increment())..add(Increment());
+        await Future<void>.delayed(Duration.zero);
+        bloc
+          ..undo()
+          ..undo()
+          ..undo()
+          ..redo()
+          ..redo()
+          ..redo();
+        await bloc.close();
+        await subscription.cancel();
+        expect(states, const <int>[1, 2, 3, 1, 3]);
+      });
     });
   });
 

--- a/packages/replay_bloc/test/replay_bloc_test.dart
+++ b/packages/replay_bloc/test/replay_bloc_test.dart
@@ -299,6 +299,25 @@ void main() {
         await subscription.cancel();
         expect(states, const <int>[1, 2, 3, 1, 3]);
       });
+
+      test(
+          'redo does not redo states which were'
+          ' filtered out by shouldReplay at transition time', () async {
+        var replayEvens = false;
+        final states = <int>[];
+        final bloc = CounterBloc(
+          shouldReplayCallback: (i) => !i.isEven || replayEvens,
+        );
+        final subscription = bloc.stream.listen(states.add);
+        bloc..add(Increment())..add(Increment())..add(Increment());
+        await Future<void>.delayed(Duration.zero);
+        bloc..undo()..undo()..undo();
+        replayEvens = true;
+        bloc..redo()..redo()..redo();
+        await bloc.close();
+        await subscription.cancel();
+        expect(states, const <int>[1, 2, 3, 1, 2, 3]);
+      });
     });
   });
 

--- a/packages/replay_bloc/test/replay_bloc_test.dart
+++ b/packages/replay_bloc/test/replay_bloc_test.dart
@@ -91,16 +91,34 @@ void main() {
         expect(states, const <int>[1]);
       });
 
-      test('skips states filtered out by shouldReplay', () async {
+      test('skips states filtered out by shouldReplay at undo time', () async {
         final states = <int>[];
-        final bloc = CounterBloc(shouldReplayCallback: (i) => i != 2);
+        final bloc = CounterBloc(shouldReplayCallback: (i) => !i.isEven);
         final subscription = bloc.stream.listen(states.add);
         bloc..add(Increment())..add(Increment())..add(Increment());
         await Future<void>.delayed(Duration.zero);
         bloc..undo()..undo()..undo();
         await bloc.close();
         await subscription.cancel();
-        expect(states, const <int>[1, 2, 3, 1, 0]);
+        expect(states, const <int>[1, 2, 3, 1]);
+      });
+
+      test(
+          'doesn\'t skip states that would be filtered out by shouldReplay '
+          'at transition time but not at undo time', () async {
+        var replayEvens = false;
+        final states = <int>[];
+        final bloc = CounterBloc(
+          shouldReplayCallback: (i) => !i.isEven || replayEvens,
+        );
+        final subscription = bloc.stream.listen(states.add);
+        bloc..add(Increment())..add(Increment())..add(Increment());
+        await Future<void>.delayed(Duration.zero);
+        replayEvens = true;
+        bloc..undo()..undo()..undo();
+        await bloc.close();
+        await subscription.cancel();
+        expect(states, const <int>[1, 2, 3, 2, 1, 0]);
       });
 
       test('loses history outside of limit', () async {

--- a/packages/replay_bloc/test/replay_cubit_test.dart
+++ b/packages/replay_bloc/test/replay_cubit_test.dart
@@ -252,6 +252,29 @@ void main() {
         await subscription.cancel();
         expect(states, const <int>[1, 2, 3, 1, 3]);
       });
+
+      test(
+          'redo does not redo states which were'
+          ' filtered out by shouldReplay at transition time', () async {
+        var replayEvens = false;
+        final states = <int>[];
+        final cubit = CounterCubit(
+          shouldReplayCallback: (i) => !i.isEven || replayEvens,
+        );
+        final subscription = cubit.stream.listen(states.add);
+        cubit
+          ..increment()
+          ..increment()
+          ..increment()
+          ..undo()
+          ..undo()
+          ..undo();
+        replayEvens = true;
+        cubit..redo()..redo()..redo();
+        await cubit.close();
+        await subscription.cancel();
+        expect(states, const <int>[1, 2, 3, 1, 2, 3]);
+      });
     });
   });
 

--- a/packages/replay_bloc/test/replay_cubit_test.dart
+++ b/packages/replay_bloc/test/replay_cubit_test.dart
@@ -92,6 +92,18 @@ void main() {
         expect(states, const <int>[1]);
       });
 
+      test('skips states filtered out by shouldReplay', () async {
+        final states = <int>[];
+        final cubit = CounterCubit(shouldReplayCallback: (i) => i != 2);
+        final subscription = cubit.stream.listen(states.add);
+        cubit..increment()..increment()..increment();
+        await Future<void>.delayed(Duration.zero);
+        cubit..undo()..undo()..undo();
+        await cubit.close();
+        await subscription.cancel();
+        expect(states, const <int>[1, 2, 3, 1, 0]);
+      });
+
       test('loses history outside of limit', () async {
         final states = <int>[];
         final cubit = CounterCubit(limit: 1);

--- a/packages/replay_bloc/test/replay_cubit_test.dart
+++ b/packages/replay_bloc/test/replay_cubit_test.dart
@@ -231,6 +231,27 @@ void main() {
         await subscription.cancel();
         expect(states, const <int>[1, 2, 1, 0]);
       });
+
+      test(
+          'redo does not redo states which were'
+          ' filtered out by shouldReplay at undo time', () async {
+        final states = <int>[];
+        final cubit = CounterCubit(shouldReplayCallback: (i) => !i.isEven);
+        final subscription = cubit.stream.listen(states.add);
+        cubit
+          ..increment()
+          ..increment()
+          ..increment()
+          ..undo()
+          ..undo()
+          ..undo()
+          ..redo()
+          ..redo()
+          ..redo();
+        await cubit.close();
+        await subscription.cancel();
+        expect(states, const <int>[1, 2, 3, 1, 3]);
+      });
     });
   });
 


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description
I added a `shouldReplay` method to `ReplayBloc` and `ReplayCubit`. The intention of this is described more in #2086, but basically, the idea is that a developer can override this method to filter out which states are saved in the undo/redo stack.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
