### PR TITLE
Fixed  vscode wrap issue.

### DIFF
--- a/extensions/vscode/src/utils/convert-to.ts
+++ b/extensions/vscode/src/utils/convert-to.ts
@@ -9,7 +9,7 @@ export const convertTo = async (
   let editor = window.activeTextEditor;
   if (!editor) return;
   const selection = getSelectedText(editor);
-  const rawWidget = editor.document.getText(selection);
+  const rawWidget = editor.document.getText(selection).replace("$", "//$");
   const match = rawWidget.match(childRegExp);
   if (!match || !match.length) return;
   const child = match[0];

--- a/extensions/vscode/src/utils/wrap-with.ts
+++ b/extensions/vscode/src/utils/wrap-with.ts
@@ -5,11 +5,7 @@ export const wrapWith = async (snippet: (widget: string) => string) => {
   let editor = window.activeTextEditor;
   if (!editor) return;
   const selection = getSelectedText(editor);
-  const widget = editor.document.getText(selection);
-  // insertSnippet will execute the $ expression in the widget text, 
-  // so first escape the $ to prevent it from being executed incorrectly, 
-  // and insertSnippet will also eliminate the escape.
-  const escapedWidget = widget.replace(/\$/g, '\\$');
-  editor.insertSnippet(new SnippetString(snippet(escapedWidget)), selection);
+  const widget = editor.document.getText(selection).replace("$", "\\$");
+  editor.insertSnippet(new SnippetString(snippet(widget)), selection);
   await commands.executeCommand("editor.action.formatDocument");
 };

--- a/extensions/vscode/src/utils/wrap-with.ts
+++ b/extensions/vscode/src/utils/wrap-with.ts
@@ -6,6 +6,10 @@ export const wrapWith = async (snippet: (widget: string) => string) => {
   if (!editor) return;
   const selection = getSelectedText(editor);
   const widget = editor.document.getText(selection);
-  editor.insertSnippet(new SnippetString(snippet(widget)), selection);
+  // insertSnippet will execute the $ expression in the widget text, 
+  // so first escape the $ to prevent it from being executed incorrectly, 
+  // and insertSnippet will also eliminate the escape.
+  const escapedWidget = widget.replace(/\$/g, '\\$');
+  editor.insertSnippet(new SnippetString(snippet(escapedWidget)), selection);
   await commands.executeCommand("editor.action.formatDocument");
 };


### PR DESCRIPTION
## Status

FINISH

## Breaking Changes

 NO

## Description

When wrapp with bloc snippet, the $ expression in the widget content will be removed.

***Root case:*** VS Code insertSnippet will execute the $ expression in the text.

***Fix:*** Escape the $ to prevent it from being executed incorrectly.

## Type of Change
- [ x ] 🛠️ Bug fix (non-breaking change which fixes an issue)
#2925 