### PR TITLE
docs(flutter_timer_tutorial): rename _mapTimerPausedToState to _onPaused

### DIFF
--- a/docs/fluttertimertutorial.md
+++ b/docs/fluttertimertutorial.md
@@ -119,7 +119,7 @@ Now let’s implement the `TimerPaused` event handler.
 
 [timer_bloc.dart](_snippets/flutter_timer_tutorial/timer_bloc_pause.dart.md ':include')
 
-In `_mapTimerPausedToState` if the `state` of our `TimerBloc` is `TimerRunInProgress`, then we can pause the `_tickerSubscription` and push a `TimerRunPause` state with the current timer duration.
+In `_onPaused` if the `state` of our `TimerBloc` is `TimerRunInProgress`, then we can pause the `_tickerSubscription` and push a `TimerRunPause` state with the current timer duration.
 
 Next, let’s implement the `TimerResumed` event handler so that we can unpause the timer.
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

In the timer tutorial documentation, I just updated the event's function name (_onPaused) in the TimerBloc. The tutorial does not use _mapTimerPausedToState, instead, it uses the event handler named _onPaused. Thus, It should be used in order to avoid confusion.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
