### PR TITLE
fix(bloc_test): throw uncaught exceptions

### DIFF
--- a/packages/bloc_test/lib/src/bloc_test.dart
+++ b/packages/bloc_test/lib/src/bloc_test.dart
@@ -200,6 +200,7 @@ Future<void> testBloc<B extends BlocBase<State>, State>({
           try {
             await act?.call(bloc);
           } catch (error) {
+            if (errors == null) rethrow;
             unhandledErrors.add(error);
           }
           if (wait != null) await Future<void>.delayed(wait);
@@ -231,7 +232,7 @@ WARNING: Please ensure state instances extend Equatable, override == and hashCod
 Alternatively, consider using Matchers in the expect of the blocTest rather than concrete state instances.\n''',
             );
           }
-          if (!unhandledErrors.contains(error)) {
+          if (errors == null || !unhandledErrors.contains(error)) {
             // ignore: only_throw_errors
             throw error;
           }

--- a/packages/bloc_test/test/bloc_bloc_test_test.dart
+++ b/packages/bloc_test/test/bloc_bloc_test_test.dart
@@ -388,7 +388,7 @@ void main() {
         build: () => ErrorCounterBloc(),
         act: (bloc) => bloc.add(CounterEvent.increment),
         expect: () => const <int>[1],
-        errors: () => [isA<ErrorCounterBlocError>()],
+        errors: () => isNotEmpty,
       );
 
       blocTest<ErrorCounterBloc, int>(

--- a/packages/bloc_test/test/bloc_bloc_test_test.dart
+++ b/packages/bloc_test/test/bloc_bloc_test_test.dart
@@ -123,9 +123,46 @@ void main() {
           await completer.future;
         }, (Object error, _) {
           actualError = error;
-          completer.complete();
+          if (!completer.isCompleted) completer.complete();
         });
         expect((actualError as TestFailure).message, expectedError);
+      });
+
+      test(
+          'fails immediately when '
+          'uncaught exception occurs within bloc', () async {
+        late Object actualError;
+        final completer = Completer<void>();
+        await runZonedGuarded(() async {
+          unawaited(testBloc<ErrorCounterBloc, int>(
+            build: () => ErrorCounterBloc(),
+            act: (bloc) => bloc.add(CounterEvent.increment),
+            expect: () => const <int>[1],
+          ).then((_) => completer.complete()));
+          await completer.future;
+        }, (Object error, _) {
+          actualError = error;
+          if (!completer.isCompleted) completer.complete();
+        });
+        expect(actualError, isA<ErrorCounterBlocError>());
+      });
+
+      test('fails immediately when exception occurs in act', () async {
+        final exception = Exception('oops');
+        late Object actualError;
+        final completer = Completer<void>();
+        await runZonedGuarded(() async {
+          unawaited(testBloc<ErrorCounterBloc, int>(
+            build: () => ErrorCounterBloc(),
+            act: (_) => throw exception,
+            expect: () => const <int>[1],
+          ).then((_) => completer.complete()));
+          await completer.future;
+        }, (Object error, _) {
+          actualError = error;
+          if (!completer.isCompleted) completer.complete();
+        });
+        expect(actualError, exception);
       });
     });
 
@@ -314,7 +351,7 @@ void main() {
         'emits [ComplexStateB] when ComplexEventB is added',
         build: () => ComplexBloc(),
         act: (bloc) => bloc.add(ComplexEventB()),
-        expect: () => <Matcher>[isA<ComplexStateB>()],
+        expect: () => [isA<ComplexStateB>()],
       );
 
       blocTest<ComplexBloc, ComplexState>(
@@ -325,7 +362,7 @@ void main() {
           ..add(ComplexEventB())
           ..add(ComplexEventA()),
         skip: 1,
-        expect: () => <Matcher>[isA<ComplexStateA>()],
+        expect: () => [isA<ComplexStateA>()],
       );
     });
     group('ErrorCounterBloc', () {
@@ -343,6 +380,7 @@ void main() {
           ..add(CounterEvent.increment),
         skip: 1,
         expect: () => const <int>[2],
+        errors: () => isNotEmpty,
       );
 
       blocTest<ErrorCounterBloc, int>(
@@ -350,13 +388,14 @@ void main() {
         build: () => ErrorCounterBloc(),
         act: (bloc) => bloc.add(CounterEvent.increment),
         expect: () => const <int>[1],
+        errors: () => [isA<ErrorCounterBlocError>()],
       );
 
       blocTest<ErrorCounterBloc, int>(
         'throws ErrorCounterBlocException when increment is added',
         build: () => ErrorCounterBloc(),
         act: (bloc) => bloc.add(CounterEvent.increment),
-        errors: () => <Matcher>[isA<ErrorCounterBlocError>()],
+        errors: () => [isA<ErrorCounterBlocError>()],
       );
 
       blocTest<ErrorCounterBloc, int>(
@@ -365,7 +404,7 @@ void main() {
         build: () => ErrorCounterBloc(),
         act: (bloc) => bloc.add(CounterEvent.increment),
         expect: () => const <int>[1],
-        errors: () => <Matcher>[isA<ErrorCounterBlocError>()],
+        errors: () => [isA<ErrorCounterBlocError>()],
       );
 
       blocTest<ErrorCounterBloc, int>(
@@ -375,6 +414,7 @@ void main() {
           ..add(CounterEvent.increment)
           ..add(CounterEvent.increment),
         expect: () => const <int>[1, 2],
+        errors: () => isNotEmpty,
       );
 
       blocTest<ErrorCounterBloc, int>(
@@ -384,7 +424,7 @@ void main() {
         act: (bloc) => bloc
           ..add(CounterEvent.increment)
           ..add(CounterEvent.increment),
-        errors: () => <Matcher>[
+        errors: () => [
           isA<ErrorCounterBlocError>(),
           isA<ErrorCounterBlocError>(),
         ],
@@ -398,7 +438,7 @@ void main() {
           ..add(CounterEvent.increment)
           ..add(CounterEvent.increment),
         expect: () => const <int>[1, 2],
-        errors: () => <Matcher>[
+        errors: () => [
           isA<ErrorCounterBlocError>(),
           isA<ErrorCounterBlocError>(),
         ],
@@ -420,6 +460,7 @@ void main() {
           ..add(CounterEvent.increment),
         skip: 1,
         expect: () => const <int>[2],
+        errors: () => isNotEmpty,
       );
 
       blocTest<ExceptionCounterBloc, int>(
@@ -427,13 +468,14 @@ void main() {
         build: () => ExceptionCounterBloc(),
         act: (bloc) => bloc.add(CounterEvent.increment),
         expect: () => const <int>[1],
+        errors: () => isNotEmpty,
       );
 
       blocTest<ExceptionCounterBloc, int>(
         'throws ExceptionCounterBlocException when increment is added',
         build: () => ExceptionCounterBloc(),
         act: (bloc) => bloc.add(CounterEvent.increment),
-        errors: () => <Matcher>[isA<ExceptionCounterBlocException>()],
+        errors: () => [isA<ExceptionCounterBlocException>()],
       );
 
       blocTest<ExceptionCounterBloc, int>(
@@ -442,7 +484,7 @@ void main() {
         build: () => ExceptionCounterBloc(),
         act: (bloc) => bloc.add(CounterEvent.increment),
         expect: () => const <int>[1],
-        errors: () => <Matcher>[isA<ExceptionCounterBlocException>()],
+        errors: () => [isA<ExceptionCounterBlocException>()],
       );
 
       blocTest<ExceptionCounterBloc, int>(
@@ -452,6 +494,7 @@ void main() {
           ..add(CounterEvent.increment)
           ..add(CounterEvent.increment),
         expect: () => const <int>[1, 2],
+        errors: () => isNotEmpty,
       );
 
       blocTest<ExceptionCounterBloc, int>(
@@ -461,7 +504,7 @@ void main() {
         act: (bloc) => bloc
           ..add(CounterEvent.increment)
           ..add(CounterEvent.increment),
-        errors: () => <Matcher>[
+        errors: () => [
           isA<ExceptionCounterBlocException>(),
           isA<ExceptionCounterBlocException>(),
         ],
@@ -475,7 +518,7 @@ void main() {
           ..add(CounterEvent.increment)
           ..add(CounterEvent.increment),
         expect: () => const <int>[1, 2],
-        errors: () => <Matcher>[
+        errors: () => [
           isA<ExceptionCounterBlocException>(),
           isA<ExceptionCounterBlocException>(),
         ],
@@ -563,7 +606,7 @@ void main() {
           await completer.future;
         }, (Object error, _) {
           actualError = error;
-          completer.complete();
+          if (!completer.isCompleted) completer.complete();
         });
         expect((actualError as TestFailure).message, expectedError);
       });

--- a/packages/bloc_test/test/cubits/delayed_counter_cubit.dart
+++ b/packages/bloc_test/test/cubits/delayed_counter_cubit.dart
@@ -6,7 +6,9 @@ class DelayedCounterCubit extends Cubit<int> {
   void increment() {
     Future<void>.delayed(
       const Duration(milliseconds: 300),
-      () => emit(state + 1),
+      () {
+        if (!isClosed) emit(state + 1);
+      },
     );
   }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->
If an uncaught error occurs within a bloc, cubit, or within the `blocTest` they are currently being swallowed by default which makes it very difficult to debug. Instead of swallowing uncaught errors, this change rethrows uncaught errors so that it is clear that an exception has occurred during the `blocTest`.

If `errors` is not null, uncaught errors will be aggregated and evaluated against the `errors` matcher.

- closes #3058

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
