### PR TITLE
fix: sign up cubit password confirmation order

### DIFF
--- a/examples/flutter_firebase_login/lib/sign_up/cubit/sign_up_cubit.dart
+++ b/examples/flutter_firebase_login/lib/sign_up/cubit/sign_up_cubit.dart
@@ -35,7 +35,7 @@ class SignUpCubit extends Cubit<SignUpState> {
       status: Formz.validate([
         state.email,
         password,
-        state.confirmedPassword,
+        confirmedPassword,
       ]),
     ));
   }

--- a/examples/flutter_firebase_login/test/sign_up/cubit/sign_up_cubit_test.dart
+++ b/examples/flutter_firebase_login/test/sign_up/cubit/sign_up_cubit_test.dart
@@ -115,6 +115,32 @@ void main() {
           ),
         ],
       );
+
+      blocTest<SignUpCubit, SignUpState>(
+        'emits [valid] when confirmedPasswordChanged is called first and then '
+        'passwordChanged is called',
+        build: () => SignUpCubit(authenticationRepository),
+        seed: () => SignUpState(
+          email: validEmail,
+        ),
+        act: (cubit) => cubit
+          ..confirmedPasswordChanged(validConfirmedPasswordString)
+          ..passwordChanged(validPasswordString),
+        expect: () => const <SignUpState>[
+          SignUpState(
+            email: validEmail,
+            password: Password.pure(),
+            confirmedPassword: validConfirmedPassword,
+            status: FormzStatus.invalid,
+          ),
+          SignUpState(
+            email: validEmail,
+            password: validPassword,
+            confirmedPassword: validConfirmedPassword,
+            status: FormzStatus.valid,
+          ),
+        ],
+      );
     });
 
     group('confirmedPasswordChanged', () {
@@ -139,6 +165,34 @@ void main() {
           validConfirmedPasswordString,
         ),
         expect: () => const <SignUpState>[
+          SignUpState(
+            email: validEmail,
+            password: validPassword,
+            confirmedPassword: validConfirmedPassword,
+            status: FormzStatus.valid,
+          ),
+        ],
+      );
+
+      blocTest<SignUpCubit, SignUpState>(
+        'emits [valid] when passwordChanged is called first and then '
+        'confirmedPasswordChanged is called',
+        build: () => SignUpCubit(authenticationRepository),
+        seed: () => SignUpState(
+          email: validEmail,
+        ),
+        act: (cubit) => cubit
+          ..passwordChanged(validPasswordString)
+          ..confirmedPasswordChanged(validConfirmedPasswordString),
+        expect: () => const <SignUpState>[
+          SignUpState(
+            email: validEmail,
+            password: validPassword,
+            confirmedPassword: ConfirmedPassword.dirty(
+              password: validPasswordString,
+            ),
+            status: FormzStatus.invalid,
+          ),
           SignUpState(
             email: validEmail,
             password: validPassword,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->
* Updates `SignUp Cubit` so that the `SignUp Button` will be enabled if both passwords match, regardless of the order in which the passwords were inputted. 
* closes #2179 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
