### PR TITLE
feat(bloc): introduced BlocBaseInterface

### DIFF
--- a/packages/bloc/lib/src/bloc_base.dart
+++ b/packages/bloc/lib/src/bloc_base.dart
@@ -44,12 +44,16 @@ abstract class ErrorSink implements Closable {
   void addError(Object error, [StackTrace? stackTrace]);
 }
 
+/// The basic interface with minimal access to both:
+/// synchronous access to the current [state] and states emitting.
+abstract class BlocBaseInterface<State>
+    implements StateStreamableSource<State>, Emittable<State> {}
+
 /// {@template bloc_base}
 /// An interface for the core functionality implemented by
 /// both [Bloc] and [Cubit].
 /// {@endtemplate}
-abstract class BlocBase<State>
-    implements StateStreamableSource<State>, Emittable<State>, ErrorSink {
+abstract class BlocBase<State> implements BlocBaseInterface<State>, ErrorSink {
   /// {@macro bloc_base}
   BlocBase(this._state) {
     // ignore: invalid_use_of_protected_member


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

Hey @felangel! The pull request is directly related to #3377, and because abstractions are no longer discussed there, I've created this absolutely straightforward solution. This new `BlocBaseInterface` can be later used in the `bloc_test` package, to make it more abstract:

```dart
void blocTest<B extends BlocBaseInterface<State>, State>

...

Future<void> testBloc<B extends BlocBaseInterface<State>, State>
```

Then all inheritors of pure bloc (that need to have their blocs testable using the `bloc_test` package, for example) can rely on this interface and not on `BlocBase` itself. Because in most cases they already inherit from both `Emittable<State>` and `StateStreamableSource<State>`. It's a rather primitive solution, but in my opinion better than nothing. I'm open to discussion, but also feel free to close this PR without comment, if you don't like this approach. Thanks!

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
