### PR TITLE
fix(examples/flutter_firestore-todos): Adding an orElse function to fix the Bad State exception

### DIFF
--- a/examples/flutter_firestore_todos/lib/screens/details_screen.dart
+++ b/examples/flutter_firestore_todos/lib/screens/details_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_firestore_todos/blocs/todos/todos.dart';
 import 'package:flutter_firestore_todos/screens/screens.dart';
+import 'package:todos_repository/todos_repository.dart';
 
 class DetailsScreen extends StatelessWidget {
   final String id;
@@ -15,7 +16,10 @@ class DetailsScreen extends StatelessWidget {
         if (state is! TodosLoaded) {
           throw StateError('Cannot render details without a valid todo');
         }
-        final todo = state.todos.firstWhere((todo) => todo.id == id);
+        final todo = state.todos.firstWhere(
+          (todo) => todo.id == id,
+          orElse: () => Todo(task: ''),
+        );
         return Scaffold(
           appBar: AppBar(
             title: Text('Todo Details'),


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

The flutter firestore todos examples throws a "Bad State: No element" exception after a todos is deleted. This is because when the DetailsScreen tries to rebuild there is no todo found or returned from the "firstWhere" function.  The details of the exception can be seen in screenshot.

![Screen Shot 2021-11-20 at 6 41 00 AM](https://user-images.githubusercontent.com/25843865/142715871-bc9b5cc8-b101-4a88-aa2f-1e77edc2239d.png)


## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

