### PR TITLE
feat(flutter_bloc): BlocSelector

### DIFF
--- a/packages/flutter_bloc/README.md
+++ b/packages/flutter_bloc/README.md
@@ -145,6 +145,23 @@ BlocBuilder<BlocA, BlocAState>(
 )
 ```
 
+### BlocSelector
+
+**BlocSelector** is a Flutter widget which is analogous to `BlocBuilder` but allows developers to filter updates by selecting a new value based on the current bloc state. Unnecessary builds are prevented if the selected value does not change. The selected value must be immutable in order for `BlocSelector` to accurately determine whether `builder` should be called again.
+
+If the `bloc` parameter is omitted, `BlocSelector` will automatically perform a lookup using `BlocProvider` and the current `BuildContext`.
+
+```dart
+BlocSelector<BlocA, BlocAState, SelectedState>(
+  selector: (state) {
+    // return selected state based on the provided state.
+  },
+  builder: (context, state) {
+    // return widget here based on the selected state.
+  },
+)
+```
+
 ### BlocProvider
 
 **BlocProvider** is a Flutter widget which provides a bloc to its children via `BlocProvider.of<T>(context)`. It is used as a dependency injection (DI) widget so that a single instance of a bloc can be provided to multiple widgets within a subtree.
@@ -205,7 +222,7 @@ In addition, `context.select` can be used to retrieve part of a state and react 
 final isPositive = context.select((CounterBloc b) => b.state >= 0);
 ```
 
-The snippet above will only rebuild if the state of the `CounterBloc` changes from positive to negative or vice versa.
+The snippet above will only rebuild if the state of the `CounterBloc` changes from positive to negative or vice versa and is functionally identical to using a `BlocSelector`.
 
 ### MultiBlocProvider
 

--- a/packages/flutter_bloc/lib/flutter_bloc.dart
+++ b/packages/flutter_bloc/lib/flutter_bloc.dart
@@ -8,6 +8,7 @@ export './src/bloc_builder.dart';
 export './src/bloc_consumer.dart';
 export './src/bloc_listener.dart' hide BlocListenerSingleChildWidget;
 export './src/bloc_provider.dart' hide BlocProviderSingleChildWidget;
+export './src/bloc_selector.dart';
 export './src/multi_bloc_listener.dart';
 export './src/multi_bloc_provider.dart';
 export './src/multi_repository_provider.dart';

--- a/packages/flutter_bloc/lib/src/bloc_builder.dart
+++ b/packages/flutter_bloc/lib/src/bloc_builder.dart
@@ -1,4 +1,3 @@
-import 'package:bloc/bloc.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:provider/provider.dart';
@@ -19,11 +18,11 @@ typedef BlocBuilderCondition<S> = bool Function(S previous, S current);
 /// reduce the amount of boilerplate code needed as well as [bloc]-specific
 /// performance improvements.
 
-/// Please refer to `BlocListener` if you want to "do" anything in response to
+/// Please refer to [BlocListener] if you want to "do" anything in response to
 /// `state` changes such as navigation, showing a dialog, etc...
 ///
 /// If the [bloc] parameter is omitted, [BlocBuilder] will automatically
-/// perform a lookup using [BlocProvider] and the current `BuildContext`.
+/// perform a lookup using [BlocProvider] and the current [BuildContext].
 ///
 /// ```dart
 /// BlocBuilder<BlocA, BlocAState>(
@@ -34,7 +33,7 @@ typedef BlocBuilderCondition<S> = bool Function(S previous, S current);
 /// ```
 ///
 /// Only specify the [bloc] if you wish to provide a [bloc] that is otherwise
-/// not accessible via [BlocProvider] and the current `BuildContext`.
+/// not accessible via [BlocProvider] and the current [BuildContext].
 ///
 /// ```dart
 /// BlocBuilder<BlocA, BlocAState>(

--- a/packages/flutter_bloc/lib/src/bloc_consumer.dart
+++ b/packages/flutter_bloc/lib/src/bloc_consumer.dart
@@ -1,4 +1,3 @@
-import 'package:bloc/bloc.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:provider/provider.dart';

--- a/packages/flutter_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/bloc_listener.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:bloc/bloc.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:provider/provider.dart';

--- a/packages/flutter_bloc/lib/src/bloc_selector.dart
+++ b/packages/flutter_bloc/lib/src/bloc_selector.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+/// Signature for the `selector` function which
+/// is responsible for returning a selected value, [T], based on [state].
+typedef BlocWidgetSelector<S, T> = T Function(S state);
+
+/// {@template bloc_selector}
+/// [BlocSelector] is analogous to [BlocBuilder] but allows developers to
+/// filter updates by selecting a new value based on the bloc state.
+/// Unnecessary builds are prevented if the selected value does not change.
+///
+/// **Note**: the selected value must be immutable in order for [BlocSelector]
+/// to accurately determine whether [builder] should be called again.
+///
+/// ```dart
+/// BlocSelector<BlocA, BlocAState, SelectedState>(
+///   selector: (state) {
+///     // return selected state based on the provided state.
+///   },
+///   builder: (context, state) {
+///     // return widget here based on the selected state.
+///   },
+/// )
+/// ```
+/// {@endtemplate}
+class BlocSelector<B extends BlocBase<S>, S, T> extends StatefulWidget {
+  /// {@macro bloc_selector}
+  const BlocSelector({
+    Key? key,
+    required this.selector,
+    required this.builder,
+    this.bloc,
+  }) : super(key: key);
+
+  /// The [bloc] that the [BlocSelector] will interact with.
+  /// If omitted, [BlocSelector] will automatically perform a lookup using
+  /// [BlocProvider] and the current [BuildContext].
+  final B? bloc;
+
+  /// The [builder] function which will be invoked
+  /// when the selected state changes.
+  /// The [builder] takes the [BuildContext] and selected `state` and
+  /// must return a widget.
+  /// This is analogous to the [builder] function in [BlocBuilder].
+  final BlocWidgetBuilder<T> builder;
+
+  /// The [selector] function which will be invoked on each widget build
+  /// and is responsible for returning a selected value of type [T] based on
+  /// the current state.
+  final BlocWidgetSelector<S, T> selector;
+
+  @override
+  State<BlocSelector<B, S, T>> createState() => _BlocSelectorState<B, S, T>();
+}
+
+class _BlocSelectorState<B extends BlocBase<S>, S, T>
+    extends State<BlocSelector<B, S, T>> {
+  late B _bloc;
+  late T _state;
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = widget.bloc ?? context.read<B>();
+    _state = widget.selector(_bloc.state);
+  }
+
+  @override
+  void didUpdateWidget(BlocSelector<B, S, T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final oldBloc = oldWidget.bloc ?? context.read<B>();
+    final currentBloc = widget.bloc ?? oldBloc;
+    if (oldBloc != currentBloc) {
+      _bloc = currentBloc;
+      _state = widget.selector(_bloc.state);
+    }
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final bloc = widget.bloc ?? context.read<B>();
+    if (_bloc != bloc) {
+      _bloc = bloc;
+      _state = widget.selector(_bloc.state);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.bloc == null) context.select<B, int>(identityHashCode);
+    return BlocListener<B, S>(
+      bloc: _bloc,
+      listener: (context, state) {
+        final selectedState = widget.selector(state);
+        if (_state != selectedState) setState(() => _state = selectedState);
+      },
+      child: widget.builder(context, _state),
+    );
+  }
+}

--- a/packages/flutter_bloc/test/bloc_selector_test.dart
+++ b/packages/flutter_bloc/test/bloc_selector_test.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class CounterCubit extends Cubit<int> {
+  CounterCubit() : super(0);
+
+  void increment() => emit(state + 1);
+}
+
+void main() {
+  group('BlocSelector', () {
+    testWidgets('renders with correct state', (tester) async {
+      final counterCubit = CounterCubit();
+      var builderCallCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: BlocSelector<CounterCubit, int, bool>(
+            bloc: counterCubit,
+            selector: (state) => state % 2 == 0,
+            builder: (context, state) {
+              builderCallCount++;
+              return Text('isEven: $state');
+            },
+          ),
+        ),
+      );
+
+      expect(find.text('isEven: true'), findsOneWidget);
+      expect(builderCallCount, equals(1));
+    });
+
+    testWidgets('only rebuilds when selected state changes', (tester) async {
+      final counterCubit = CounterCubit();
+      var builderCallCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: BlocSelector<CounterCubit, int, bool>(
+            bloc: counterCubit,
+            selector: (state) => state == 1,
+            builder: (context, state) {
+              builderCallCount++;
+              return Text('equals 1: $state');
+            },
+          ),
+        ),
+      );
+
+      expect(find.text('equals 1: false'), findsOneWidget);
+      expect(builderCallCount, equals(1));
+
+      counterCubit.increment();
+      await tester.pumpAndSettle();
+
+      expect(find.text('equals 1: true'), findsOneWidget);
+      expect(builderCallCount, equals(2));
+
+      counterCubit.increment();
+      await tester.pumpAndSettle();
+
+      expect(find.text('equals 1: false'), findsOneWidget);
+      expect(builderCallCount, equals(3));
+
+      counterCubit.increment();
+      await tester.pumpAndSettle();
+
+      expect(find.text('equals 1: false'), findsOneWidget);
+      expect(builderCallCount, equals(3));
+    });
+
+    testWidgets('infers bloc from context', (tester) async {
+      final counterCubit = CounterCubit();
+      var builderCallCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: BlocProvider.value(
+            value: counterCubit,
+            child: BlocSelector<CounterCubit, int, bool>(
+              selector: (state) => state % 2 == 0,
+              builder: (context, state) {
+                builderCallCount++;
+                return Text('isEven: $state');
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('isEven: true'), findsOneWidget);
+      expect(builderCallCount, equals(1));
+    });
+
+    testWidgets('rebuilds when provided bloc is changed', (tester) async {
+      final firstCounterCubit = CounterCubit();
+      final secondCounterCubit = CounterCubit()..emit(100);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: BlocProvider.value(
+            value: firstCounterCubit,
+            child: BlocSelector<CounterCubit, int, bool>(
+              selector: (state) => state % 2 == 0,
+              builder: (context, state) => Text('isEven: $state'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('isEven: true'), findsOneWidget);
+
+      firstCounterCubit.increment();
+      await tester.pumpAndSettle();
+      expect(find.text('isEven: false'), findsOneWidget);
+      expect(find.text('isEven: true'), findsNothing);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: BlocProvider.value(
+            value: secondCounterCubit,
+            child: BlocSelector<CounterCubit, int, bool>(
+              selector: (state) => state % 2 == 0,
+              builder: (context, state) => Text('isEven: $state'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('isEven: true'), findsOneWidget);
+      expect(find.text('isEven: false'), findsNothing);
+
+      secondCounterCubit.increment();
+      await tester.pumpAndSettle();
+
+      expect(find.text('isEven: false'), findsOneWidget);
+      expect(find.text('isEven: true'), findsNothing);
+    });
+
+    testWidgets('rebuilds when bloc is changed at runtime', (tester) async {
+      final firstCounterCubit = CounterCubit();
+      final secondCounterCubit = CounterCubit()..emit(100);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: BlocSelector<CounterCubit, int, bool>(
+            bloc: firstCounterCubit,
+            selector: (state) => state % 2 == 0,
+            builder: (context, state) => Text('isEven: $state'),
+          ),
+        ),
+      );
+
+      expect(find.text('isEven: true'), findsOneWidget);
+
+      firstCounterCubit.increment();
+      await tester.pumpAndSettle();
+      expect(find.text('isEven: false'), findsOneWidget);
+      expect(find.text('isEven: true'), findsNothing);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: BlocSelector<CounterCubit, int, bool>(
+            bloc: secondCounterCubit,
+            selector: (state) => state % 2 == 0,
+            builder: (context, state) => Text('isEven: $state'),
+          ),
+        ),
+      );
+
+      expect(find.text('isEven: true'), findsOneWidget);
+      expect(find.text('isEven: false'), findsNothing);
+
+      secondCounterCubit.increment();
+      await tester.pumpAndSettle();
+
+      expect(find.text('isEven: false'), findsOneWidget);
+      expect(find.text('isEven: true'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->
- feat(flutter_bloc): BlocSelector (closes #1989)

As a developer, I want to be able to select part of a bloc state and selectively rebuild UI in response to when the selected value changes. Currently this can be accomplishing via the `context.select` extension but it is not supported as a built-in widget (specifically in cases where the bloc is not available in the current `BuildContext`).

### Documentation

**BlocSelector** is a Flutter widget which is analogous to `BlocBuilder` but allows developers to filter updates by selecting a new value based on the current bloc state. Unnecessary builds are prevented if the selected value does not change. The selected value must be immutable in order for `BlocSelector` to accurately determine whether `builder` should be called again.

If the `bloc` parameter is omitted, `BlocSelector` will automatically perform a lookup using `BlocProvider` and the current `BuildContext`.

```dart
BlocSelector<BlocA, BlocAState, SelectedState>(
  selector: (state) {
    // return selected state based on the provided state.
  },
  builder: (context, state) {
    // return widget here based on the selected state.
  },
)
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
