### PR TITLE
feat(bloc_test): add `setUp` and `tearDown`

### DIFF
--- a/packages/bloc_test/CHANGELOG.md
+++ b/packages/bloc_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 8.1.0
+
+- feat: add `setUp` and `tearDown` to `blocTest`
+
 # 8.0.2
 
 - fix: revert `package:mocktail` export to reduce conflicts with `package:mockito`

--- a/packages/bloc_test/README.md
+++ b/packages/bloc_test/README.md
@@ -82,7 +82,9 @@ expect(counterBloc.state, equals(3));
 **blocTest** creates a new `bloc`-specific test case with the given `description`.
 `blocTest` will handle asserting that the `bloc` emits the `expect`ed states (in order) after `act` is executed. `blocTest` also handles ensuring that no additional states are emitted by closing the `bloc` stream before evaluating the `expect`ation.
 
-`build` should be used for all `bloc` initialization and preparation and must return the `bloc` under test.
+`setUp` is optional and should be used to set up any dependencies prior to initializing the `bloc` under test.
+
+`build` should construct and return the `bloc` under test.
 
 `seed` is an optional `Function` that returns a state which will be used to seed the `bloc` before `act` is called.
 
@@ -97,6 +99,8 @@ expect(counterBloc.state, equals(3));
 `verify` is an optional callback which is invoked after `expect` and can be used for additional verification/assertions. `verify` is called with the `bloc` returned by `build`.
 
 `errors` is an optional `Function` that returns a `Matcher` which the `bloc` under test is expected to throw after `act` is executed.
+
+`tearDown` is optional and can be used to execute any code after the test has run.
 
 ```dart
 group('CounterBloc', () {

--- a/packages/bloc_test/README.md
+++ b/packages/bloc_test/README.md
@@ -82,7 +82,7 @@ expect(counterBloc.state, equals(3));
 **blocTest** creates a new `bloc`-specific test case with the given `description`.
 `blocTest` will handle asserting that the `bloc` emits the `expect`ed states (in order) after `act` is executed. `blocTest` also handles ensuring that no additional states are emitted by closing the `bloc` stream before evaluating the `expect`ation.
 
-`setUp` is optional and should be used to set up any dependencies prior to initializing the `bloc` under test.
+`setUp` is optional and should be used to set up any dependencies prior to initializing the `bloc` under test. `setUp` should be used to set up state necessary for a particular test case. For common set up code, prefer to use `setUp` from `package:test/test.dart`.
 
 `build` should construct and return the `bloc` under test.
 
@@ -100,7 +100,7 @@ expect(counterBloc.state, equals(3));
 
 `errors` is an optional `Function` that returns a `Matcher` which the `bloc` under test is expected to throw after `act` is executed.
 
-`tearDown` is optional and can be used to execute any code after the test has run.
+`tearDown` is optional and can be used to execute any code after the test has run. `tearDown` should be used to clean up after a particular test case. For common tear down code, prefer to use `tearDown` from `package:test/test.dart`.
 
 ```dart
 group('CounterBloc', () {

--- a/packages/bloc_test/lib/src/bloc_test.dart
+++ b/packages/bloc_test/lib/src/bloc_test.dart
@@ -10,8 +10,10 @@ import 'package:test/test.dart' as test;
 /// [blocTest] also handles ensuring that no additional states are emitted
 /// by closing the `bloc` stream before evaluating the [expect]ation.
 ///
-/// [build] should be used for all `bloc` initialization and preparation
-/// and must return the `bloc` under test.
+/// [setUp] is optional and should be used to set up
+/// any dependencies prior to initializing the `bloc` under test.
+///
+/// [build] should construct and return the `bloc` under test.
 ///
 /// [seed] is an optional `Function` that returns a state
 /// which will be used to seed the `bloc` before [act] is called.
@@ -34,6 +36,9 @@ import 'package:test/test.dart' as test;
 ///
 /// [errors] is an optional `Function` that returns a `Matcher` which the `bloc`
 /// under test is expected to throw after [act] is executed.
+///
+/// [tearDown] is optional and can be used to
+/// execute any code after the test has run.
 ///
 /// ```dart
 /// blocTest(

--- a/packages/bloc_test/lib/src/bloc_test.dart
+++ b/packages/bloc_test/lib/src/bloc_test.dart
@@ -12,6 +12,8 @@ import 'package:test/test.dart' as test;
 ///
 /// [setUp] is optional and should be used to set up
 /// any dependencies prior to initializing the `bloc` under test.
+/// [setUp] should be used to set up state necessary for a particular test case.
+/// For common set up code, prefer to use `setUp` from `package:test/test.dart`.
 ///
 /// [build] should construct and return the `bloc` under test.
 ///
@@ -39,6 +41,8 @@ import 'package:test/test.dart' as test;
 ///
 /// [tearDown] is optional and can be used to
 /// execute any code after the test has run.
+/// [tearDown] should be used to clean up after a particular test case.
+/// For common tear down code, prefer to use `tearDown` from `package:test/test.dart`.
 ///
 /// ```dart
 /// blocTest(

--- a/packages/bloc_test/lib/src/bloc_test.dart
+++ b/packages/bloc_test/lib/src/bloc_test.dart
@@ -116,6 +116,7 @@ import 'package:test/test.dart' as test;
 @isTest
 void blocTest<B extends BlocBase<State>, State>(
   String description, {
+  FutureOr<void> Function()? setUp,
   required B Function() build,
   State Function()? seed,
   Function(B bloc)? act,
@@ -124,9 +125,11 @@ void blocTest<B extends BlocBase<State>, State>(
   dynamic Function()? expect,
   Function(B bloc)? verify,
   dynamic Function()? errors,
+  FutureOr<void> Function()? tearDown,
 }) {
   test.test(description, () async {
     await testBloc<B, State>(
+      setUp: setUp,
       build: build,
       seed: seed,
       act: act,
@@ -135,6 +138,7 @@ void blocTest<B extends BlocBase<State>, State>(
       expect: expect,
       verify: verify,
       errors: errors,
+      tearDown: tearDown,
     );
   });
 }
@@ -143,6 +147,7 @@ void blocTest<B extends BlocBase<State>, State>(
 /// This should never be used directly -- please use [blocTest] instead.
 @visibleForTesting
 Future<void> testBloc<B extends BlocBase<State>, State>({
+  FutureOr<void> Function()? setUp,
   required B Function() build,
   State Function()? seed,
   Function(B bloc)? act,
@@ -151,11 +156,13 @@ Future<void> testBloc<B extends BlocBase<State>, State>({
   dynamic Function()? expect,
   Function(B bloc)? verify,
   dynamic Function()? errors,
+  FutureOr<void> Function()? tearDown,
 }) async {
   final unhandledErrors = <Object>[];
   var shallowEquality = false;
   await runZonedGuarded(
     () async {
+      await setUp?.call();
       final states = <State>[];
       final bloc = build();
       // ignore: invalid_use_of_visible_for_testing_member, invalid_use_of_protected_member
@@ -178,6 +185,7 @@ Future<void> testBloc<B extends BlocBase<State>, State>({
       }
       await subscription.cancel();
       await verify?.call(bloc);
+      await tearDown?.call();
     },
     (Object error, _) {
       if (error is BlocUnhandledErrorException) {

--- a/packages/bloc_test/pubspec.yaml
+++ b/packages/bloc_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc_test
 description: A testing library which makes it easy to test blocs. Built to be used with the bloc state management package.
-version: 8.0.2
+version: 8.1.0
 repository: https://github.com/felangel/bloc/tree/master/packages/bloc_test
 issue_tracker: https://github.com/felangel/bloc/issues
 homepage: https://bloclibrary.dev

--- a/packages/bloc_test/test/bloc_bloc_test_test.dart
+++ b/packages/bloc_test/test/bloc_bloc_test_test.dart
@@ -506,6 +506,17 @@ void main() {
         },
       );
 
+      blocTest<SideEffectCounterBloc, int>(
+        'custom setUp is executed before build/act',
+        setUp: () {
+          when(() => repository.sideEffect()).thenThrow(Exception());
+        },
+        build: () => SideEffectCounterBloc(repository),
+        act: (bloc) => bloc.add(CounterEvent.increment),
+        expect: () => const <int>[],
+        errors: () => [isException],
+      );
+
       test('fails immediately when verify is incorrect', () async {
         const expectedError =
             '''Expected: <2>\n  Actual: <1>\nUnexpected number of calls\n''';

--- a/packages/bloc_test/test/bloc_bloc_test_test.dart
+++ b/packages/bloc_test/test/bloc_bloc_test_test.dart
@@ -507,7 +507,7 @@ void main() {
       );
 
       blocTest<SideEffectCounterBloc, int>(
-        'custom setUp is executed before build/act',
+        'setUp is executed before build/act',
         setUp: () {
           when(() => repository.sideEffect()).thenThrow(Exception());
         },
@@ -560,5 +560,31 @@ Alternatively, consider using Matchers in the expect of the blocTest rather than
         expect((actualError as TestFailure).message, expectedError);
       });
     });
+  });
+
+  group('tearDown', () {
+    late int tearDownCallCount;
+    int? state;
+
+    setUp(() {
+      tearDownCallCount = 0;
+    });
+
+    tearDown(() {
+      expect(tearDownCallCount, equals(1));
+    });
+
+    blocTest<CounterBloc, int>(
+      'is called after the test is run',
+      build: () => CounterBloc(),
+      act: (bloc) => bloc.add(CounterEvent.increment),
+      verify: (bloc) {
+        state = bloc.state;
+      },
+      tearDown: () {
+        tearDownCallCount++;
+        expect(state, equals(1));
+      },
+    );
   });
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->
- feat(bloc_test): add `setUp` and `tearDown` methods

As a developer, I want to have the ability to execute set up and tear down code as part of a `blocTest` so that I don't have to clutter the `build` and `verify` api:

```dart
blocTest(
  setUp: () {
    // Execute any set up code needed prior to building the bloc.
    when(() => repository.someMethod()).thenReturn(...);
  },
  build: () => MyBloc(repository),
  act: (bloc) => bloc.add(...),
  expect: () => [...],
  tearDown: () {
    // Execute any tear down code needed after the test has run.
    verifyNoMoreInteractions(repository);
  },
);
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
