### PR TITLE
docs(architecture): fix constructor name in bloc-to-bloc communication snippet

### DIFF
--- a/docs/_snippets/architecture/do_not_do_this_at_home.dart.md
+++ b/docs/_snippets/architecture/do_not_do_this_at_home.dart.md
@@ -3,7 +3,7 @@ class BadBloc extends Bloc {
   final OtherBloc otherBloc;
   late final StreamSubscription otherBlocSubscription;
 
-  MyBloc(this.otherBloc) {
+  BadBloc(this.otherBloc) {
     // No matter how much you are tempted to do this, you should not do this!
     // Keep reading for better alternatives!
     otherBlocSubscription = otherBloc.stream.listen((state) {


### PR DESCRIPTION
## Status

READY

## Breaking Changes

NO

## Description

Missed a constructor name when renaming 🤦‍♀️

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
