### PR TITLE
typo 'onError'

### DIFF
--- a/docs/coreconcepts.md
+++ b/docs/coreconcepts.md
@@ -208,7 +208,7 @@ CounterCubit Change { currentState: 0, nextState: 1 }
 
 ### Error Handling
 
-> Every `Cubit` has an `addError` method which can be used to indicate that an error has occurred.
+> Every `Cubit` has an `onError` method which can be used to indicate that an error has occurred.
 
 ```dart
 class CounterCubit extends Cubit<int> {


### PR DESCRIPTION

## Status

READY

## Breaking Changes

NO

## Description

onError for Change instead of addError(typo)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
