### PR TITLE
docs(architecture): update bloc-to-bloc communication snippet to null safety

### DIFF
--- a/docs/_snippets/architecture/bloc_to_bloc_communication.dart.md
+++ b/docs/_snippets/architecture/bloc_to_bloc_communication.dart.md
@@ -1,10 +1,10 @@
 ```dart
 class MyBloc extends Bloc {
   final OtherBloc otherBloc;
-  StreamSubscription otherBlocSubscription;
+  late StreamSubscription otherBlocSubscription;
 
   MyBloc(this.otherBloc) {
-    otherBlocSubscription = otherBloc.listen((state) {
+    otherBlocSubscription = otherBloc.stream.listen((state) {
         // React to state changes here.
         // Add events here to trigger changes in MyBloc.
     });

--- a/docs/_snippets/architecture/bloc_to_bloc_communication.dart.md
+++ b/docs/_snippets/architecture/bloc_to_bloc_communication.dart.md
@@ -1,7 +1,7 @@
 ```dart
 class MyBloc extends Bloc {
   final OtherBloc otherBloc;
-  late StreamSubscription otherBlocSubscription;
+  late final StreamSubscription otherBlocSubscription;
 
   MyBloc(this.otherBloc) {
     otherBlocSubscription = otherBloc.stream.listen((state) {


### PR DESCRIPTION
Fixed:

1. 'listen' is deprecated and shouldn't be used. Use stream.listen instead. Will be removed in v8.0.0.


2. Non-nullable instance field 'otherBlocSubscription' must be initialized.  Try adding an initializer expression, or add a field initializer in this constructor, or mark it 'late'.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY/IN DEVELOPMENT/HOLD**

## Breaking Changes

YES | NO

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
