### PR TITLE
fixed wrong case conversion in VSCode Bloc and Cubit templates

### DIFF
--- a/extensions/vscode/src/commands/new-cubit.command.ts
+++ b/extensions/vscode/src/commands/new-cubit.command.ts
@@ -32,7 +32,7 @@ export const newCubit = async (uri: Uri) => {
   }
 
   const blocType = await getBlocType(TemplateType.Cubit);
-  const pascalCaseCubitName = changeCase.pascalCase(cubitName.toLowerCase());
+  const pascalCaseCubitName = changeCase.pascalCase(cubitName).toLowerCase();
   try {
     await generateCubitCode(cubitName, targetDirectory, blocType);
     window.showInformationMessage(
@@ -106,7 +106,7 @@ function createCubitStateTemplate(
   targetDirectory: string,
   type: BlocType
 ) {
-  const snakeCaseCubitName = changeCase.snakeCase(cubitName.toLowerCase());
+  const snakeCaseCubitName = changeCase.snakeCase(cubitName).toLowerCase();
   const targetPath = `${targetDirectory}/${snakeCaseCubitName}_state.dart`;
   if (existsSync(targetPath)) {
     throw Error(`${snakeCaseCubitName}_state.dart already exists`);
@@ -132,7 +132,7 @@ function createCubitTemplate(
   targetDirectory: string,
   type: BlocType
 ) {
-  const snakeCaseCubitName = changeCase.snakeCase(cubitName.toLowerCase());
+  const snakeCaseCubitName = changeCase.snakeCase(cubitName).toLowerCase();
   const targetPath = `${targetDirectory}/${snakeCaseCubitName}_cubit.dart`;
   if (existsSync(targetPath)) {
     throw Error(`${snakeCaseCubitName}_cubit.dart already exists`);

--- a/extensions/vscode/src/templates/bloc-event.template.ts
+++ b/extensions/vscode/src/templates/bloc-event.template.ts
@@ -13,8 +13,8 @@ export function getBlocEventTemplate(blocName: string, type: BlocType): string {
 }
 
 function getEquatableBlocEventTemplate(blocName: string): string {
-  const pascalCaseBlocName = changeCase.pascalCase(blocName.toLowerCase());
-  const snakeCaseBlocName = changeCase.snakeCase(blocName.toLowerCase());
+  const pascalCaseBlocName = changeCase.pascalCase(blocName);
+  const snakeCaseBlocName = changeCase.snakeCase(blocName).toLowerCase();
   return `part of '${snakeCaseBlocName}_bloc.dart';
 
 abstract class ${pascalCaseBlocName}Event extends Equatable {
@@ -27,8 +27,8 @@ abstract class ${pascalCaseBlocName}Event extends Equatable {
 }
 
 function getDefaultBlocEventTemplate(blocName: string): string {
-  const pascalCaseBlocName = changeCase.pascalCase(blocName.toLowerCase());
-  const snakeCaseBlocName = changeCase.snakeCase(blocName.toLowerCase());
+  const pascalCaseBlocName = changeCase.pascalCase(blocName);
+  const snakeCaseBlocName = changeCase.snakeCase(blocName).toLowerCase();
   return `part of '${snakeCaseBlocName}_bloc.dart';
 
 @immutable
@@ -38,8 +38,8 @@ abstract class ${pascalCaseBlocName}Event {}
 
 function getFreezedBlocEvent(blocName: string): string {
   const pascalCaseBlocName =
-    changeCase.pascalCase(blocName.toLowerCase()) + "Event";
-  const snakeCaseBlocName = changeCase.snakeCase(blocName.toLowerCase());
+    changeCase.pascalCase(blocName) + "Event";
+  const snakeCaseBlocName = changeCase.snakeCase(blocName).toLowerCase();
   return `part of '${snakeCaseBlocName}_bloc.dart';
 
 @freezed

--- a/extensions/vscode/src/templates/bloc-state.template.ts
+++ b/extensions/vscode/src/templates/bloc-state.template.ts
@@ -13,8 +13,8 @@ export function getBlocStateTemplate(blocName: string, type: BlocType): string {
 }
 
 function getEquatableBlocStateTemplate(blocName: string): string {
-  const pascalCaseBlocName = changeCase.pascalCase(blocName.toLowerCase());
-  const snakeCaseBlocName = changeCase.snakeCase(blocName.toLowerCase());
+  const pascalCaseBlocName = changeCase.pascalCase(blocName);
+  const snakeCaseBlocName = changeCase.snakeCase(blocName).toLowerCase();
   return `part of '${snakeCaseBlocName}_bloc.dart';
 
 abstract class ${pascalCaseBlocName}State extends Equatable {
@@ -29,8 +29,8 @@ class ${pascalCaseBlocName}Initial extends ${pascalCaseBlocName}State {}
 }
 
 function getDefaultBlocStateTemplate(blocName: string): string {
-  const pascalCaseBlocName = changeCase.pascalCase(blocName.toLowerCase());
-  const snakeCaseBlocName = changeCase.snakeCase(blocName.toLowerCase());
+  const pascalCaseBlocName = changeCase.pascalCase(blocName);
+  const snakeCaseBlocName = changeCase.snakeCase(blocName).toLowerCase();
   return `part of '${snakeCaseBlocName}_bloc.dart';
 
 @immutable
@@ -42,8 +42,8 @@ class ${pascalCaseBlocName}Initial extends ${pascalCaseBlocName}State {}
 
 function getFreezedBlocStateTemplate(blocName: string): string {
   const pascalCaseBlocName =
-    changeCase.pascalCase(blocName.toLowerCase()) + "State";
-  const snakeCaseBlocName = changeCase.snakeCase(blocName.toLowerCase());
+    changeCase.pascalCase(blocName) + "State";
+  const snakeCaseBlocName = changeCase.snakeCase(blocName).toLowerCase();
   return `part of '${snakeCaseBlocName}_bloc.dart';
 
 @freezed

--- a/extensions/vscode/src/templates/bloc.template.ts
+++ b/extensions/vscode/src/templates/bloc.template.ts
@@ -13,8 +13,8 @@ export function getBlocTemplate(blocName: string, type: BlocType): string {
 }
 
 function getEquatableBlocTemplate(blocName: string) {
-  const pascalCaseBlocName = changeCase.pascalCase(blocName.toLowerCase());
-  const snakeCaseBlocName = changeCase.snakeCase(blocName.toLowerCase());
+  const pascalCaseBlocName = changeCase.pascalCase(blocName);
+  const snakeCaseBlocName = changeCase.snakeCase(blocName).toLowerCase();
   const blocState = `${pascalCaseBlocName}State`;
   const blocEvent = `${pascalCaseBlocName}Event`;
   return `import 'package:bloc/bloc.dart';
@@ -34,8 +34,8 @@ class ${pascalCaseBlocName}Bloc extends Bloc<${blocEvent}, ${blocState}> {
 }
 
 function getDefaultBlocTemplate(blocName: string) {
-  const pascalCaseBlocName = changeCase.pascalCase(blocName.toLowerCase());
-  const snakeCaseBlocName = changeCase.snakeCase(blocName.toLowerCase());
+  const pascalCaseBlocName = changeCase.pascalCase(blocName);
+  const snakeCaseBlocName = changeCase.snakeCase(blocName).toLowerCase();
   const blocState = `${pascalCaseBlocName}State`;
   const blocEvent = `${pascalCaseBlocName}Event`;
   return `import 'package:bloc/bloc.dart';
@@ -55,8 +55,8 @@ class ${pascalCaseBlocName}Bloc extends Bloc<${blocEvent}, ${blocState}> {
 }
 
 export function getFreezedBlocTemplate(blocName: string) {
-  const pascalCaseBlocName = changeCase.pascalCase(blocName.toLowerCase());
-  const snakeCaseBlocName = changeCase.snakeCase(blocName.toLowerCase());
+  const pascalCaseBlocName = changeCase.pascalCase(blocName);
+  const snakeCaseBlocName = changeCase.snakeCase(blocName).toLowerCase();
   const blocState = `${pascalCaseBlocName}State`;
   const blocEvent = `${pascalCaseBlocName}Event`;
   return `import 'package:bloc/bloc.dart';

--- a/extensions/vscode/src/templates/cubit-state.template.ts
+++ b/extensions/vscode/src/templates/cubit-state.template.ts
@@ -16,8 +16,8 @@ export function getCubitStateTemplate(
 }
 
 function getEquatableCubitStateTemplate(cubitName: string): string {
-  const pascalCaseCubitName = changeCase.pascalCase(cubitName.toLowerCase());
-  const snakeCaseCubitName = changeCase.snakeCase(cubitName.toLowerCase());
+  const pascalCaseCubitName = changeCase.pascalCase(cubitName).toLowerCase();
+  const snakeCaseCubitName = changeCase.snakeCase(cubitName).toLowerCase();
   return `part of '${snakeCaseCubitName}_cubit.dart';
 
 abstract class ${pascalCaseCubitName}State extends Equatable {
@@ -32,8 +32,8 @@ class ${pascalCaseCubitName}Initial extends ${pascalCaseCubitName}State {}
 }
 
 function getDefaultCubitStateTemplate(cubitName: string): string {
-  const pascalCaseCubitName = changeCase.pascalCase(cubitName.toLowerCase());
-  const snakeCaseCubitName = changeCase.snakeCase(cubitName.toLowerCase());
+  const pascalCaseCubitName = changeCase.pascalCase(cubitName).toLowerCase();
+  const snakeCaseCubitName = changeCase.snakeCase(cubitName).toLowerCase();
   return `part of '${snakeCaseCubitName}_cubit.dart';
 
 @immutable
@@ -44,8 +44,8 @@ class ${pascalCaseCubitName}Initial extends ${pascalCaseCubitName}State {}
 }
 
 function getFreezedCubitStateTemplate(cubitName: string): string {
-  const pascalCaseCubitName = changeCase.pascalCase(cubitName.toLowerCase());
-  const snakeCaseCubitName = changeCase.snakeCase(cubitName.toLowerCase());
+  const pascalCaseCubitName = changeCase.pascalCase(cubitName).toLowerCase();
+  const snakeCaseCubitName = changeCase.snakeCase(cubitName).toLowerCase();
   return `part of '${snakeCaseCubitName}_cubit.dart';
 
 @freezed

--- a/extensions/vscode/src/templates/cubit.template.ts
+++ b/extensions/vscode/src/templates/cubit.template.ts
@@ -13,8 +13,8 @@ export function getCubitTemplate(cubitName: string, type: BlocType): string {
 }
 
 function getEquatableCubitTemplate(cubitName: string) {
-  const pascalCaseCubitName = changeCase.pascalCase(cubitName.toLowerCase());
-  const snakeCaseCubitName = changeCase.snakeCase(cubitName.toLowerCase());
+  const pascalCaseCubitName = changeCase.pascalCase(cubitName).toLowerCase();
+  const snakeCaseCubitName = changeCase.snakeCase(cubitName).toLowerCase();
   const cubitState = `${pascalCaseCubitName}State`;
   return `import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
@@ -28,8 +28,8 @@ class ${pascalCaseCubitName}Cubit extends Cubit<${cubitState}> {
 }
 
 function getDefaultCubitTemplate(cubitName: string) {
-  const pascalCaseCubitName = changeCase.pascalCase(cubitName.toLowerCase());
-  const snakeCaseCubitName = changeCase.snakeCase(cubitName.toLowerCase());
+  const pascalCaseCubitName = changeCase.pascalCase(cubitName).toLowerCase();
+  const snakeCaseCubitName = changeCase.snakeCase(cubitName).toLowerCase();
   const cubitState = `${pascalCaseCubitName}State`;
   return `import 'package:bloc/bloc.dart';
 import 'package:meta/meta.dart';
@@ -43,8 +43,8 @@ class ${pascalCaseCubitName}Cubit extends Cubit<${cubitState}> {
 }
 
 export function getFreezedCubitTemplate(cubitName: string) {
-  const pascalCaseCubitName = changeCase.pascalCase(cubitName.toLowerCase());
-  const snakeCaseCubitName = changeCase.snakeCase(cubitName.toLowerCase());
+  const pascalCaseCubitName = changeCase.pascalCase(cubitName).toLowerCase();
+  const snakeCaseCubitName = changeCase.snakeCase(cubitName).toLowerCase();
   const cubitState = `${pascalCaseCubitName}State`;
   return `import 'package:bloc/bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';


### PR DESCRIPTION

## Status

**IN DEVELOPMENT**

## Breaking Changes

YES

## Description
Implements a fix for #3401 

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
