### PR TITLE
docs(flutterbloccoreconcepts): rename events to follow naming conventions

### DIFF
--- a/docs/_snippets/flutter_bloc_core_concepts/counter_bloc.dart.md
+++ b/docs/_snippets/flutter_bloc_core_concepts/counter_bloc.dart.md
@@ -1,12 +1,12 @@
 ```dart
 abstract class CounterEvent {}
-class Increment extends CounterEvent {}
-class Decrement extends CounterEvent {}
+class CounterIncremented extends CounterEvent {}
+class CounterDecremented extends CounterEvent {}
 
 class CounterBloc extends Bloc<CounterEvent, int> {
   CounterBloc() : super(0) {
-    on<Increment>((event, emit) => emit(state + 1));
-    on<Decrement>((event, emit) => emit(state - 1));
+    on<CounterIncremented>((event, emit) => emit(state + 1));
+    on<CounterDecremented>((event, emit) => emit(state - 1));
   }
 }
 ```

--- a/docs/_snippets/flutter_bloc_core_concepts/counter_bloc.dart.md
+++ b/docs/_snippets/flutter_bloc_core_concepts/counter_bloc.dart.md
@@ -1,12 +1,12 @@
 ```dart
 abstract class CounterEvent {}
-class CounterIncremented extends CounterEvent {}
-class CounterDecremented extends CounterEvent {}
+class CounterIncrementPressed extends CounterEvent {}
+class CounterDecrementPressed extends CounterEvent {}
 
 class CounterBloc extends Bloc<CounterEvent, int> {
   CounterBloc() : super(0) {
-    on<CounterIncremented>((event, emit) => emit(state + 1));
-    on<CounterDecremented>((event, emit) => emit(state - 1));
+    on<CounterIncrementPressed>((event, emit) => emit(state + 1));
+    on<CounterDecrementPressed>((event, emit) => emit(state - 1));
   }
 }
 ```

--- a/docs/_snippets/flutter_bloc_core_concepts/counter_page.dart.md
+++ b/docs/_snippets/flutter_bloc_core_concepts/counter_page.dart.md
@@ -22,14 +22,14 @@ class CounterPage extends StatelessWidget {
             padding: EdgeInsets.symmetric(vertical: 5.0),
             child: FloatingActionButton(
               child: Icon(Icons.add),
-              onPressed: () => context.read<CounterBloc>().add(Increment()),
+              onPressed: () => context.read<CounterBloc>().add(CounterIncremented()),
             ),
           ),
           Padding(
             padding: EdgeInsets.symmetric(vertical: 5.0),
             child: FloatingActionButton(
               child: Icon(Icons.remove),
-              onPressed: () => context.read<CounterBloc>().add(Decrement()),
+              onPressed: () => context.read<CounterBloc>().add(CounterDecremented()),
             ),
           ),
         ],

--- a/docs/_snippets/flutter_bloc_core_concepts/counter_page.dart.md
+++ b/docs/_snippets/flutter_bloc_core_concepts/counter_page.dart.md
@@ -22,14 +22,14 @@ class CounterPage extends StatelessWidget {
             padding: EdgeInsets.symmetric(vertical: 5.0),
             child: FloatingActionButton(
               child: Icon(Icons.add),
-              onPressed: () => context.read<CounterBloc>().add(CounterIncremented()),
+              onPressed: () => context.read<CounterBloc>().add(CounterIncrementPressed()),
             ),
           ),
           Padding(
             padding: EdgeInsets.symmetric(vertical: 5.0),
             child: FloatingActionButton(
               child: Icon(Icons.remove),
-              onPressed: () => context.read<CounterBloc>().add(CounterDecremented()),
+              onPressed: () => context.read<CounterBloc>().add(CounterDecrementPressed()),
             ),
           ),
         ],


### PR DESCRIPTION
## Status

READY

## Breaking Changes

NO

## Description

Update examples on docs(flutterbloccoreconcepts) follow naming convention.
#3023 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
