### PR TITLE
docs(pt-br): add links to the Migration Guide

### DIFF
--- a/docs/pt-br/_coverpage.md
+++ b/docs/pt-br/_coverpage.md
@@ -10,7 +10,7 @@
 [![Discord](https://img.shields.io/discord/649708778631200778.svg?logo=discord&color=blue)](https://discord.gg/bloc)
 [![License: MIT](https://img.shields.io/badge/license-MIT-purple.svg)](https://opensource.org/licenses/MIT)
 
-> uma biblioteca previsível de gerenciamento de estado para o Dart.
+> uma biblioteca previsível de gerenciamento de estado para Dart.
 
 - Simples e leve
 - Altamente testável
@@ -21,3 +21,18 @@
     <a href="https://github.com/felangel/bloc/" target="_blank" rel="noopener">GitHub</a>
     <a href="#/pt-br/gettingstarted">Iniciar</a>
 </p>
+
+<p align="center" style="margin-top: 2em; margin-bottom: 0"><b>Patrocinado com 💖 por</b></p>
+
+<table align="center">
+    <tbody>
+        <tr>
+            <td align="center" style="padding-right: 0.5em">
+                <a href="https://verygood.ventures"><img src="https://raw.githubusercontent.com/felangel/bloc/master/docs/assets/vgv_logo_transparent.png" width="80"/></a>
+            </td>
+            <td align="center" style="padding-left: 0.5em">
+                <a href="https://getstream.io/chat/flutter/tutorial/?utm_source=https://github.com/felangel/bloc&utm_medium=github&utm_content=developer&utm_term=flutter" target="_blank"><img width="120" src="https://stream-blog-v2.imgix.net/blog/wp-content/uploads/bae8c920a484d1c49dbd148306aa1335/stream-bloc-flutter.png?auto=compress&fit=clip&w=120"/></a><br/><span><a href="https://getstream.io/chat/flutter/tutorial/?utm_source=https://github.com/felangel/bloc&utm_medium=github&utm_content=developer&utm_term=flutter" target="_blank">Experimente o Tutorial do Flutter Chat &nbsp💬</a></span>
+            </td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/pt-br/_coverpage.md
+++ b/docs/pt-br/_coverpage.md
@@ -16,5 +16,8 @@
 - Altamente testável
 - Para Dart, Flutter e AngularDart
 
-[GitHub](https://github.com/felangel/bloc/)
-[Iniciar](pt-br/gettingstarted.md)
+<p class="buttons">
+    <a href="#/pt-br/migration">Guia de Migração</a>
+    <a href="https://github.com/felangel/bloc/" target="_blank" rel="noopener">GitHub</a>
+    <a href="#/pt-br/gettingstarted">Iniciar</a>
+</p>

--- a/docs/pt-br/_sidebar.md
+++ b/docs/pt-br/_sidebar.md
@@ -9,6 +9,7 @@
   - [Testando](pt-br/testing.md)
   - [Naming Conventions](pt-br/blocnamingconventions.md)
   - [FAQs](pt-br/faqs.md)
+  - [Migração](pt-br/migration.md)
 
 - Tutoriais
 

--- a/docs/pt-br/_sidebar.md
+++ b/docs/pt-br/_sidebar.md
@@ -7,7 +7,7 @@
     - [flutter_bloc](pt-br/flutterbloccoreconcepts.md)
   - [Arquitetura](pt-br/architecture.md)
   - [Testando](pt-br/testing.md)
-  - [Naming Conventions](pt-br/blocnamingconventions.md)
+  - [Convenções de nomenclatura](pt-br/blocnamingconventions.md)
   - [FAQs](pt-br/faqs.md)
   - [Migração](pt-br/migration.md)
 

--- a/docs/pt-br/migration.md
+++ b/docs/pt-br/migration.md
@@ -1,4 +1,4 @@
-# Migration Guide
+# Guia de Migração
 
 ?> **Tip**: Por favor, consulte o [release log](https://github.com/felangel/bloc/releases) para obter mais informações sobre o que mudou em cada versão.
 


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

- add links to the Migration Guide in the sidebar and cover page
- add the sponsor info on the cover page

> Note: Currently, the Migration Guide (pt-br) already exists in the repo, however, there was no link pointing to this document.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
