### PR TITLE
feat(flutter_bloc): provide all Multi*Provider parameters in constructor

### DIFF
--- a/packages/flutter_bloc/lib/src/multi_bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/multi_bloc_listener.dart
@@ -52,6 +52,7 @@ class MultiBlocListener extends MultiProvider {
   MultiBlocListener({
     Key? key,
     required List<BlocListenerSingleChildWidget> listeners,
-    required Widget child,
-  }) : super(key: key, providers: listeners, child: child);
+    required Widget? child,
+    TransitionBuilder? builder,
+  }) : super(key: key, providers: listeners, child: child, builder: builder);
 }

--- a/packages/flutter_bloc/lib/src/multi_bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/multi_bloc_provider.dart
@@ -52,6 +52,7 @@ class MultiBlocProvider extends MultiProvider {
   MultiBlocProvider({
     Key? key,
     required List<BlocProviderSingleChildWidget> providers,
-    required Widget child,
-  }) : super(key: key, providers: providers, child: child);
+    required Widget? child,
+    TransitionBuilder? builder,
+  }) : super(key: key, providers: providers, child: child, builder: builder);
 }

--- a/packages/flutter_bloc/lib/src/multi_repository_provider.dart
+++ b/packages/flutter_bloc/lib/src/multi_repository_provider.dart
@@ -46,6 +46,7 @@ class MultiRepositoryProvider extends MultiProvider {
   MultiRepositoryProvider({
     Key? key,
     required List<RepositoryProviderSingleChildWidget> providers,
-    required Widget child,
-  }) : super(key: key, providers: providers, child: child);
+    required Widget? child,
+    TransitionBuilder? builder,
+  }) : super(key: key, providers: providers, child: child, builder: builder);
 }


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO (compiletime) / maybe YES (binary)

## Description
Making the child nullable to simplify usage within a _nested_ hierarchy.
Also adding the transition builder for consitency with `MultiProvider`.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
