### PR TITLE
docs(flutter_todos): add theme.dart create command in tutorial

### DIFF
--- a/docs/fluttertodostutorial.md
+++ b/docs/fluttertodostutorial.md
@@ -208,6 +208,8 @@ The most notable thing is the concrete implementation of the `local_storage_todo
 
 This provides theme definition for light and dark mode.
 
+Let's create `lib/theme/theme.dart` with the following contents:
+
 [theme.dart](https://raw.githubusercontent.com/felangel/bloc/master/examples/flutter_todos/lib/theme/theme.dart ':include')
 
 ### Home


### PR DESCRIPTION
It does not create `lib/theme/theme.dart` during the Flutter Todos Tutorial.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
