### PR TITLE
Added onDone in forEach and onEach methods of Emitter

### DIFF
--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -955,6 +955,27 @@ void main() {
         expect(states, equals(expectedStates));
       });
 
+      test('forEach executes onDone when the stream is over', () async {
+        const expectedStates = [0, 1, 2, -1];
+        final states = <int>[];
+        final controller = StreamController<int>.broadcast();
+        final bloc = RestartableStreamBloc(controller.stream)
+          ..stream.listen(states.add)
+          ..add(ForEachOnDone());
+
+        await tick();
+
+        controller
+          ..add(0)
+          ..add(1)
+          ..add(2);
+
+        await controller.close();
+
+        await bloc.close();
+        expect(states, equals(expectedStates));
+      });
+
       test(
           'forEach with onError handles errors emitted by stream '
           'and does not cancel the subscription', () async {

--- a/packages/bloc/test/blocs/stream/restartable_stream_bloc.dart
+++ b/packages/bloc/test/blocs/stream/restartable_stream_bloc.dart
@@ -7,6 +7,8 @@ abstract class RestartableStreamEvent {}
 
 class ForEach extends RestartableStreamEvent {}
 
+class ForEachOnDone extends RestartableStreamEvent {}
+
 class ForEachOnError extends RestartableStreamEvent {}
 
 class ForEachTryCatch extends RestartableStreamEvent {}
@@ -36,6 +38,17 @@ class RestartableStreamBloc extends Bloc<RestartableStreamEvent, int> {
         await emit.forEach<int>(
           stream,
           onData: (i) => i,
+        );
+      },
+      transformer: (events, mapper) => events.switchMap(mapper),
+    );
+
+    on<ForEachOnDone>(
+      (_, emit) async {
+        await emit.forEach<int>(
+          stream,
+          onData: (i) => i,
+          onDone: () => -1,
         );
       },
       transformer: (events, mapper) => events.switchMap(mapper),


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

**NO**

## Description

In the current version of `Bloc`, if I want to emit a "finishing state" when a Stream is closed, I would do the following:

![image](https://user-images.githubusercontent.com/20285104/184212774-f2aae319-7fb6-4b6a-8d6b-5f073328a30e.png)

It would be much easier to figure this out if we have the same callbacks of the [`listen`](https://api.flutter.dev/flutter/dart-async/Stream/listen.html) method of a `Stream`, which includes the `onDone` callback.

So, I added this callback on `forEach` and `onEach` methods of `Emitter`, and now, we can do this instead:

![image](https://user-images.githubusercontent.com/20285104/184214843-4e083466-140f-405f-a27a-712efc894b60.png)

The first approach doesn't ensure that the `Stream` is really closed, but by relying on `onDone` callback from `listen`, we can guarantee this. We can verify this behavior in the unit test, where the `close` method of `StreamController` is called, and `onDone` is invoked. Is just a syntactic sugar, but it can be really useful when working with `Stream` through `Bloc`.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
