### PR TITLE
feat(flutter_bloc): Adds nullable return widget for BlocBuilder

### DIFF
--- a/packages/flutter_bloc/lib/src/bloc_builder.dart
+++ b/packages/flutter_bloc/lib/src/bloc_builder.dart
@@ -4,7 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 /// Signature for the `builder` function which takes the `BuildContext` and
 /// [state] and is responsible for returning a widget which is to be rendered.
 /// This is analogous to the `builder` function in [StreamBuilder].
-typedef BlocWidgetBuilder<S> = Widget Function(BuildContext context, S state);
+typedef BlocWidgetBuilder<S> = Widget? Function(BuildContext context, S state);
 
 /// Signature for the `buildWhen` function which takes the previous `state` and
 /// the current `state` and is responsible for returning a [bool] which
@@ -86,7 +86,8 @@ class BlocBuilder<B extends BlocBase<S>, S> extends BlocBuilderBase<B, S> {
   final BlocWidgetBuilder<S> builder;
 
   @override
-  Widget build(BuildContext context, S state) => builder(context, state);
+  Widget build(BuildContext context, S state) =>
+      builder(context, state) ?? Container();
 }
 
 /// {@template bloc_builder_base}


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

When using BlocBuilder, there are a lot of times where you have to check your state's type and return an empty Container when none of the types are matched. This pull request makes the return Widget of the builder function nullable. If no widget is returned, the BlocBuilder will return an empty Container.

## Type of Change

- [x ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
