### PR TITLE
chore: remove 'abstract' keyword from freezed template

### DIFF
--- a/extensions/vscode/src/templates/cubit-state.template.ts
+++ b/extensions/vscode/src/templates/cubit-state.template.ts
@@ -49,7 +49,7 @@ function getFreezedCubitStateTemplate(cubitName: string): string {
   return `part of '${snakeCaseCubitName}_cubit.dart';
 
 @freezed
-abstract class ${pascalCaseCubitName}State with _\$${pascalCaseCubitName}State {
+class ${pascalCaseCubitName}State with _\$${pascalCaseCubitName}State {
   const factory ${pascalCaseCubitName}State.initial() = _Initial;
 }
 `;


### PR DESCRIPTION
## Status

Ready for review

## Breaking Changes

NO

## Description

Freezed does not require the abstract keyword [anymore](https://github.com/rrousselGit/freezed/tree/master/packages/freezed#the-abstract-keyword). Removed the `abstract` keyword from the cubit state template in accordance, to avoid following warning in the build_runner output.
```
The class MyCubit was declared as abstract, but it is not need anymore.
Read here: https://github.com/rrousselGit/freezed/tree/master/packages/freezed#the-abstract-keyword
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
