### PR TITLE
fix(vscode): Reduce VSCode extension bundle size by ignoring node_modules and changing webpack output

### DIFF
--- a/extensions/vscode/.vscodeignore
+++ b/extensions/vscode/.vscodeignore
@@ -1,5 +1,6 @@
 .vscode/**
 .vscode-test/**
+node_modules
 out/test/**
 src/**
 .gitignore

--- a/extensions/vscode/.vscodeignore
+++ b/extensions/vscode/.vscodeignore
@@ -1,7 +1,7 @@
 .vscode/**
 .vscode-test/**
 node_modules
-out/test/**
+out/**
 src/**
 .gitignore
 vsc-extension-quickstart.md

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -32,7 +32,7 @@
     "onCommand:extension.new-bloc",
     "workspaceContains:**/pubspec.yaml"
   ],
-  "main": "./out/extension.js",
+  "main": "./dist/extension",
   "contributes": {
     "configuration": [
       {

--- a/extensions/vscode/webpack.config.js
+++ b/extensions/vscode/webpack.config.js
@@ -8,8 +8,8 @@ const config = {
 
   entry: './src/extension.ts', // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
   output: {
-    // the bundle is stored in the 'out' folder (check package.json), 📖 -> https://webpack.js.org/configuration/output/
-    path: path.resolve(__dirname, 'out'),
+    // the bundle is stored in the 'dist' folder (check package.json), 📖 -> https://webpack.js.org/configuration/output/
+    path: path.resolve(__dirname, 'dist'),
     filename: 'extension.js',
     libraryTarget: 'commonjs2',
     devtoolModuleFilenameTemplate: '../[resource-path]'


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

VSCode extensions `.vscodeignore` was missing an entry for `node_modules` which meant the bundle size was larger by shipping unnecessary node_modules JS files. I also changed the webpack `output.path` to `dist` and package main entrypoint to `./dist/extension` so that output of `tsc -p ./` in `./out/` can also be safely ignored from VSCode extension bundle.

This change reduces the generated vsix file size from (1311 files, 2.32MB) to (15 files, 1.27MB).

**BEFORE**

![initial](https://user-images.githubusercontent.com/38353746/159156836-05eca800-3f56-46dc-89f6-afc9b0984e90.png)

**AFTER**

![after-changes](https://user-images.githubusercontent.com/38353746/159156870-2c8173a3-6453-492c-9c66-1271d8e279c2.png)

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [X] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
