### PR TITLE
feat(bloc_test): Add a mapper to blocTest

### DIFF
--- a/packages/bloc_test/lib/src/bloc_test.dart
+++ b/packages/bloc_test/lib/src/bloc_test.dart
@@ -131,6 +131,7 @@ void blocTest<B extends BlocBase<State>, State>(
   Function(B bloc)? act,
   Duration? wait,
   int skip = 0,
+  dynamic Function(State state)? map,
   dynamic Function()? expect,
   Function(B bloc)? verify,
   dynamic Function()? errors,
@@ -144,6 +145,7 @@ void blocTest<B extends BlocBase<State>, State>(
       act: act,
       wait: wait,
       skip: skip,
+      map: map,
       expect: expect,
       verify: verify,
       errors: errors,
@@ -162,6 +164,7 @@ Future<void> testBloc<B extends BlocBase<State>, State>({
   Function(B bloc)? act,
   Duration? wait,
   int skip = 0,
+  dynamic Function(State state)? map,
   dynamic Function()? expect,
   Function(B bloc)? verify,
   dynamic Function()? errors,
@@ -172,11 +175,18 @@ Future<void> testBloc<B extends BlocBase<State>, State>({
   await runZonedGuarded(
     () async {
       await setUp?.call();
-      final states = <State>[];
+      final states = <dynamic>[];
       final bloc = build();
       // ignore: invalid_use_of_visible_for_testing_member, invalid_use_of_protected_member
       if (seed != null) bloc.emit(seed());
-      final subscription = bloc.stream.skip(skip).listen(states.add);
+      final subscription = bloc.stream.skip(skip).listen((State state) {
+        if (map != null) {
+          states.add(map(state));
+        } else {
+          states.add(state);
+        }
+      });
+
       try {
         await act?.call(bloc);
       } catch (error) {

--- a/packages/bloc_test/test/map_bloc_test_test.dart
+++ b/packages/bloc_test/test/map_bloc_test_test.dart
@@ -1,0 +1,50 @@
+import 'package:bloc/bloc.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:meta/meta.dart';
+import 'package:test/test.dart';
+
+import 'blocs/blocs.dart';
+
+@immutable
+class CounterState {
+  const CounterState([this.counter]);
+
+  final int? counter;
+
+  CounterState copyWith(int? counter) => CounterState(counter);
+}
+
+class CounterExtBloc extends Bloc<CounterEvent, CounterState> {
+  CounterExtBloc() : super(const CounterState()) {
+    on<CounterEvent>((event, emit) {
+      switch (event) {
+        case CounterEvent.increment:
+          if (state.counter == 2) {
+            return emit(state.copyWith(null));
+          }
+          return emit(state.copyWith((state.counter ?? 0) + 1));
+      }
+    });
+  }
+}
+
+void main() {
+  group('blocTest', () {
+    group('CounterExtBloc', () {
+      blocTest<CounterExtBloc, CounterState>(
+        'emits [1, 2] when CounterEvent.increment is called multiple times '
+        'with async act',
+        build: () => CounterExtBloc(),
+        act: (bloc) async {
+          bloc
+            ..add(CounterEvent.increment)
+            ..add(CounterEvent.increment)
+            ..add(CounterEvent.increment)
+            ..add(CounterEvent.increment);
+        },
+        map: (CounterState state) => state.counter,
+        expect: () => const <int?>[1, 2, null, 1],
+      );
+    });
+  });
+}


### PR DESCRIPTION
PR for feature
https://github.com/felangel/bloc/issues/2817

## Status

**READY**

Have a test, but needs documentation and example.

## Breaking Changes

NO

## Description

Add a mapper to blocTest function so You can choose only needed part of the state and have no need to put whole states to expect parameter. 
It can save your time if the state is big, and your test does not need to examine the whole state, but only changes of some part of it.

```dart
blocTest<CounterExtBloc, CounterState>(
        'emits [1, 2] when CounterEvent.increment is called multiple times '
        'with async act',
        build: () => CounterExtBloc(),
        act: (bloc) async {
          bloc
            ..add(CounterEvent.increment)
            ..add(CounterEvent.increment)
            ..add(CounterEvent.increment)
            ..add(CounterEvent.increment);
        },
        map: (CounterState state) => state.counter,
        expect: () => const <int?>[1, 2, null, 1],
      );
```

where CounterState is:
```dart
@immutable
class CounterState {
  const CounterState([this.counter]);

  final int? counter;

  CounterState copyWith(int? counter) => CounterState(counter);
}
```

## Type of Change

- [x ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
