### PR TITLE
fix(flutter_bloc): determine bloc reference changes via identical

### DIFF
--- a/packages/flutter_bloc/lib/src/bloc_builder.dart
+++ b/packages/flutter_bloc/lib/src/bloc_builder.dart
@@ -155,6 +155,7 @@ class _BlocBuilderBaseState<B extends BlocBase<S>, S>
   Widget build(BuildContext context) {
     if (widget.bloc == null) {
       // Trigger a rebuild if the bloc reference has changed.
+      // See https://github.com/felangel/bloc/issues/2127.
       context.select<B, bool>((bloc) => identical(_bloc, bloc));
     }
     return BlocListener<B, S>(

--- a/packages/flutter_bloc/lib/src/bloc_consumer.dart
+++ b/packages/flutter_bloc/lib/src/bloc_consumer.dart
@@ -127,6 +127,7 @@ class _BlocConsumerState<B extends BlocBase<S>, S>
   Widget build(BuildContext context) {
     if (widget.bloc == null) {
       // Trigger a rebuild if the bloc reference has changed.
+      // See https://github.com/felangel/bloc/issues/2127.
       context.select<B, bool>((bloc) => identical(_bloc, bloc));
     }
     return BlocBuilder<B, S>(

--- a/packages/flutter_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/bloc_listener.dart
@@ -182,6 +182,7 @@ class _BlocListenerBaseState<B extends BlocBase<S>, S>
   Widget buildWithChild(BuildContext context, Widget? child) {
     if (widget.bloc == null) {
       // Trigger a rebuild if the bloc reference has changed.
+      // See https://github.com/felangel/bloc/issues/2127.
       context.select<B, bool>((bloc) => identical(_bloc, bloc));
     }
     return child!;

--- a/packages/flutter_bloc/lib/src/bloc_selector.dart
+++ b/packages/flutter_bloc/lib/src/bloc_selector.dart
@@ -91,6 +91,7 @@ class _BlocSelectorState<B extends BlocBase<S>, S, T>
   Widget build(BuildContext context) {
     if (widget.bloc == null) {
       // Trigger a rebuild if the bloc reference has changed.
+      // See https://github.com/felangel/bloc/issues/2127.
       context.select<B, bool>((bloc) => identical(_bloc, bloc));
     }
     return BlocListener<B, S>(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->
- fix(flutter_bloc): determine bloc reference changes via `identical`
  - Previously`identityHashCode` was used to determine if the bloc reference had changed to trigger a rebuild (#2482) however, it's possible for different bloc references to have the same `hashCode` as a result of hash collisions. The fix uses `identical` to determine whether the bloc reference has changed.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
