### PR TITLE
docs(bloc): Included missing slash in doc comment

### DIFF
--- a/packages/bloc/lib/src/emitter.dart
+++ b/packages/bloc/lib/src/emitter.dart
@@ -31,7 +31,7 @@ abstract class Emitter<State> {
     void Function(Object error, StackTrace stackTrace)? onError,
   });
 
-  // Subscribes to the provided [stream] and invokes the [onData] callback
+  /// Subscribes to the provided [stream] and invokes the [onData] callback
   /// when the [stream] emits new data and the result of [onData] is emitted.
   ///
   /// [forEach] completes when the event handler is cancelled or when


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

Included an additional slash to convert the block comment (`//`) to a doc comment (`///`). Closes #3166 .

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
