### PR TITLE
Add `BuildContext` extensions

### DIFF
--- a/packages/flutter_bloc/lib/src/bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/bloc_provider.dart
@@ -146,3 +146,8 @@ class BlocProvider<T extends StateStreamableSource<Object?>>
     return subscription.cancel;
   }
 }
+
+extension BlocProviderContext on BuildContext{
+  T readBloc<T> => BlocProvider.of<T>(this);
+  T watchBloc<T> => BlocProvider.of<T>(this, listen: true);
+}

--- a/packages/flutter_bloc/lib/src/repository_provider.dart
+++ b/packages/flutter_bloc/lib/src/repository_provider.dart
@@ -80,3 +80,8 @@ class RepositoryProvider<T> extends Provider<T>
     }
   }
 }
+
+extension RepositoryProviderContext on BuildContext{
+  T readRepository<T> => RepositoryProvider.of<T>(this);
+  T watchRepository<T> => RepositoryProvider.of<T>(this, listen: true);
+}


### PR DESCRIPTION
Add extensions similar to `Provider`s ones which expose useful methods.

## Status

**READY**

## Breaking Changes

NO

## Description

Add `sugar` extensions for simplifying of access to `BlocProvider.of`/`RepositoryProvider.of`:
```
final myBloc = context.readBloc<MyBloc>();
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
