### PR TITLE
Add 'allowEmitSameState' parameter to emit function

### DIFF
--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -135,7 +135,8 @@ abstract class Bloc<Event, State> extends BlocBase<State>
   /// {@endtemplate}
   @visibleForTesting
   @override
-  void emit(State state) => super.emit(state);
+  void emit(State state, {bool allowEmitSameState = false}) =>
+      super.emit(state);
 
   /// Register event handler for an event of type `E`.
   /// There should only ever be one event handler per event type `E`.
@@ -165,6 +166,7 @@ abstract class Bloc<Event, State> extends BlocBase<State>
   void on<E extends Event>(
     EventHandler<E, State> handler, {
     EventTransformer<E>? transformer,
+    bool allowEmitSameState = false,
   }) {
     assert(() {
       final handlerExists = _handlers.any((handler) => handler.type == E);
@@ -184,7 +186,7 @@ abstract class Bloc<Event, State> extends BlocBase<State>
       (dynamic event) {
         void onEmit(State state) {
           if (isClosed) return;
-          if (this.state == state && _emitted) return;
+          if (this.state == state && _emitted && !allowEmitSameState) return;
           onTransition(Transition(
             currentState: this.state,
             event: event as E,

--- a/packages/bloc/lib/src/bloc_base.dart
+++ b/packages/bloc/lib/src/bloc_base.dart
@@ -31,7 +31,7 @@ abstract class Closable {
 /// An object that can emit new states.
 abstract class Emittable<State extends Object?> {
   /// Emits a new [state].
-  void emit(State state);
+  void emit(State state, {bool allowEmitSameState = false});
 }
 
 /// A generic destination for errors.
@@ -85,16 +85,19 @@ abstract class BlocBase<State>
   /// emitting a state which is equal to the initial state is allowed as long
   /// as it is the first thing emitted by the instance.
   ///
+  /// If [allowEmitSameState] is true then the state will be emitted,
+  /// even if it is the same as the current state.
+  ///
   /// * Throws a [StateError] if the bloc is closed.
   @protected
   @visibleForTesting
   @override
-  void emit(State state) {
+  void emit(State state, {bool allowEmitSameState = false}) {
     try {
       if (isClosed) {
         throw StateError('Cannot emit new states after calling close');
       }
-      if (state == _state && _emitted) return;
+      if (state == _state && _emitted && !allowEmitSameState) return;
       onChange(Change<State>(currentState: this.state, nextState: state));
       _state = state;
       _stateController.add(_state);

--- a/packages/bloc/test/cubit_test.dart
+++ b/packages/bloc/test/cubit_test.dart
@@ -113,6 +113,62 @@ void main() {
         }, blocObserver: observer);
       });
 
+      test(
+        'does state change even previous state is same as next state with allowEmitSameState emit parameter',
+        () async {
+          await BlocOverrides.runZoned(
+            () async {
+              final changes = <Change<int>>[];
+              final cubit = CounterCubit(onChangeCallback: changes.add)
+                ..emitSameState()
+                ..emitSameState();
+
+              expect(2, changes.length);
+
+              verify(
+                // ignore: invalid_use_of_protected_member
+                () => observer.onChange(
+                  cubit,
+                  const Change<int>(currentState: 0, nextState: 0),
+                ),
+              ).called(2);
+
+              await cubit.close();
+            },
+            blocObserver: observer,
+          );
+        },
+      );
+
+      test(
+        'does not state change if previous state is same as next state',
+        () async {
+          await BlocOverrides.runZoned(
+            () async {
+              final changes = <Change<int>>[];
+              final cubit = CounterCubit(onChangeCallback: changes.add)
+                ..emitWithoutParameter()
+                ..emitWithoutParameter();
+
+              expect(changes.length, 1);
+
+              verify(
+                () {
+                  // ignore: invalid_use_of_protected_member
+                  observer.onChange(
+                    cubit,
+                    const Change<int>(currentState: 0, nextState: 0),
+                  );
+                },
+              ).called(1);
+
+              await cubit.close();
+            },
+            blocObserver: observer,
+          );
+        },
+      );
+
       test('is called with correct changes for multiple state changes',
           () async {
         await BlocOverrides.runZoned(() async {

--- a/packages/bloc/test/cubits/counter_cubit.dart
+++ b/packages/bloc/test/cubits/counter_cubit.dart
@@ -8,6 +8,8 @@ class CounterCubit extends Cubit<int> {
 
   void increment() => emit(state + 1);
   void decrement() => emit(state - 1);
+  void emitSameState() => emit(state, allowEmitSameState: true);
+  void emitWithoutParameter() => emit(state);
 
   @override
   void onChange(Change<int> change) {


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

While I am building a base structure, I am building a structure where I can handle some operations according to automatic network requests. In this structure, it may be necessary to send different 'loading' states without changing the state. I think the 'allowEmitSameState' parameter is necessary for such cases.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
