### PR TITLE
added support for the equatable package when making a bloc brick

### DIFF
--- a/bricks/bloc/README.md
+++ b/bricks/bloc/README.md
@@ -25,6 +25,9 @@ mason make bloc --name counter
 | Variable | Description                | Default   | Type     |
 | -------- | -------------------------- | --------- | -------- |
 | `name`   | The name of the bloc class | `counter` | `string` |
+| `use_equatable` | Creates the equatable override | `true`   | `bool` |
+| `add events` | Add events to the bloc | `false`   | `bool` |
+| `add states` | Add states to the bloc | `false`   | `bool` |
 
 ## Output 📦
 

--- a/bricks/bloc/__brick__/{{name.snakeCase()}}_bloc.dart
+++ b/bricks/bloc/__brick__/{{name.snakeCase()}}_bloc.dart
@@ -1,3 +1,4 @@
+{{#use_equatable}}import 'package:equatable/equatable.dart';{{/use_equatable}}
 import 'package:bloc/bloc.dart';
 
 part '{{name.snakeCase()}}_event.dart';

--- a/bricks/bloc/__brick__/{{name.snakeCase()}}_bloc.dart
+++ b/bricks/bloc/__brick__/{{name.snakeCase()}}_bloc.dart
@@ -7,7 +7,17 @@ part '{{name.snakeCase()}}_state.dart';
 class {{name.pascalCase()}}Bloc extends Bloc<{{name.pascalCase()}}Event, {{name.pascalCase()}}State> {
   {{name.pascalCase()}}Bloc() : super(const {{name.pascalCase()}}State()) {
     on<{{name.pascalCase()}}Event>((event, emit) {
+    // TODO: implement event handler
+    });
+
+    {{#events}}on<{{eventName.pascalCase()}}>((event, emit) {
       // TODO: implement event handler
     });
+    {{/events}}
   }
 }
+
+
+
+
+

--- a/bricks/bloc/__brick__/{{name.snakeCase()}}_event.dart
+++ b/bricks/bloc/__brick__/{{name.snakeCase()}}_event.dart
@@ -1,5 +1,9 @@
 part of '{{name.snakeCase()}}_bloc.dart';
 
-abstract class {{name.pascalCase()}}Event {
+abstract class {{name.pascalCase()}}Event {{#use_equatable}}extends Equatable{{/use_equatable}}{
   const {{name.pascalCase()}}Event();
+  {{#use_equatable}}
+  @override
+  List<Object?> get props => [];
+  {{/use_equatable}}
 }

--- a/bricks/bloc/__brick__/{{name.snakeCase()}}_event.dart
+++ b/bricks/bloc/__brick__/{{name.snakeCase()}}_event.dart
@@ -1,9 +1,14 @@
 part of '{{name.snakeCase()}}_bloc.dart';
 
-abstract class {{name.pascalCase()}}Event {{#use_equatable}}extends Equatable{{/use_equatable}}{
+abstract class {{name.pascalCase()}}Event {{#use_equatable}}extends Equatable{{/use_equatable}} {
   const {{name.pascalCase()}}Event();
   {{#use_equatable}}
   @override
   List<Object?> get props => [];
   {{/use_equatable}}
 }
+{{#events}}
+class {{eventName.pascalCase()}} extends {{name.pascalCase()}}Event {
+  const {{eventName.pascalCase()}}();
+}
+{{/events}}

--- a/bricks/bloc/__brick__/{{name.snakeCase()}}_state.dart
+++ b/bricks/bloc/__brick__/{{name.snakeCase()}}_state.dart
@@ -1,9 +1,18 @@
 part of '{{name.snakeCase()}}_bloc.dart';
 
-class {{name.pascalCase()}}State {{#use_equatable}}extends Equatable{{/use_equatable}}{
+abstract class {{name.pascalCase()}}State {{#use_equatable}}extends Equatable{{/use_equatable}} {
   const {{name.pascalCase()}}State();
   {{#use_equatable}}
   @override
   List<Object?> get props => [];
   {{/use_equatable}}
 }
+
+class {{name.pascalCase()}}Initial extends {{name.pascalCase()}}State {
+  const {{name.pascalCase()}}Initial();
+}
+{{#states}}
+class {{stateName.pascalCase()}} extends {{name.pascalCase()}}State {
+  const {{stateName.pascalCase()}}();
+}
+{{/states}}

--- a/bricks/bloc/__brick__/{{name.snakeCase()}}_state.dart
+++ b/bricks/bloc/__brick__/{{name.snakeCase()}}_state.dart
@@ -1,5 +1,9 @@
 part of '{{name.snakeCase()}}_bloc.dart';
 
-class {{name.pascalCase()}}State {
+class {{name.pascalCase()}}State {{#use_equatable}}extends Equatable{{/use_equatable}}{
   const {{name.pascalCase()}}State();
+  {{#use_equatable}}
+  @override
+  List<Object?> get props => [];
+  {{/use_equatable}}
 }

--- a/bricks/bloc/brick.yaml
+++ b/bricks/bloc/brick.yaml
@@ -12,3 +12,8 @@ vars:
     description: The name of the bloc class.
     default: counter
     prompt: Please enter the bloc name.
+  use_equatable:
+    default: true
+    type: boolean
+    description: Has equatable
+    prompt: Does this bloc use equatable?

--- a/bricks/bloc/hooks/pre_gen.dart
+++ b/bricks/bloc/hooks/pre_gen.dart
@@ -1,0 +1,80 @@
+import 'package:mason/mason.dart';
+
+void run(HookContext context) {
+  final logger = context.logger;
+  bool hasEvents = true;
+  if (!logger.confirm(
+    '? Do you want to add events to your bloc?',
+    defaultValue: false,
+  )) {
+    context.vars = {
+      ...context.vars,
+      'hasEvents': false,
+    };
+
+
+    hasEvents = false;
+  }
+  if (hasEvents) {
+    logger.alert(lightYellow.wrap('enter "e" to exit adding events'));
+    logger.alert('Format: eventName e.g, myEvent:');
+    final events = <Map<String, dynamic>>[];
+
+    while (true) {
+      final event = logger.prompt(':').replaceAll(RegExp('\\s+'), ' ').trim();
+      if (event.toLowerCase() == 'e') {
+        break;
+      }
+      // TODO check if event only contains alphabetical characters
+
+
+      final eventName = event;
+      events.add({
+        'eventName': eventName,
+
+      });
+    }
+    context.vars = {
+      ...context.vars,
+      'events': events,
+      'hasEvents': events.isNotEmpty,
+    };
+  }
+
+
+  // adding states
+  if (!logger.confirm(
+    '? Do you want to add states to your bloc?',
+    defaultValue: false,
+  )) {
+    context.vars = {
+      ...context.vars,
+      'hasStates': false,
+    };
+    return;
+  }
+
+  logger.alert(lightYellow.wrap('enter "e" to exit adding states'));
+  logger.alert('Format: stateName e.g, myState:');
+  final states = <Map<String, dynamic>>[];
+
+  while (true) {
+    final state = logger.prompt(':').replaceAll(RegExp('\\s+'), ' ').trim();
+    if (state.toLowerCase() == 'e') {
+      break;
+    }
+    // TODO check if state only contains alphabetical characters
+
+
+    final stateName = state;
+    states.add({
+      'stateName': stateName,
+
+    });
+  }
+  context.vars = {
+    ...context.vars,
+    'states': states,
+    'hasStates': states.isNotEmpty,
+  };
+}

--- a/bricks/bloc/hooks/pubspec.yaml
+++ b/bricks/bloc/hooks/pubspec.yaml
@@ -1,0 +1,7 @@
+name: model_hooks
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+
+dependencies:
+  mason: ^0.1.0-dev


### PR DESCRIPTION

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

 When creating a bloc with mason you now have the option to add equatable package. This PR solves issue [#3486](https://github.com/felangel/bloc/issues/3486):

Also added a way to create events/states directly from the CLI (see issue [#3487)](https://github.com/felangel/bloc/issues/3487)
-->

## Status

**UNDER DEVELOPMENT**

I have not broken anything but the input changed. You can now choose to add equatable, states and events in the cli.


## Description

<!--- Describe your changes in detail -->
Changed the {{name.snakeCase()}}_bloc.dart to now import equatable when needed
Changed the {{name.snakeCase()}}_event.dart to extend equatable and implemented the getter props
Changed the {{name.snakeCase()}}_state.dart to extend equatable and implemented the getter props

Added hooks to generate events/states.
All variables in a list:

| Variable | Description                | Default   | Type     |
| -------- | -------------------------- | --------- | -------- |
| `name`   | The name of the bloc class | `counter` | `string` |
| `use_equatable` | Creates the equatable override | `true`   | `bool` |
| `add events` | Add events to the bloc | `false`   | `bool` |
| `add states` | Add states to the bloc | `false`   | `bool` |

mason make bloc --name counter --use_equatable true

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
