### PR TITLE
feat(hydrated_bloc): storagePrefix for obfuscation tolerance

### DIFF
--- a/packages/hydrated_bloc/lib/src/hydrated_bloc.dart
+++ b/packages/hydrated_bloc/lib/src/hydrated_bloc.dart
@@ -385,9 +385,17 @@ mixin HydratedMixin<State> on BlocBase<State> {
   /// in order to keep the caches independent of each other.
   String get id => '';
 
+  /// Storage prefix which can be overridden to provide a custom
+  /// storage namespace.
+  /// Defaults to [runtimeType] but should be overridden in cases
+  /// where stored data should be resilient to obfuscation or persist
+  /// between debug/release builds.
+  String get storagePrefix => runtimeType.toString();
+
   /// `storageToken` is used as registration token for hydrated storage.
+  /// Composed of [storagePrefix] and [id].
   @nonVirtual
-  String get storageToken => '${runtimeType.toString()}$id';
+  String get storageToken => '$storagePrefix$id';
 
   /// [clear] is used to wipe or invalidate the cache of a [HydratedBloc].
   /// Calling [clear] will delete the cached state of the bloc

--- a/packages/hydrated_bloc/test/hydrated_bloc_test.dart
+++ b/packages/hydrated_bloc/test/hydrated_bloc_test.dart
@@ -48,12 +48,16 @@ class MyCallbackHydratedBloc extends HydratedBloc<CounterEvent, int> {
 }
 
 class MyHydratedBloc extends HydratedBloc<int, int> {
-  MyHydratedBloc([this._id]) : super(0);
+  MyHydratedBloc([this._id, this._storagePrefix]) : super(0);
 
   final String? _id;
+  final String? _storagePrefix;
 
   @override
   String get id => _id ?? '';
+
+  @override
+  String get storagePrefix => _storagePrefix ?? super.storagePrefix;
 
   @override
   Map<String, int>? toJson(int state) {
@@ -139,6 +143,32 @@ void main() {
       HydratedBlocOverrides.runZoned(() {
         MyCallbackHydratedBloc();
         verify<dynamic>(() => storage.read('MyCallbackHydratedBloc')).called(1);
+      }, storage: storage);
+    });
+
+    test(
+        'reads from storage once upon initialization w/custom storagePrefix/id',
+        () {
+      HydratedBlocOverrides.runZoned(() {
+        const storagePrefix = '__storagePrefix__';
+        const id = '__id__';
+        MyHydratedBloc(id, storagePrefix);
+        verify<dynamic>(() => storage.read('$storagePrefix$id')).called(1);
+      }, storage: storage);
+    });
+
+    test('writes to storage when onChange is called w/custom storagePrefix/id',
+        () {
+      HydratedBlocOverrides.runZoned(() {
+        const change = Change(
+          currentState: 0,
+          nextState: 0,
+        );
+        const expected = <String, int>{'value': 0};
+        const storagePrefix = '__storagePrefix__';
+        const id = '__id__';
+        MyHydratedBloc(id, storagePrefix).onChange(change);
+        verify(() => storage.write('$storagePrefix$id', expected)).called(2);
       }, storage: storage);
     });
 

--- a/packages/hydrated_bloc/test/hydrated_cubit_test.dart
+++ b/packages/hydrated_bloc/test/hydrated_cubit_test.dart
@@ -39,13 +39,21 @@ class MyCallbackHydratedCubit extends HydratedCubit<int> {
 }
 
 class MyHydratedCubit extends HydratedCubit<int> {
-  MyHydratedCubit([this._id, this._callSuper = true]) : super(0);
+  MyHydratedCubit([
+    this._id,
+    this._callSuper = true,
+    this._storagePrefix,
+  ]) : super(0);
 
   final String? _id;
   final bool _callSuper;
+  final String? _storagePrefix;
 
   @override
   String get id => _id ?? '';
+
+  @override
+  String get storagePrefix => _storagePrefix ?? super.storagePrefix;
 
   @override
   Map<String, int> toJson(int state) => {'value': state};
@@ -94,6 +102,32 @@ void main() {
         verify<dynamic>(
           () => storage.read('MyCallbackHydratedCubit'),
         ).called(1);
+      }, storage: storage);
+    });
+
+    test(
+        'reads from storage once upon initialization w/custom storagePrefix/id',
+        () {
+      HydratedBlocOverrides.runZoned(() {
+        const storagePrefix = '__storagePrefix__';
+        const id = '__id__';
+        MyHydratedCubit(id, true, storagePrefix);
+        verify<dynamic>(() => storage.read('$storagePrefix$id')).called(1);
+      }, storage: storage);
+    });
+
+    test('writes to storage when onChange is called w/custom storagePrefix/id',
+        () {
+      HydratedBlocOverrides.runZoned(() {
+        const change = Change(
+          currentState: 0,
+          nextState: 0,
+        );
+        const expected = <String, int>{'value': 0};
+        const storagePrefix = '__storagePrefix__';
+        const id = '__id__';
+        MyHydratedCubit(id, true, storagePrefix).onChange(change);
+        verify(() => storage.write('$storagePrefix$id', expected)).called(2);
       }, storage: storage);
     });
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->
- feat(hydrated_bloc): storagePrefix for obfuscation tolerance (closes #3255)

```dart
class CounterBloc extends HydratedBloc<CounterEvent, int> {
  CounterBloc() : super(0) {
    on<CounterIncrementPressed>((event, emit) => emit(state + 1));
    on<CounterDecrementPressed>((event, emit) => emit(state - 1));
  }

  @override
  String get storagePrefix => 'CounterBloc';

  @override
  int fromJson(Map<String, dynamic> json) => json['value'] as int;

  @override
  Map<String, int> toJson(int state) => {'value': state};
}
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
