### PR TITLE
Fix the order of super.onChange in docs

### DIFF
--- a/docs/_snippets/core_concepts/counter_bloc_on_error.dart.md
+++ b/docs/_snippets/core_concepts/counter_bloc_on_error.dart.md
@@ -13,8 +13,8 @@ class CounterBloc extends Bloc<CounterEvent, int> {
 
   @override
   void onChange(Change<int> change) {
-    print(change);
     super.onChange(change);
+    print(change);
   }
 
   @override

--- a/docs/_snippets/core_concepts/counter_cubit_on_change.dart.md
+++ b/docs/_snippets/core_concepts/counter_cubit_on_change.dart.md
@@ -6,8 +6,8 @@ class CounterCubit extends Cubit<int> {
 
   @override
   void onChange(Change<int> change) {
-    print(change);
     super.onChange(change);
+    print(change);
   }
 }
 ```


### PR DESCRIPTION
Fix the order of super.onChange in docs

## Status

**READY**

## Breaking Changes

NO

## Description

A fix on the order in which super.onChange is called in a couple of places, which otherwise contradicts the source docs.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
