### PR TITLE
docs(bloc): update `onChange` description in README

### DIFF
--- a/packages/bloc/README.md
+++ b/packages/bloc/README.md
@@ -69,7 +69,7 @@ A `Cubit` is class which extends `BlocBase` and can be extended to manage any ty
 
 ![Cubit Flow](https://raw.githubusercontent.com/felangel/bloc/master/docs/assets/cubit_flow.png)
 
-State changes in cubit begin with predefined function calls which can use the `emit` method to output new states. `onChange` is called on each state change and contains the current and next state.
+State changes in cubit begin with predefined function calls which can use the `emit` method to output new states. `onChange` is called right before a state change occurs and contains the current and next state.
 
 #### Creating a Cubit
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->

I have updated this only paragraph which was confusing the users about `onChange` method: 
>State changes in cubit begin with predefined function calls which can use the emit method to output new states. onChange is called on each state change and contains the current and next state.

To
>State changes in cubit begin with predefined function calls which can use the emit method to output new states. **onChange is called right before a state change occurs and contains the current and next state.**
## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
