### PR TITLE
Add 'allowEmitSameState' parameter to emit function

### DIFF
--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -54,6 +54,7 @@ abstract class Bloc<Event, State> extends BlocBase<State> {
   StreamSubscription<Transition<Event, State>>? _transitionSubscription;
 
   StreamController<Event>? __eventController;
+
   StreamController<Event> get _eventController {
     return __eventController ??= StreamController<Event>.broadcast();
   }
@@ -145,7 +146,14 @@ abstract class Bloc<Event, State> extends BlocBase<State> {
   @protected
   @visibleForTesting
   @override
-  void emit(State state) => super.emit(state);
+  void emit(
+    State state, {
+    bool allowEmitSameState = false,
+  }) =>
+      super.emit(
+        state,
+        allowEmitSameState: allowEmitSameState,
+      );
 
   /// Must be implemented when a class extends [Bloc].
   /// [mapEventToState] is called whenever an [event] is [add]ed
@@ -280,6 +288,7 @@ abstract class BlocBase<State> {
   }
 
   StreamController<State>? __stateController;
+
   StreamController<State> get _stateController {
     return __stateController ??= StreamController<State>.broadcast();
   }
@@ -322,9 +331,12 @@ abstract class BlocBase<State> {
   /// To allow for the possibility of notifying listeners of the initial state,
   /// emitting a state which is equal to the initial state is allowed as long
   /// as it is the first thing emitted by the instance.
-  void emit(State state) {
+  ///
+  /// If [allowEmitSameState] is true then the state will be emitted,
+  /// even if it is the same as the current state.
+  void emit(State state, {bool allowEmitSameState = false}) {
     if (_stateController.isClosed) return;
-    if (state == _state && _emitted) return;
+    if (state == _state && _emitted && !allowEmitSameState) return;
     onChange(Change<State>(currentState: this.state, nextState: state));
     _state = state;
     _stateController.add(_state);

--- a/packages/bloc/test/cubit_test.dart
+++ b/packages/bloc/test/cubit_test.dart
@@ -6,6 +6,8 @@ import 'package:test/test.dart';
 
 import 'cubits/cubits.dart';
 
+// ignore_for_file: invalid_use_of_protected_member
+
 class MockBlocObserver extends Mock implements BlocObserver {}
 
 class FakeBlocBase<S> extends Fake implements BlocBase<S> {}
@@ -24,7 +26,6 @@ void main() {
 
       test('triggers onCreate on observer', () {
         final cubit = CounterCubit();
-        // ignore: invalid_use_of_protected_member
         verify(() => observer.onCreate(cubit)).called(1);
       });
     });
@@ -80,7 +81,6 @@ void main() {
         final cubit = CounterCubit(onChangeCallback: changes.add);
         await cubit.close();
         expect(changes, isEmpty);
-        // ignore: invalid_use_of_protected_member
         verifyNever(() => observer.onChange(any(), any()));
       });
 
@@ -93,13 +93,60 @@ void main() {
           const [Change<int>(currentState: 0, nextState: 1)],
         );
         verify(
-          // ignore: invalid_use_of_protected_member
           () => observer.onChange(
             cubit,
             const Change<int>(currentState: 0, nextState: 1),
           ),
         ).called(1);
       });
+
+      test(
+        'does state change even previous state is same as next state with '
+        'allowEmitSameState emit parameter',
+        () async {
+          final changes = <Change<int>>[];
+          final calledSameEmitStateCount = 2;
+          final cubit = CounterCubit(onChangeCallback: changes.add);
+
+          for (var i = 0; i < calledSameEmitStateCount; i++) {
+            cubit.emitSameState();
+          }
+
+          expect(
+            calledSameEmitStateCount,
+            changes.length,
+          );
+
+          verify(
+            () => observer.onChange(
+              cubit,
+              const Change<int>(currentState: 0, nextState: 0),
+            ),
+          ).called(calledSameEmitStateCount);
+          await cubit.close();
+        },
+      );
+
+      test(
+        'does not state change if previous state is same as next state',
+        () async {
+          final changes = <Change<int>>[];
+          final cubit = CounterCubit(onChangeCallback: changes.add)
+            ..emitWithoutParameter()
+            ..emitWithoutParameter();
+
+          expect(changes.length, 1);
+
+          verify(() {
+            observer.onChange(
+              cubit,
+              const Change<int>(currentState: 0, nextState: 0),
+            );
+          }).called(1);
+
+          await cubit.close();
+        },
+      );
 
       test('is called with correct changes for multiple state changes',
           () async {
@@ -116,14 +163,12 @@ void main() {
           ],
         );
         verify(
-          // ignore: invalid_use_of_protected_member
           () => observer.onChange(
             cubit,
             const Change<int>(currentState: 0, nextState: 1),
           ),
         ).called(1);
         verify(
-          // ignore: invalid_use_of_protected_member
           () => observer.onChange(
             cubit,
             const Change<int>(currentState: 1, nextState: 2),
@@ -178,7 +223,9 @@ void main() {
         final states = <int>[];
         final cubit = SeededCubit(initialState: 0);
         final subscription = cubit.stream.listen(states.add);
-        cubit..emitState(0)..emitState(0);
+        cubit
+          ..emitState(0)
+          ..emitState(0);
         await cubit.close();
         await subscription.cancel();
         expect(states, [0]);
@@ -190,7 +237,9 @@ void main() {
         final states = <int>[];
         final cubit = SeededCubit(initialState: 0);
         final subscription = cubit.stream.listen(states.add);
-        cubit..emitState(0)..emitState(1);
+        cubit
+          ..emitState(0)
+          ..emitState(1);
         await cubit.close();
         await subscription.cancel();
         expect(states, [0, 1]);
@@ -320,7 +369,6 @@ void main() {
       test('triggers onClose on observer', () async {
         final cubit = CounterCubit();
         await cubit.close();
-        // ignore: invalid_use_of_protected_member
         verify(() => observer.onClose(cubit)).called(1);
       });
 

--- a/packages/bloc/test/cubits/counter_cubit.dart
+++ b/packages/bloc/test/cubits/counter_cubit.dart
@@ -7,6 +7,8 @@ class CounterCubit extends Cubit<int> {
 
   void increment() => emit(state + 1);
   void decrement() => emit(state - 1);
+  void emitSameState() => emit(state, allowEmitSameState: true);
+  void emitWithoutParameter() => emit(state);
 
   @override
   void onChange(Change<int> change) {


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

While I am building a base structure, I am building a structure where I can handle some operations according to automatic network requests. In this structure, it may be necessary to send different 'loading' states without changing the state. I think the 'allowEmitSameState' parameter is necessary for such cases.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
