### PR TITLE
docs(hydrated_bloc): fix example link rendered on pub.dev

### DIFF
--- a/packages/hydrated_bloc/README.md
+++ b/packages/hydrated_bloc/README.md
@@ -44,7 +44,7 @@ Our top sponsors are shown below! [[Become a Sponsor](https://github.com/sponsor
 
 `hydrated_bloc` exports a `Storage` interface which means it can work with any storage provider. Out of the box, it comes with its own implementation: `HydratedStorage`.
 
-`HydratedStorage` is built on top of [hive](https://pub.dev/packages/hive) for a platform-agnostic, performant storage layer. See the complete [example](example) for more details.
+`HydratedStorage` is built on top of [hive](https://pub.dev/packages/hive) for a platform-agnostic, performant storage layer. See the complete [example](https://github.com/felangel/bloc/blob/master/packages/hydrated_bloc/example) for more details.
 
 ## Usage
 


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

[https://pub.dev/packages/hydrated_bloc](https://pub.dev/packages/hydrated_bloc) mentions an example 404ing to [https://github.com/felangel/bloc/blob/master/example](https://github.com/felangel/bloc/blob/master/example)

Either point to the concrete url or maybe remove the wording.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
