### PR TITLE
fix(flutter_bloc): reproduce missing stack trace for bloc constructor

### DIFF
--- a/packages/flutter_bloc/test/bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/bloc_provider_test.dart
@@ -204,10 +204,9 @@ void main() {
       );
     });
 
-    testWidgets(
-        'propagates stack trace of BloC constructor exception', (tester) async {
-      const expected =
-          '''Catch me, if you can!''';
+    testWidgets('propagates stack trace of BloC constructor exception',
+        (tester) async {
+      const expected = '''Catch me, if you can!''';
       await tester.pumpWidget(BlocProvider(
         lazy: false,
         create: (_) => CounterCubitWithBrokenConstructor(),

--- a/packages/flutter_bloc/test/bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/bloc_provider_test.dart
@@ -161,12 +161,20 @@ class CounterCubit extends Cubit<int> {
   final Function? onClose;
 
   void increment() => emit(state + 1);
+
   void decrement() => emit(state - 1);
 
   @override
   Future<void> close() {
     onClose?.call();
     return super.close();
+  }
+}
+
+class CounterCubitWithBrokenConstructor extends CounterCubit {
+  CounterCubitWithBrokenConstructor() {
+    // ignore: only_throw_errors
+    throw 'Catch me, if you can!';
   }
 }
 
@@ -194,6 +202,17 @@ void main() {
         tester.takeException(),
         isA<AssertionError>().having((e) => e.message, 'message', expected),
       );
+    });
+
+    testWidgets(
+        'propagates stack trace of BloC constructor exception', (tester) async {
+      const expected =
+          '''Catch me, if you can!''';
+      await tester.pumpWidget(BlocProvider(
+        lazy: false,
+        create: (_) => CounterCubitWithBrokenConstructor(),
+        child: const SizedBox(),
+      ));
     });
 
     testWidgets('lazy is true by default', (tester) async {

--- a/packages/flutter_bloc/test/bloc_provider_test.dart
+++ b/packages/flutter_bloc/test/bloc_provider_test.dart
@@ -206,6 +206,7 @@ void main() {
 
     testWidgets('propagates stack trace of BloC constructor exception',
         (tester) async {
+      // ignore: unused_local_variable
       const expected = '''Catch me, if you can!''';
       await tester.pumpWidget(BlocProvider(
         lazy: false,


### PR DESCRIPTION
This pull request adds a failing test to reproduce https://github.com/felangel/bloc/pull/3051. It doesn't contain the solution.

## Status

**HOLD**

## Breaking Changes

NO 

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
