### PR TITLE
fix(bloc_listener) null pointer exception when no child has been given

### DIFF
--- a/packages/flutter_bloc/lib/src/bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/bloc_listener.dart
@@ -185,7 +185,7 @@ class _BlocListenerBaseState<B extends BlocBase<S>, S>
       // See https://github.com/felangel/bloc/issues/2127.
       context.select<B, bool>((bloc) => identical(_bloc, bloc));
     }
-    return child!;
+    return child ?? const SizedBox.shrink();
   }
 
   @override


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

When you add a BlocListener to the Widget tree the child is optional. to not break the current BlocListener interface I've made a check on the overridden buildWithChild that if the child is null when returned a Sizedbox Shrink constructor is called to return a valid non-nullable widget. 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
