### PR TITLE
chore(flutter_login): remove redundant setUp in authentication_bloc_test of flutter_login example

### DIFF
--- a/examples/flutter_login/test/authentication/authentication_bloc_test.dart
+++ b/examples/flutter_login/test/authentication/authentication_bloc_test.dart
@@ -70,9 +70,6 @@ void main() {
     blocTest<AuthenticationBloc, AuthenticationState>(
       'emits [authenticated] when status is authenticated',
       setUp: () {
-        when(() => authenticationRepository.status).thenAnswer(
-          (_) => Stream.value(AuthenticationStatus.authenticated),
-        );
         when(() => userRepository.getUser()).thenAnswer((_) async => user);
       },
       build: () => AuthenticationBloc(
@@ -89,11 +86,6 @@ void main() {
 
     blocTest<AuthenticationBloc, AuthenticationState>(
       'emits [unauthenticated] when status is unauthenticated',
-      setUp: () {
-        when(() => authenticationRepository.status).thenAnswer(
-          (_) => Stream.value(AuthenticationStatus.unauthenticated),
-        );
-      },
       build: () => AuthenticationBloc(
         authenticationRepository: authenticationRepository,
         userRepository: userRepository,
@@ -143,11 +135,6 @@ void main() {
 
     blocTest<AuthenticationBloc, AuthenticationState>(
       'emits [unknown] when status is unknown',
-      setUp: () {
-        when(() => authenticationRepository.status).thenAnswer(
-          (_) => Stream.value(AuthenticationStatus.unknown),
-        );
-      },
       build: () => AuthenticationBloc(
         authenticationRepository: authenticationRepository,
         userRepository: userRepository,


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

Just a cleanup of flutter_login example tests

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
