### PR TITLE
fix(flutter_firebase_login): Authentication Repository test failing

### DIFF
--- a/examples/flutter_firebase_login/packages/authentication_repository/pubspec.yaml
+++ b/examples/flutter_firebase_login/packages/authentication_repository/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ">=2.18.5 <3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
   cache:

--- a/examples/flutter_firebase_login/packages/authentication_repository/pubspec.yaml
+++ b/examples/flutter_firebase_login/packages/authentication_repository/pubspec.yaml
@@ -9,12 +9,12 @@ environment:
 dependencies:
   cache:
     path: ../cache
+  equatable: ^2.0.5
+  firebase_auth: ^4.0.2
+  firebase_core: ^2.1.0
   # Unfortunately, a breaking change was introduced in 4.5.2.
   # https://github.com/firebase/flutterfire/issues/9806
-  equatable: ^2.0.5
-  firebase_auth: ^4.1.5
-  firebase_core: ^2.3.0
-  firebase_core_platform_interface: ^4.5.2
+  firebase_core_platform_interface: 4.5.1
   flutter:
     sdk: flutter
   google_sign_in: ^5.4.2

--- a/examples/flutter_firebase_login/packages/authentication_repository/pubspec.yaml
+++ b/examples/flutter_firebase_login/packages/authentication_repository/pubspec.yaml
@@ -4,21 +4,21 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ">=2.18.0 <3.0.0"
+  sdk: ">=2.18.5 <3.0.0"
 
 dependencies:
   cache:
     path: ../cache
-  equatable: ^2.0.3
-  firebase_auth: ^3.11.2
-  firebase_core: ^1.17.1  
   # Unfortunately, a breaking change was introduced in 4.5.2.
   # https://github.com/firebase/flutterfire/issues/9806
-  firebase_core_platform_interface: 4.5.1
+  equatable: ^2.0.5
+  firebase_auth: ^4.1.5
+  firebase_core: ^2.3.0
+  firebase_core_platform_interface: ^4.5.2
   flutter:
     sdk: flutter
-  google_sign_in: ^5.3.3
-  meta: ^1.7.0
+  google_sign_in: ^5.4.2
+  meta: ^1.8.0
 
 dev_dependencies:
   flutter_test:

--- a/examples/flutter_firebase_login/packages/authentication_repository/pubspec.yaml
+++ b/examples/flutter_firebase_login/packages/authentication_repository/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   cache:
     path: ../cache
   equatable: ^2.0.3
-  firebase_auth: ^3.4.0
+  firebase_auth: ^3.11.2
   firebase_core: ^1.17.1  
   # Unfortunately, a breaking change was introduced in 4.5.2.
   # https://github.com/firebase/flutterfire/issues/9806

--- a/examples/flutter_firebase_login/packages/authentication_repository/test/authentication_repository_test.dart
+++ b/examples/flutter_firebase_login/packages/authentication_repository/test/authentication_repository_test.dart
@@ -2,6 +2,7 @@
 import 'package:authentication_repository/authentication_repository.dart';
 import 'package:cache/cache.dart';
 import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
+import 'package:firebase_auth_platform_interface/firebase_auth_platform_interface.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -33,6 +34,8 @@ class MockUserCredential extends Mock implements firebase_auth.UserCredential {}
 
 class FakeAuthCredential extends Fake implements firebase_auth.AuthCredential {}
 
+class FakeAuthProvider extends Fake implements AuthProvider {}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -51,6 +54,7 @@ void main() {
 
     setUpAll(() {
       registerFallbackValue(FakeAuthCredential());
+      registerFallbackValue(FakeAuthProvider());
     });
 
     setUp(() {
@@ -149,6 +153,7 @@ void main() {
             .thenAnswer((_) => Future.value(MockUserCredential()));
         when(() => firebaseAuth.signInWithPopup(any()))
             .thenAnswer((_) => Future.value(MockUserCredential()));
+
       });
 
       test('calls signIn authentication, and signInWithCredential', () async {

--- a/examples/flutter_firebase_login/packages/authentication_repository/test/authentication_repository_test.dart
+++ b/examples/flutter_firebase_login/packages/authentication_repository/test/authentication_repository_test.dart
@@ -153,7 +153,6 @@ void main() {
             .thenAnswer((_) => Future.value(MockUserCredential()));
         when(() => firebaseAuth.signInWithPopup(any()))
             .thenAnswer((_) => Future.value(MockUserCredential()));
-
       });
 
       test('calls signIn authentication, and signInWithCredential', () async {

--- a/examples/flutter_firebase_login/pubspec.yaml
+++ b/examples/flutter_firebase_login/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     path: packages/authentication_repository
   bloc: ^8.1.0
   equatable: ^2.0.3
-  firebase_core: ^1.17.1
+  firebase_core: ^2.1.0
   flow_builder: ^0.0.9
   flutter:
     sdk: flutter


### PR DESCRIPTION
Fixes: #3651

## Status

**READY**

## Breaking Changes

NO

## Description

Fixing test failing 

```
m@m-inspiron5567:~/code/pr/bloc/examples/flutter_firebase_login/packages/authentication_repository$ flutter test
00:12 +4 -1: /home/m/code/pr/bloc/examples/flutter_firebase_login/packages/authentication_repository/test/authentication_repository_test.dart: AuthenticationRepository loginWithGoogle calls signIn authentication, and signInWithCredential [E]
  Bad state: A test tried to use `any` or `captureAny` on a parameter of type `AuthProvider`, but
  registerFallbackValue was not previously called to register a fallback value for `AuthProvider`.  
```

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
