### PR TITLE
docs(flutter_bloc): Extension Methods documentation

### DIFF
--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -174,3 +174,37 @@ Since we only have one repository in our app, we will inject it into our widget 
 Now when instantiating a bloc, we can access the instance of a repository via `context.read` and inject the repository into the bloc via constructor.
 
 [flutter_weather_link]: https://github.com/felangel/bloc/blob/master/examples/flutter_weather
+
+## Extension Methods Usage
+
+Extension methods, introduced in Dart 2.7, allows to add functionalities to existing classes. 
+
+Importing the `flutter_bloc` package includes different extension methods and this section aims to describe what and how these should be used.
+
+?> Check out the official [Dart Documentation](https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html) for more information about extension methods.
+
+### Provider
+
+`flutter_bloc` besides depending on `flutter` also depends on the [provider](https://pub.dev/packages/provider) package. Provider aims to wrap `InheritedWidget` and simplify its usage. 
+
+In essence, when using `BlocProvider`, `MultiBlocProvider`, `RepositoryProvider` and `MultiRepositoryProvider` widgets are including an `InheritedProvider` to the widget tree. 
+
+?> Check out the official [Flutter Documentation](https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html) to learn more about `InheritedWidget`.
+
+#### ReadContext extension
+
+##### What is `context.read<T>`?
+
+`Provider` is a wrapper over `InheritedWidget`. The convention for `InheritedWidget`s is to expose a `static` method named `of`. This method usually searches the widget tree for the nearest `InheritedWidget` which matches a given `Type`. This is exactly what `BlocProvider.of<T>(context)` does.
+
+Some developers consider `BlocProvider.of<T>(context)` too verbose and take advantage of *extension methods*. Thus, the provider package creates an extension on `BuildContext` (named `ReadContext`) that includes the `read<T>()` method.
+
+It is important to note that `BlocProvider.of<T>(context)` and `context.read<T>` do not listen to `T`. In other words, if the provided `Object` changes `read` will not be called to update the value after this change.
+
+?> `BlocProvider.of<T>(context)` and `context.read<T>` are equivalent.
+
+##### How to use `context.read<T>`?
+
+#### WatchContext extension
+
+#### SelectContext extension

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -191,6 +191,8 @@ In essence, `BlocProvider`, `MultiBlocProvider`, `RepositoryProvider` and `Multi
 
 In addition, `flutter_bloc` exports `ReadContext`, `WatchContext` and `SelectContext`, all extensions from `package:provider`. This means that when importing `package:flutter_bloc` we have access to these extensions.
 
+?> Check out [Provider's pub page](https://pub.dev/packages/provider) to learn more about `Provider`.
+
 ### ReadContext
 
 #### What is `context.read<T>`?

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -177,9 +177,7 @@ Now when instantiating a bloc, we can access the instance of a repository via `c
 
 ## Extension Methods Usage
 
-Extension methods, introduced in Dart 2.7, allow to add functionalities to existing classes. 
-
-Importing the `flutter_bloc` package includes different extension methods and this section aims to describe what and how these should be used.
+Importing the `flutter_bloc` package includes different extension methods and this section aims to describe what and how these should be used. This type of methods, included in Dart 2.7, allow to add functionalities to existing classes.
 
 ?> Check out the official [Dart Documentation](https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html) for more information about extension methods.
 
@@ -191,7 +189,7 @@ Importing the `flutter_bloc` package includes different extension methods and th
 
 In essence, `BlocProvider`, `MultiBlocProvider`, `RepositoryProvider` and `MultiRepositoryProvider` widgets are including an `InheritedProvider` to the widget tree.
 
-In addition, `flutter_bloc` exports `ReadContext`, `WatchContext` and `SelectContext`, all extensions from `package:provider`.
+In addition, `flutter_bloc` exports `ReadContext`, `WatchContext` and `SelectContext`, all extensions from `package:provider`. This means that when importing `package:flutter_bloc` we have access to these extensions.
 
 #### ReadContext extension
 
@@ -199,7 +197,7 @@ In addition, `flutter_bloc` exports `ReadContext`, `WatchContext` and `SelectCon
 
 `Provider` is a wrapper over `InheritedWidget`. The convention for `InheritedWidget`s is to expose a `static` method named `of`. This method usually searches the widget tree for the nearest `InheritedWidget` which matches a given `Type`. This is exactly what `BlocProvider.of<T>(context)` does.
 
-Some developers consider `BlocProvider.of<T>(context)` too verbose and take advantage of *extension methods*. Thus, the provider package creates an extension on `BuildContext` (named `ReadContext`) that includes the `read<T>()` method.
+Some developers consider `BlocProvider.of<T>(context)` too verbose and take advantage of *extension methods*. Thus, `package:provider` creates an extension, named `ReadContext` on `BuildContext` that includes the `read<T>()` method.
 
 It is important to note that `BlocProvider.of<T>(context)` and `context.read<T>` do not listen to `T`. In other words, if the provided `Object` changes `read` will not be called to update the value after this change.
 

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -197,14 +197,41 @@ In addition, `flutter_bloc` exports `ReadContext`, `WatchContext` and `SelectCon
 
 `Provider` is a wrapper over `InheritedWidget`. The convention for `InheritedWidget`s is to expose a `static` method named `of`. This method usually searches the widget tree for the nearest `InheritedWidget` which matches a given `Type`. This is exactly what `BlocProvider.of<T>(context)` does.
 
-Some developers consider `BlocProvider.of<T>(context)` too verbose and take advantage of *extension methods*. Thus, `package:provider` creates an extension, named `ReadContext` on `BuildContext` that includes the `read<T>()` method.
+Some developers consider `BlocProvider.of<T>(context)` too verbose and take advantage of *extension methods*. Thus, `package:provider` creates an extension, named `ReadContext` on `BuildContext` that defines the `read<T>()` method.
 
-It is important to note that `BlocProvider.of<T>(context)` and `context.read<T>` do not listen to `T`. In other words, if the provided `Object` changes `read` will not be called to update the value after this change.
+It is important to note that `BlocProvider.of<T>(context)` and `context.read<T>()` do not listen to `T`. In other words, if the provided `Object` of type `T` changes `read` will not be called to update the value after this change.
 
-?> `BlocProvider.of<T>(context)` and `context.read<T>` are equivalent.
+?> `BlocProvider.of<T>(context)` and `context.read<T>()` are equivalent.
 
 ##### How to use `context.read<T>`?
 
 #### WatchContext extension
 
+##### What is `context.watch<T>`?
+
+`package:provider` creates an extension, named `WatchContext` on `BuildContext` that defines the `watch<T>()` method. 
+
+Not only `context.watch<T>()` provides the closest `T` provided in the widget tree. But it also listens to changes on `T`, unlike `context.read<T>()`. This means that, if the provided `Object` of type `T` changes, `watch` will trigger a rebuild. Thus, this method is only accesible inside a `StatelessWidget`'s or `State`'s `build` method.
+
+?> `BlocProvider.of<T>(context, listen: true)` and `context.watch<T>()` are equivalent.
+
+##### How to use `context.watch<T>`?
+
 #### SelectContext extension
+
+##### What is `context.select<T, R>`?
+
+`package:provider` creates an extension, named `SelectContext` on `BuildContext` that defines the `select<T, R>(R function(T value))` method. 
+
+As in  `context.watch<T>()`, `context.select<T, R>(R function(T value))` provides the closest `T` provided in the widget tree. And also listens to changes on `T`, unlike `context.read<T>()`. However, the `select` method allows to be more selective, and avoid uneccesary rebuilds by specifying which property should be listened.
+
+For example, the code below will only rebuild the widget when the property `name` of `Unicorn` changes value. It will not rebuild if some other property of `Unicorn` changes.
+
+```dart
+Widget build(BuildContext context) {
+  final name = context.select((Unicorn unicorn) => unicorn.name);
+  return Text(name);
+}
+```
+
+##### How to use `context.select<T, R>`?

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -193,7 +193,6 @@ In addition, `package:flutter_bloc` exports the `ReadContext`, `WatchContext` an
 
 ### ReadContext
 
-`package:provider` creates an extension named `ReadContext` on `BuildContext` that defines the `read<T>()` method. 
 
 `context.read<T>()` provides the closest `T` provided in the widget tree. However, `context.read<T>()` does not listen to `T`. In other words, if the provided `Object` of type `T` changes, `read` will not trigger a rebuild.
 

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -193,7 +193,6 @@ In addition, `package:flutter_bloc` exports the `ReadContext`, `WatchContext` an
 
 ### ReadContext
 
-
 `context.read<T>()` provides the closest `T` provided in the widget tree. However, `context.read<T>()` does not listen to `T`. In other words, if the provided `Object` of type `T` changes, `read` will not trigger a rebuild.
 
 The convention for `InheritedWidgets` is to expose a `static` method named `of`. This method usually searches the widget tree via `BuildContext` for the nearest `InheritedWidget` which matches a given `Type`. This is exactly what `BlocProvider.of<T>(context)` and `context.read<T>()` do.
@@ -204,7 +203,7 @@ The convention for `InheritedWidgets` is to expose a `static` method named `of`.
 
 Both, `BlocProvider.of<T>(context)` and `context.read<T>()` are functionally equivalent. It is up to the developer to go with the most convenient method. Although, it is preferred to be consistent with the given choice.
 
-**DO** use `context.read<T>()` to add events.
+**DO** use `context.read` to add events.
 
 ```dart
 context.read<CounterBloc>().add(CounterIncrementPressed()),
@@ -212,7 +211,7 @@ context.read<CounterBloc>().add(CounterIncrementPressed()),
 
 `context.read` is most commonly used for retrieving a bloc instance in order to add an event within `onPressed` callbacks. `context.read` should not be used to retrieve a bloc's state directly within the build method.
 
-**AVOID** using `context.read<T>()` to retrieve state.
+**AVOID** using `context.read` to retrieve state.
 
 ```dart
 @override
@@ -230,9 +229,9 @@ Like `context.read<T>()`, `context.watch<T>()` provides the closest `T` provided
 
 ?> `BlocProvider.of<T>(context, listen: true)` and `context.watch<T>()` are functionally equivalent.
 
-#### How to use `context.watch<T>`?
+#### How to use `context.watch`?
 
-**DON'T** use `context.watch<T>()` when parent widget in build method doesn't depend on state.
+**DON'T** use `context.watch` when parent widget in build method doesn't depend on state.
 
 ```dart
 @override
@@ -250,7 +249,7 @@ Widget build(BuildContext context) {
 
 !> Using `context.watch` at the root of the `build` method will result in the entire widget being rebuilt when the bloc state changes.
 
-**PREFER** use `BlocBuilder` instead of `context.watch<T>()` to explicitly scope rebuilds.
+**PREFER** use `BlocBuilder` instead of `context.watch` to explicitly scope rebuilds.
 
 ```dart
 Widget build(BuildContext context) {
@@ -313,11 +312,11 @@ Widget build(BuildContext context) {
 
 The above will only rebuild the widget when the property `value` of `MyBloc` changes value. It will not rebuild if some other property of `MyBloc` changes.
 
-##### How to use `context.select<T, R>`?
+##### How to use `context.select`?
 
 Whenever it is required to only listen to specific changes of a bloc state, it is preferred to be selective and avoid unnecessary rebuilds.
 
-**DON'T** use `context.select<T>()` when parent widget in build method doesn't depend on state.
+**DON'T** use `context.select` when parent widget in build method doesn't depend on state.
 
 ```dart
 @override
@@ -335,7 +334,7 @@ Widget build(BuildContext context) {
 
 !> Using `context.watch` at the root of the `build` method will result in the entire widget being rebuilt when the bloc state changes.
 
-**PREFER** use `BlocSelector` instead of `context.select<T>()` to explicitly scope rebuilds.
+**PREFER** use `BlocSelector` instead of `context.select` to explicitly scope rebuilds.
 
 ```dart
 Widget build(BuildContext context) {

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -177,7 +177,7 @@ Now when instantiating a bloc, we can access the instance of a repository via `c
 
 ## Extension Methods Usage
 
-Extension methods, introduced in Dart 2.7, allows to add functionalities to existing classes. 
+Extension methods, introduced in Dart 2.7, allow to add functionalities to existing classes. 
 
 Importing the `flutter_bloc` package includes different extension methods and this section aims to describe what and how these should be used.
 
@@ -187,7 +187,7 @@ Importing the `flutter_bloc` package includes different extension methods and th
 
 `flutter_bloc` besides depending on `flutter` also depends on the [provider](https://pub.dev/packages/provider) package. Provider aims to wrap `InheritedWidget` and simplify its usage. 
 
-In essence, when using `BlocProvider`, `MultiBlocProvider`, `RepositoryProvider` and `MultiRepositoryProvider` widgets are including an `InheritedProvider` to the widget tree. 
+In essence, `BlocProvider`, `MultiBlocProvider`, `RepositoryProvider` and `MultiRepositoryProvider` widgets are including an `InheritedProvider` to the widget tree.
 
 ?> Check out the official [Flutter Documentation](https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html) to learn more about `InheritedWidget`.
 

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -261,7 +261,7 @@ Builder(
 );
 ```
 
-!> Using `context.watch` at the root of the `build` method will result in the entire widget being rebuilt when the bloc state changes. If the entire widget does not need to be rebuilt, either use `BlocBuilder` to wrap the parts that should rebuild, use a `Builder` with `context.watch` to scope the rebuilds, or decompose the widget into smaller widgets.
+!> Using `context.watch` at the root of the `build` method will result in the entire widget being rebuilt when the bloc state changes. If the entire widget does not need to be rebuilt, either use `BlocBuilder` to wrap the parts that should rebuild, or use a `Builder` with `context.watch` to scope the rebuilds, or decompose the widget into smaller widgets.
 
 ### SelectContext
 
@@ -279,3 +279,13 @@ Widget build(BuildContext context) {
 The above, will only rebuild the widget when the property `name` of `Unicorn` changes value. It will not rebuild if some other property of `Unicorn` changes.
 
 ##### How to use `context.select<T, R>`?
+
+Whenever it is required to only listen to specific changes of a bloc state, it is preferred to be selective and avoid unnecessary rebuilds.
+
+```dart
+
+```
+
+?> Check out the [Bloc Selector](flutterbloccoreconcepts?id=blocselector) for more information about `BlocSelector`.
+
+!> Using `context.select` at the root of the `build` method will result in the entire widget being rebuilt when the selected bloc property changes. If the entire widget does not need to be rebuilt, either use `BlocSelector` to wrap the parts that should rebuild, or use a `Builder` with `context.select` to scope the rebuilds, or decompose the widget into smaller widgets.

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -179,7 +179,7 @@ Now when instantiating a bloc, we can access the instance of a repository via `c
 
 Importing the `flutter_bloc` package includes different extension methods and this section aims to describe what and how these should be used. This type of methods, included in Dart 2.7, allow to add functionalities to existing classes.
 
-?> Check out the official [Dart Documentation](https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html) for more information about extension methods.
+?> Check out the official [Dart Documentation](https://dart.dev/guides/language/extension-methods) for more information about extension methods.
 
 ### Provider
 

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -210,8 +210,7 @@ Both, `BlocProvider.of<T>(context)` and `context.read<T>()` are functionally equ
 context.read<CounterBloc>().add(CounterIncrementPressed()),
 ```
 
-It is common to use these methods to retrieve a bloc in order to add events.
-However, it is preferred to use, where appropriate, a `BlocBuilder`, `BlocSelector`, `BlocListener` or `BlocConsumer` to access the `state` of a bloc instead of `context.read<FooBloc>().state`.
+`context.read` is most commonly used for retrieving a bloc instance in order to add an event within `onPressed` callbacks. `context.read` should not be used to retrieve a bloc's state directly within the build method.
 
 **AVOID** using `context.read<T>()` to retrieve state.
 

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -187,7 +187,7 @@ Now when instantiating a bloc, we can access the instance of a repository via `c
 
 Internally, `package:flutter_bloc` uses `package:provider` to implement: `BlocProvider`, `MultiBlocProvider`, `RepositoryProvider` and `MultiRepositoryProvider` widgets. Ultimately, each of these widgets uses `Provider` (`InheritedWidget`) to provide instances of various objects to the widget tree.
 
-In addition, `flutter_bloc` exports `ReadContext`, `WatchContext` and `SelectContext`, all extension methods from `package:provider`. This means that importing `package:flutter_bloc` exposes these extensions.
+In addition, `package:flutter_bloc` exports the `ReadContext`, `WatchContext` and `SelectContext`, extensions from `package:provider`.
 
 ?> Check out [Provider's pub page](https://pub.dev/packages/provider) to learn more about `Provider`.
 

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -308,7 +308,6 @@ The above will only rebuild the widget when the property `name` of the `ProfileB
 
 #### Usage
 
-
 ✅ **DO** use `BlocSelector` instead of `context.select` to explicitly scope rebuilds.
 
 ```dart

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -261,7 +261,7 @@ Builder(
 ### SelectContext
 
 
-As in  `context.watch<T>()`, `context.select<T, R>(R function(T value))` provides the closest `T` provided in the widget tree. And also listens to changes on `T`, unlike `context.read<T>()`. However, the `select` method allows you to be more selective, and avoid unnecessary rebuilds by specifying which property should be listened to.
+As with `context.watch<T>()`, `context.select<T, R>(R function(T value))` provides the closest `T` provided in the widget tree and also listens to changes on `T`. In addition, the `select` method allows you to be more selective, and avoid unnecessary rebuilds by specifying which state property should be accessed.
 
 ```dart
 Widget build(BuildContext context) {

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -185,11 +185,13 @@ Importing the `flutter_bloc` package includes different extension methods and th
 
 ### Provider
 
-`flutter_bloc` besides depending on `flutter` also depends on the [provider](https://pub.dev/packages/provider) package. Provider aims to wrap `InheritedWidget` and simplify its usage. 
+`flutter_bloc` besides depending on `flutter` also depends on the [provider](https://pub.dev/packages/provider) package. Provider aims to wrap `InheritedWidget` and simplify its usage.
+
+?> Check out the official [Flutter Documentation](https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html) to learn more about `InheritedWidget`.
 
 In essence, `BlocProvider`, `MultiBlocProvider`, `RepositoryProvider` and `MultiRepositoryProvider` widgets are including an `InheritedProvider` to the widget tree.
 
-?> Check out the official [Flutter Documentation](https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html) to learn more about `InheritedWidget`.
+In addition, `flutter_bloc` exports `ReadContext`, `WatchContext` and `SelectContext`, all extensions from `package:provider`.
 
 #### ReadContext extension
 

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -260,7 +260,6 @@ Builder(
 
 ### SelectContext
 
-`package:provider` creates an extension, named `SelectContext` on `BuildContext` that defines the `select<T, R>(R function(T value))` method. 
 
 As in  `context.watch<T>()`, `context.select<T, R>(R function(T value))` provides the closest `T` provided in the widget tree. And also listens to changes on `T`, unlike `context.read<T>()`. However, the `select` method allows you to be more selective, and avoid unnecessary rebuilds by specifying which property should be listened to.
 

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -185,7 +185,7 @@ Now when instantiating a bloc, we can access the instance of a repository via `c
 `flutter_bloc` has a dependency on [package:provider](https://pub.dev/packages/provider) which simplifies the usage of [`InheritedWidget`](https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html).
 
 
-In essence; `BlocProvider`, `MultiBlocProvider`, `RepositoryProvider` and `MultiRepositoryProvider` widgets are injecting one or more `InheritedProviders` to the widget tree.
+Internally, `package:flutter_bloc` uses `package:provider` to implement: `BlocProvider`, `MultiBlocProvider`, `RepositoryProvider` and `MultiRepositoryProvider` widgets. Ultimately, each of these widgets uses `Provider` (`InheritedWidget`) to provide instances of various objects to the widget tree.
 
 In addition, `flutter_bloc` exports `ReadContext`, `WatchContext` and `SelectContext`, all extension methods from `package:provider`. This means that importing `package:flutter_bloc` exposes these extensions.
 

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -198,7 +198,7 @@ In addition, `package:flutter_bloc` exports the `ReadContext`, `WatchContext` an
 
 The convention for `InheritedWidgets` is to expose a `static` method named `of`. This method usually searches the widget tree via `BuildContext` for the nearest `InheritedWidget` which matches a given `Type`. This is exactly what `BlocProvider.of<T>(context)` and `context.read<T>()` do.
 
-?> `BlocProvider.of<T>(context)` and `context.read<T>()` are equivalent.
+?> `BlocProvider.of<T>(context)` and `context.read<T>()` are functionally equivalent.
 
 #### How to use `context.read<T>`?
 
@@ -229,7 +229,7 @@ The above usage is error prone because the `Text` widget will not be rebuilt if 
 
 Like `context.read<T>(), `context.watch<T>()` provides the closest `T` provided in the widget tree, however it also listens to changes on `T`. This means that, if the provided `Object` of type `T` changes, `watch` will trigger a rebuild. Thus, this method is only accessible inside a `StatelessWidget`'s or `State`'s `build` method.
 
-?> `BlocProvider.of<T>(context, listen: true)` and `context.watch<T>()` are equivalent.
+?> `BlocProvider.of<T>(context, listen: true)` and `context.watch<T>()` are functionally equivalent.
 
 #### How to use `context.watch<T>`?
 

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -227,7 +227,7 @@ The above usage is error prone because the `Text` widget will not be rebuilt if 
 ### WatchContext
 
 
-Not only `context.watch<T>()` provides the closest `T` provided in the widget tree, it also listens to changes on `T`, unlike `context.read<T>()`. This means that, if the provided `Object` of type `T` changes, `watch` will trigger a rebuild. Thus, this method is only accessible inside a `StatelessWidget`'s or `State`'s `build` method.
+Like `context.read<T>(), `context.watch<T>()` provides the closest `T` provided in the widget tree, however it also listens to changes on `T`. This means that, if the provided `Object` of type `T` changes, `watch` will trigger a rebuild. Thus, this method is only accessible inside a `StatelessWidget`'s or `State`'s `build` method.
 
 ?> `BlocProvider.of<T>(context, listen: true)` and `context.watch<T>()` are equivalent.
 

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -177,7 +177,7 @@ Now when instantiating a bloc, we can access the instance of a repository via `c
 
 ## Extension Methods
 
-Importing the `flutter_bloc` package includes different extension methods and this section aims to describe what they do and how they should be used. This type of method, included since Dart 2.7, allows adding functionalities to existing classes.
+[Extension methods](https://dart.dev/guides/language/extension-methods), introduced in Dart 2.7, are a way to add functionality to existing libraries. In this section, we'll take a look at extension methods included in `package:flutter_bloc` and how they can be used.
 
 ?> Check out the official [Dart Documentation](https://dart.dev/guides/language/extension-methods) for more information about extension methods.
 

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -189,7 +189,7 @@ Importing the `flutter_bloc` package includes different extension methods and th
 
 In essence, `BlocProvider`, `MultiBlocProvider`, `RepositoryProvider` and `MultiRepositoryProvider` widgets are including an `InheritedProvider` to the widget tree.
 
-In addition, `flutter_bloc` exports `ReadContext`, `WatchContext` and `SelectContext`, all extensions from `package:provider`. This means that when importing `package:flutter_bloc` we have access to these extensions.
+In addition, `flutter_bloc` exports `ReadContext`, `WatchContext` and `SelectContext`, all extensions from `package:provider`. This means that importing `package:flutter_bloc` exposes these extensions.
 
 ?> Check out [Provider's pub page](https://pub.dev/packages/provider) to learn more about `Provider`.
 
@@ -269,13 +269,13 @@ Builder(
 
 As in  `context.watch<T>()`, `context.select<T, R>(R function(T value))` provides the closest `T` provided in the widget tree. And also listens to changes on `T`, unlike `context.read<T>()`. However, the `select` method allows to be more selective, and avoid unnecessary rebuilds by specifying which property should be listened.
 
-For example, the code below will only rebuild the widget when the property `name` of `Unicorn` changes value. It will not rebuild if some other property of `Unicorn` changes.
-
 ```dart
 Widget build(BuildContext context) {
   final name = context.select((Unicorn unicorn) => unicorn.name);
   return Text(name);
 }
 ```
+
+The above, will only rebuild the widget when the property `name` of `Unicorn` changes value. It will not rebuild if some other property of `Unicorn` changes.
 
 ##### How to use `context.select<T, R>`?

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -177,35 +177,35 @@ Now when instantiating a bloc, we can access the instance of a repository via `c
 
 ## Extension Methods
 
-Importing the `flutter_bloc` package includes different extension methods and this section aims to describe what and how these should be used. This type of methods, included in Dart 2.7, allow to add functionalities to existing classes.
+Importing the `flutter_bloc` package includes different extension methods and this section aims to describe what they do and how they should be used. This type of method, included since Dart 2.7, allows adding functionalities to existing classes.
 
 ?> Check out the official [Dart Documentation](https://dart.dev/guides/language/extension-methods) for more information about extension methods.
 
 ### Provider
 
-`flutter_bloc` besides depending on `flutter` also depends on the [provider](https://pub.dev/packages/provider) package. Provider aims to wrap `InheritedWidget` and simplify its usage.
+`flutter_bloc` besides depending on `flutter` also depends on the [provider](https://pub.dev/packages/provider) package. Provider wraps `InheritedWidget` and simplifies its usage.
 
 ?> Check out the official [Flutter Documentation](https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html) to learn more about `InheritedWidget`.
 
-In essence, `BlocProvider`, `MultiBlocProvider`, `RepositoryProvider` and `MultiRepositoryProvider` widgets are including an `InheritedProvider` to the widget tree.
+In essence; `BlocProvider`, `MultiBlocProvider`, `RepositoryProvider` and `MultiRepositoryProvider` widgets are injecting one or more `InheritedProviders` to the widget tree.
 
-In addition, `flutter_bloc` exports `ReadContext`, `WatchContext` and `SelectContext`, all extensions from `package:provider`. This means that importing `package:flutter_bloc` exposes these extensions.
+In addition, `flutter_bloc` exports `ReadContext`, `WatchContext` and `SelectContext`, all extension methods from `package:provider`. This means that importing `package:flutter_bloc` exposes these extensions.
 
 ?> Check out [Provider's pub page](https://pub.dev/packages/provider) to learn more about `Provider`.
 
 ### ReadContext
 
-`package:provider` creates an extension, named `ReadContext` on `BuildContext` that defines the `read<T>()` method. 
+`package:provider` creates an extension named `ReadContext` on `BuildContext` that defines the `read<T>()` method. 
 
-`context.read<T>()` provides the closest `T` provided in the widget tree. However, `context.read<T>()` does not listen to `T`. In other words, if the provided `Object` of type `T` changes `read` will not trigger a rebuild.
+`context.read<T>()` provides the closest `T` provided in the widget tree. However, `context.read<T>()` does not listen to `T`. In other words, if the provided `Object` of type `T` changes, `read` will not trigger a rebuild.
 
-In essence, `Provider` is a wrapper over `InheritedWidget`. The convention for `InheritedWidget`s is to expose a `static` method named `of`. This method usually searches the widget tree for the nearest `InheritedWidget` which matches a given `Type`. This is exactly what `BlocProvider.of<T>(context)` and `context.read<T>()` do.
+The convention for `InheritedWidgets` is to expose a `static` method named `of`. This method usually searches the widget tree via `BuildContext` for the nearest `InheritedWidget` which matches a given `Type`. This is exactly what `BlocProvider.of<T>(context)` and `context.read<T>()` do.
 
 ?> `BlocProvider.of<T>(context)` and `context.read<T>()` are equivalent.
 
 #### How to use `context.read<T>`?
 
-Both, `BlocProvider.of<T>(context)` and `context.read<T>()` are equally valid. Is up to the developer to go with the most convenient method. Although, it is preferred to be consistent with the given choice.
+Both, `BlocProvider.of<T>(context)` and `context.read<T>()` are equally valid. It is up to the developer to go with the most convenient method. Although, it is preferred to be consistent with the given choice.
 
 **DO** use `context.read<T>()` to add events.
 
@@ -232,7 +232,7 @@ The above usage is error prone because the `Text` widget will not be rebuilt if 
 
 `package:provider` creates an extension, named `WatchContext` on `BuildContext` that defines the `watch<T>()` method. 
 
-Not only `context.watch<T>()` provides the closest `T` provided in the widget tree. But it also listens to changes on `T`, unlike `context.read<T>()`. This means that, if the provided `Object` of type `T` changes, `watch` will trigger a rebuild. Thus, this method is only accessible inside a `StatelessWidget`'s or `State`'s `build` method.
+Not only `context.watch<T>()` provides the closest `T` provided in the widget tree, it also listens to changes on `T`, unlike `context.read<T>()`. This means that, if the provided `Object` of type `T` changes, `watch` will trigger a rebuild. Thus, this method is only accessible inside a `StatelessWidget`'s or `State`'s `build` method.
 
 ?> `BlocProvider.of<T>(context, listen: true)` and `context.watch<T>()` are equivalent.
 
@@ -261,13 +261,13 @@ Builder(
 );
 ```
 
-!> Using `context.watch` at the root of the `build` method will result in the entire widget being rebuilt when the bloc state changes. If the entire widget does not need to be rebuilt, either use `BlocBuilder` to wrap the parts that should rebuild, or use a `Builder` with `context.watch` to scope the rebuilds, or decompose the widget into smaller widgets.
+!> Using `context.watch` at the root of the `build` method will result in the entire widget being rebuilt when the bloc state changes. If the entire widget does not need to be rebuilt, either use `BlocBuilder` to wrap the parts that should rebuild, use a `Builder` with `context.watch` to scope the rebuilds, or decompose the widget into smaller widgets.
 
 ### SelectContext
 
 `package:provider` creates an extension, named `SelectContext` on `BuildContext` that defines the `select<T, R>(R function(T value))` method. 
 
-As in  `context.watch<T>()`, `context.select<T, R>(R function(T value))` provides the closest `T` provided in the widget tree. And also listens to changes on `T`, unlike `context.read<T>()`. However, the `select` method allows to be more selective, and avoid unnecessary rebuilds by specifying which property should be listened.
+As in  `context.watch<T>()`, `context.select<T, R>(R function(T value))` provides the closest `T` provided in the widget tree. And also listens to changes on `T`, unlike `context.read<T>()`. However, the `select` method allows you to be more selective, and avoid unnecessary rebuilds by specifying which property should be listened to.
 
 ```dart
 Widget build(BuildContext context) {
@@ -276,16 +276,33 @@ Widget build(BuildContext context) {
 }
 ```
 
-The above, will only rebuild the widget when the property `name` of `Unicorn` changes value. It will not rebuild if some other property of `Unicorn` changes.
+The above will only rebuild the widget when the property `name` of `Unicorn` changes value. It will not rebuild if some other property of `Unicorn` changes.
 
 ##### How to use `context.select<T, R>`?
 
 Whenever it is required to only listen to specific changes of a bloc state, it is preferred to be selective and avoid unnecessary rebuilds.
 
 ```dart
+class Input extends StatelessWidget {
+  const Input({Key? key}) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return BlocSelector<BlocA, BlocAState, String>(
+      selector: (state) => state.input,
+      builder: (context, state) {
+        return TextField(
+          onChanged: (value) => context.read<BlocA>().add(InputChanged(value)),
+          decoration: InputDecoration(
+            errorText: state.length < 1 ? 'input is too short' : null,
+          ),
+        );
+      },
+    );
+  }
+}
 
 ```
 
 ?> Check out the [Bloc Selector](flutterbloccoreconcepts?id=blocselector) for more information about `BlocSelector`.
 
-!> Using `context.select` at the root of the `build` method will result in the entire widget being rebuilt when the selected bloc property changes. If the entire widget does not need to be rebuilt, either use `BlocSelector` to wrap the parts that should rebuild, or use a `Builder` with `context.select` to scope the rebuilds, or decompose the widget into smaller widgets.
+!> Using `context.select` at the root of the `build` method will result in the entire widget being rebuilt when the selected bloc property changes. If the entire widget does not need to be rebuilt, either use `BlocSelector` to wrap the parts that should rebuild, use a `Builder` with `context.select` to scope the rebuilds, or decompose the widget into smaller widgets.

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -179,7 +179,6 @@ Now when instantiating a bloc, we can access the instance of a repository via `c
 
 [Extension methods](https://dart.dev/guides/language/extension-methods), introduced in Dart 2.7, are a way to add functionality to existing libraries. In this section, we'll take a look at extension methods included in `package:flutter_bloc` and how they can be used.
 
-?> Check out the official [Dart Documentation](https://dart.dev/guides/language/extension-methods) for more information about extension methods.
 
 ### Provider
 

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -203,7 +203,7 @@ The convention for `InheritedWidgets` is to expose a `static` method named `of`.
 
 #### How to use `context.read<T>`?
 
-Both, `BlocProvider.of<T>(context)` and `context.read<T>()` are equally valid. It is up to the developer to go with the most convenient method. Although, it is preferred to be consistent with the given choice.
+Both, `BlocProvider.of<T>(context)` and `context.read<T>()` are functionally equivalent. It is up to the developer to go with the most convenient method. Although, it is preferred to be consistent with the given choice.
 
 **DO** use `context.read<T>()` to add events.
 

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -195,8 +195,6 @@ In addition, `flutter_bloc` exports `ReadContext`, `WatchContext` and `SelectCon
 
 ### ReadContext
 
-#### What is `context.read<T>`?
-
 `package:provider` creates an extension, named `ReadContext` on `BuildContext` that defines the `read<T>()` method. 
 
 `context.read<T>()` provides the closest `T` provided in the widget tree. However, `context.read<T>()` does not listen to `T`. In other words, if the provided `Object` of type `T` changes `read` will not trigger a rebuild.
@@ -232,8 +230,6 @@ The above usage is error prone because the `Text` widget will not be rebuilt if 
 
 ### WatchContext
 
-#### What is `context.watch<T>`?
-
 `package:provider` creates an extension, named `WatchContext` on `BuildContext` that defines the `watch<T>()` method. 
 
 Not only `context.watch<T>()` provides the closest `T` provided in the widget tree. But it also listens to changes on `T`, unlike `context.read<T>()`. This means that, if the provided `Object` of type `T` changes, `watch` will trigger a rebuild. Thus, this method is only accessible inside a `StatelessWidget`'s or `State`'s `build` method.
@@ -268,8 +264,6 @@ Builder(
 !> Using `context.watch` at the root of the `build` method will result in the entire widget being rebuilt when the bloc state changes. If the entire widget does not need to be rebuilt, either use `BlocBuilder` to wrap the parts that should rebuild, use a `Builder` with `context.watch` to scope the rebuilds, or decompose the widget into smaller widgets.
 
 ### SelectContext
-
-#### What is `context.select<T, R>`?
 
 `package:provider` creates an extension, named `SelectContext` on `BuildContext` that defines the `select<T, R>(R function(T value))` method. 
 

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -191,9 +191,9 @@ In essence, `BlocProvider`, `MultiBlocProvider`, `RepositoryProvider` and `Multi
 
 In addition, `flutter_bloc` exports `ReadContext`, `WatchContext` and `SelectContext`, all extensions from `package:provider`. This means that when importing `package:flutter_bloc` we have access to these extensions.
 
-#### ReadContext extension
+### ReadContext
 
-##### What is `context.read<T>`?
+#### What is `context.read<T>`?
 
 `Provider` is a wrapper over `InheritedWidget`. The convention for `InheritedWidget`s is to expose a `static` method named `of`. This method usually searches the widget tree for the nearest `InheritedWidget` which matches a given `Type`. This is exactly what `BlocProvider.of<T>(context)` does.
 
@@ -203,11 +203,11 @@ It is important to note that `BlocProvider.of<T>(context)` and `context.read<T>(
 
 ?> `BlocProvider.of<T>(context)` and `context.read<T>()` are equivalent.
 
-##### How to use `context.read<T>`?
+#### How to use `context.read<T>`?
 
-#### WatchContext extension
+### WatchContext
 
-##### What is `context.watch<T>`?
+#### What is `context.watch<T>`?
 
 `package:provider` creates an extension, named `WatchContext` on `BuildContext` that defines the `watch<T>()` method. 
 
@@ -215,11 +215,11 @@ Not only `context.watch<T>()` provides the closest `T` provided in the widget tr
 
 ?> `BlocProvider.of<T>(context, listen: true)` and `context.watch<T>()` are equivalent.
 
-##### How to use `context.watch<T>`?
+#### How to use `context.watch<T>`?
 
-#### SelectContext extension
+### SelectContext
 
-##### What is `context.select<T, R>`?
+#### What is `context.select<T, R>`?
 
 `package:provider` creates an extension, named `SelectContext` on `BuildContext` that defines the `select<T, R>(R function(T value))` method. 
 

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -226,7 +226,6 @@ The above usage is error prone because the `Text` widget will not be rebuilt if 
 
 ### WatchContext
 
-`package:provider` creates an extension, named `WatchContext` on `BuildContext` that defines the `watch<T>()` method. 
 
 Not only `context.watch<T>()` provides the closest `T` provided in the widget tree, it also listens to changes on `T`, unlike `context.read<T>()`. This means that, if the provided `Object` of type `T` changes, `watch` will trigger a rebuild. Thus, this method is only accessible inside a `StatelessWidget`'s or `State`'s `build` method.
 

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -184,7 +184,6 @@ Now when instantiating a bloc, we can access the instance of a repository via `c
 
 `flutter_bloc` has a dependency on [package:provider](https://pub.dev/packages/provider) which simplifies the usage of [`InheritedWidget`](https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html).
 
-?> Check out the official [Flutter Documentation](https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html) to learn more about `InheritedWidget`.
 
 In essence; `BlocProvider`, `MultiBlocProvider`, `RepositoryProvider` and `MultiRepositoryProvider` widgets are injecting one or more `InheritedProviders` to the widget tree.
 

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -175,7 +175,7 @@ Now when instantiating a bloc, we can access the instance of a repository via `c
 
 [flutter_weather_link]: https://github.com/felangel/bloc/blob/master/examples/flutter_weather
 
-## Extension Methods Usage
+## Extension Methods
 
 Importing the `flutter_bloc` package includes different extension methods and this section aims to describe what and how these should be used. This type of methods, included in Dart 2.7, allow to add functionalities to existing classes.
 

--- a/docs/flutterbloccoreconcepts.md
+++ b/docs/flutterbloccoreconcepts.md
@@ -182,7 +182,7 @@ Now when instantiating a bloc, we can access the instance of a repository via `c
 
 ### Provider
 
-`flutter_bloc` besides depending on `flutter` also depends on the [provider](https://pub.dev/packages/provider) package. Provider wraps `InheritedWidget` and simplifies its usage.
+`flutter_bloc` has a dependency on [package:provider](https://pub.dev/packages/provider) which simplifies the usage of [`InheritedWidget`](https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html).
 
 ?> Check out the official [Flutter Documentation](https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html) to learn more about `InheritedWidget`.
 


### PR DESCRIPTION
## Status

**IN DEVELOPMENT**

## Breaking Changes

NO

## Description

Aims to resolve #3141 , by including an "Extension Methods usage" section that documents what and how extension methods included when importing `flutter_bloc` should be used.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
