### PR TITLE
Fixes `droppable` (bloc_concurrency)

### DIFF
--- a/packages/bloc_concurrency/lib/src/droppable.dart
+++ b/packages/bloc_concurrency/lib/src/droppable.dart
@@ -39,7 +39,9 @@ class _ExhaustMapStreamTransformer<T> extends StreamTransformerBase<T, T> {
         mappedSubscription = mappedStream.listen(
           controller.add,
           onError: controller.addError,
-          onDone: () => mappedSubscription = null,
+          onDone: () => Timer.run(() {
+              mappedSubscription = null;
+            });,
         );
       },
       onError: controller.addError,


### PR DESCRIPTION
This pull request fixes #3236.

**Description:**
If handler function that is passed to the `on` doesn't schedule any event(events are added to events queue) and we pass `droppable()` to `transformer`,then new events won't be dropped( even though last event isn't still done.)


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
