### PR TITLE
docs(flutter_weather): fix typo in tutorial

### DIFF
--- a/docs/flutterweathertutorial.md
+++ b/docs/flutterweathertutorial.md
@@ -185,13 +185,13 @@ Our API client will expose two methods:
 
 #### Location Search
 
-The `locationSearch` method hits the location API and throws `LocationIdRequestFailiure` errors as applicable. The completed method looks as follows:
+The `locationSearch` method hits the location API and throws `LocationIdRequestFailure` errors as applicable. The completed method looks as follows:
 
 [meta_weather_api_client.dart](_snippets/flutter_weather_tutorial/data_layer/location_search_method.dart.md ':include')
 
 #### Get Weather
 
-Similarly, the `getWeather` method hits the weather API and throws `WeatherRequestFailiure` errors as applicable. The completed method looks as follows:
+Similarly, the `getWeather` method hits the weather API and throws `WeatherRequestFailure` errors as applicable. The completed method looks as follows:
 
 [meta_weather_api_client.dart](_snippets/flutter_weather_tutorial/data_layer/get_weather_method.dart.md ':include')
 


### PR DESCRIPTION
Fix typo in flutterweathertutorial

## Status

**READY**

## Breaking Changes

NO

## Description

Fix the name of the exceptiont thrown.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
