### PR TITLE
docs(fluttertodostutorial): use correct ascii character in `--recursive`

### DIFF
--- a/docs/fluttertodostutorial.md
+++ b/docs/fluttertodostutorial.md
@@ -48,7 +48,7 @@ We can then replace the contents of `pubspec.yaml` with:
 Finally, we can install all the dependencies:
 
 ```sh
-very_good packages get —-recursive
+very_good packages get --recursive
 ```
 
 ## Project Structure


### PR DESCRIPTION
Follow up to https://github.com/felangel/bloc/commit/4e1cfbb8ffafaa239c6c94e88844f985b5704a63

## Status

**READY**

## Breaking Changes

NO

## Description

Both dashes should be character 45 instead of 151 and 45 (https://www.petefreitag.com/cheatsheets/ascii-codes/). I confirmed that copy/pasting the existing characters makes the command fail in the terminal.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
