### PR TITLE
feat(intelliJ): add Equatable props generator

### DIFF
--- a/extensions/intellij/README.md
+++ b/extensions/intellij/README.md
@@ -24,6 +24,9 @@ If you wish to disable this quick code action `(Bloc) Wrap with` you can do it s
 
 ![intention_settings](https://github.com/felangel/bloc/raw/master/extensions/intellij/assets/intention_settings.png)
 
+### Equatable props generator
+// TODO: Add an image?
+
 ## Snippets
 
 ### Bloc

--- a/extensions/intellij/intellij_generator_plugin/src/main/java/com/bloc/intellij_generator_plugin/action/GenerateEquatablePropsAction.kt
+++ b/extensions/intellij/intellij_generator_plugin/src/main/java/com/bloc/intellij_generator_plugin/action/GenerateEquatablePropsAction.kt
@@ -1,0 +1,88 @@
+package com.bloc.intellij_generator_plugin.action
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.psi.util.PsiUtilBase
+
+
+class GenerateEquatablePropsAction : AnAction() {
+
+//    override fun update(event: AnActionEvent?) {
+//        super.update(event)
+//        val action = event?.presentation;
+//        if (action != null) {
+//            val editor = event.getRequiredData(CommonDataKeys.EDITOR)
+//            val project = event.project ?: return
+//            val currentFile = PsiUtilBase.getPsiFileInEditor(editor, project)
+//            action.isVisible = currentFile?.name?.endsWith(".dart") == true
+//            action.isEnabledAndVisible
+//        }
+//    }
+
+    override fun actionPerformed(event: AnActionEvent) {
+        val editor = event.getRequiredData(CommonDataKeys.EDITOR)
+        val project = event.project ?: return
+        val currentFile = PsiUtilBase.getPsiFileInEditor(editor, project) ?: return
+
+        val currentOffset = editor.caretModel.currentCaret.offset;
+        val element = currentFile.findElementAt(currentOffset) ?: return
+        var node = element.node;
+        while (node != null) {
+            if (node.toString() == "Element(CLASS_DEFINITION)") {
+                break
+            }
+            node = node.treeParent
+        }
+
+        if (node == null) return
+        val members = node.getChildren(null).find { astNode -> astNode.toString() == "Element(CLASS_BODY)" }
+            ?.getChildren(null)?.find { astNode -> astNode.toString() == "Element(CLASS_MEMBERS)" }?.getChildren(null)
+            ?.filter { astNode -> astNode.toString() == "Element(VAR_DECLARATION_LIST)" }
+
+        if (members == null) return
+
+        var isNullable = false
+        val memberNames = members.map { n ->
+            val memberNode = n.firstChildNode;
+            if (memberNode.toString() == "Element(VAR_ACCESS_DECLARATION)") {
+                val type =
+                    memberNode.getChildren(null)
+                        .find { astNode -> astNode.toString() == "Element(TYPE)" }?.psi
+
+                if (!isNullable && type != null && editor.document.getText(type.textRange).endsWith("?")) {
+                    isNullable = true
+                }
+
+                val member =
+                    memberNode.getChildren(null).find { astNode -> astNode.toString() == "Element(COMPONENT_NAME)" }
+                        ?.getChildren(null)
+                        ?.find { astNode -> astNode.toString() == "Element(ID)" }?.getChildren(null)
+                        ?.find { astNode -> astNode.toString() == "PsiElement(IDENTIFIER)" }?.psi
+
+                return@map if (member == null) "" else editor.document.getText(member.textRange)
+            }
+            return@map ""
+        }
+
+        val nullStr = if (isNullable) "?" else ""
+        var props: String = "";
+        for ((i, s) in memberNames.withIndex()) {
+            if (s != "") {
+                if (i == 0 && memberNames.size == 1) {
+                    props += s
+                } else if (i == memberNames.size - 1) {
+                    props += s
+                } else {
+                    props += "$s, "
+                }
+            }
+        }
+        val propsStr = "@override\nList<Object$nullStr> get props => [$props];"
+
+        WriteCommandAction.runWriteCommandAction(project) {
+            editor.document.insertString(currentOffset, propsStr)
+        }
+    }
+}

--- a/extensions/intellij/intellij_generator_plugin/src/main/resources/META-INF/plugin.xml
+++ b/extensions/intellij/intellij_generator_plugin/src/main/resources/META-INF/plugin.xml
@@ -58,9 +58,9 @@
                     anchor="first"/>
         </action>
         <action class="com.bloc.intellij_generator_plugin.action.GenerateEquatablePropsAction"
-                description="Generate Equatable props"
+                description="Generate Equatable Props Override"
                 id="GenerateEquatablePropsId"
-                text="Equatable props">
+                text="Equatable Props">
             <add-to-group group-id="GenerateGroup"
                           anchor="last"/>
         </action>

--- a/extensions/intellij/intellij_generator_plugin/src/main/resources/META-INF/plugin.xml
+++ b/extensions/intellij/intellij_generator_plugin/src/main/resources/META-INF/plugin.xml
@@ -57,6 +57,13 @@
                     group-id="NewGroup"
                     anchor="first"/>
         </action>
+        <action class="com.bloc.intellij_generator_plugin.action.GenerateEquatablePropsAction"
+                description="Generate Equatable props"
+                id="GenerateEquatablePropsId"
+                text="Equatable props">
+            <add-to-group group-id="GenerateGroup"
+                          anchor="last"/>
+        </action>
     </actions>
 
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

Adds a new option to the IntelliJ Generator menu, which generates `Equatable props` with defined class members.

For now, it looks like this

https://user-images.githubusercontent.com/67197047/124289277-6bf5bc80-db52-11eb-8baf-50987d843ed4.mp4

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
