### PR TITLE
fix(bloc): remove unnecessary "async" from "Emitter.onEach"

### DIFF
--- a/packages/bloc/lib/src/emitter.dart
+++ b/packages/bloc/lib/src/emitter.dart
@@ -76,7 +76,7 @@ class _Emitter<State> implements Emitter<State> {
     Stream<T> stream, {
     required void Function(T data) onData,
     void Function(Object error, StackTrace stackTrace)? onError,
-  }) async {
+  }) {
     final completer = Completer<void>();
     final subscription = stream.listen(
       onData,


### PR DESCRIPTION
## Status

Ready

## Breaking Changes

NO

## Description

`Emitter.onEach` returns a `Future` from a function marked `async`. Since it returns the `Future` and does no `awaiting`, it doesn't need to be marked `async`.

This appears to have been an old typo. Not actually sure if this caused any bugs, but likely not working as intended.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
