### PR TITLE
refactor(flutter_login): dispose authentication repository

### DIFF
--- a/examples/flutter_login/lib/app.dart
+++ b/examples/flutter_login/lib/app.dart
@@ -7,24 +7,38 @@ import 'package:flutter_login/login/login.dart';
 import 'package:flutter_login/splash/splash.dart';
 import 'package:user_repository/user_repository.dart';
 
-class App extends StatelessWidget {
-  const App({
-    super.key,
-    required this.authenticationRepository,
-    required this.userRepository,
-  });
+class App extends StatefulWidget {
+  const App({super.key});
 
-  final AuthenticationRepository authenticationRepository;
-  final UserRepository userRepository;
+  @override
+  State<App> createState() => _AppState();
+}
+
+class _AppState extends State<App> {
+  late final AuthenticationRepository _authenticationRepository;
+  late final UserRepository _userRepository;
+
+  @override
+  void initState() {
+    super.initState();
+    _authenticationRepository = AuthenticationRepository();
+    _userRepository = UserRepository();
+  }
+
+  @override
+  void dispose() {
+    _authenticationRepository.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return RepositoryProvider.value(
-      value: authenticationRepository,
+      value: _authenticationRepository,
       child: BlocProvider(
         create: (_) => AuthenticationBloc(
-          authenticationRepository: authenticationRepository,
-          userRepository: userRepository,
+          authenticationRepository: _authenticationRepository,
+          userRepository: _userRepository,
         ),
         child: const AppView(),
       ),

--- a/examples/flutter_login/lib/app.dart
+++ b/examples/flutter_login/lib/app.dart
@@ -7,7 +7,7 @@ import 'package:flutter_login/login/login.dart';
 import 'package:flutter_login/splash/splash.dart';
 import 'package:user_repository/user_repository.dart';
 
-class App extends StatelessWidget {
+class App extends StatefulWidget {
   const App({
     super.key,
     required this.authenticationRepository,
@@ -18,13 +18,24 @@ class App extends StatelessWidget {
   final UserRepository userRepository;
 
   @override
+  State<App> createState() => _AppState();
+}
+
+class _AppState extends State<App> {
+  @override
+  void dispose() {
+    widget.authenticationRepository.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return RepositoryProvider.value(
-      value: authenticationRepository,
+      value: widget.authenticationRepository,
       child: BlocProvider(
         create: (_) => AuthenticationBloc(
-          authenticationRepository: authenticationRepository,
-          userRepository: userRepository,
+          authenticationRepository: widget.authenticationRepository,
+          userRepository: widget.userRepository,
         ),
         child: const AppView(),
       ),

--- a/examples/flutter_login/lib/app.dart
+++ b/examples/flutter_login/lib/app.dart
@@ -7,7 +7,7 @@ import 'package:flutter_login/login/login.dart';
 import 'package:flutter_login/splash/splash.dart';
 import 'package:user_repository/user_repository.dart';
 
-class App extends StatefulWidget {
+class App extends StatelessWidget {
   const App({
     super.key,
     required this.authenticationRepository,
@@ -18,24 +18,13 @@ class App extends StatefulWidget {
   final UserRepository userRepository;
 
   @override
-  State<App> createState() => _AppState();
-}
-
-class _AppState extends State<App> {
-  @override
-  void dispose() {
-    widget.authenticationRepository.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     return RepositoryProvider.value(
-      value: widget.authenticationRepository,
+      value: authenticationRepository,
       child: BlocProvider(
         create: (_) => AuthenticationBloc(
-          authenticationRepository: widget.authenticationRepository,
-          userRepository: widget.userRepository,
+          authenticationRepository: authenticationRepository,
+          userRepository: userRepository,
         ),
         child: const AppView(),
       ),

--- a/examples/flutter_login/lib/authentication/bloc/authentication_bloc.dart
+++ b/examples/flutter_login/lib/authentication/bloc/authentication_bloc.dart
@@ -31,7 +31,6 @@ class AuthenticationBloc
   @override
   Future<void> close() {
     _authenticationStatusSubscription.cancel();
-    _authenticationRepository.dispose();
     return super.close();
   }
 

--- a/examples/flutter_login/lib/main.dart
+++ b/examples/flutter_login/lib/main.dart
@@ -1,42 +1,4 @@
-import 'package:authentication_repository/authentication_repository.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_login/app.dart';
-import 'package:user_repository/user_repository.dart';
 
-void main() {
-  runApp(const FlutterLogin());
-}
-
-class FlutterLogin extends StatefulWidget {
-  const FlutterLogin({
-    super.key,
-  });
-
-  @override
-  State<FlutterLogin> createState() => _FlutterLoginState();
-}
-
-class _FlutterLoginState extends State<FlutterLogin> {
-  late AuthenticationRepository authenticationRepository;
-  late UserRepository userRepository;
-  @override
-  void initState() {
-    authenticationRepository = AuthenticationRepository();
-    userRepository = UserRepository();
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    authenticationRepository.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return App(
-      authenticationRepository: authenticationRepository,
-      userRepository: userRepository,
-    );
-  }
-}
+void main() => runApp(const App());

--- a/examples/flutter_login/lib/main.dart
+++ b/examples/flutter_login/lib/main.dart
@@ -4,10 +4,39 @@ import 'package:flutter_login/app.dart';
 import 'package:user_repository/user_repository.dart';
 
 void main() {
-  runApp(
-    App(
-      authenticationRepository: AuthenticationRepository(),
-      userRepository: UserRepository(),
-    ),
-  );
+  runApp(const FlutterLogin());
+}
+
+class FlutterLogin extends StatefulWidget {
+  const FlutterLogin({
+    super.key,
+  });
+
+  @override
+  State<FlutterLogin> createState() => _FlutterLoginState();
+}
+
+class _FlutterLoginState extends State<FlutterLogin> {
+  late AuthenticationRepository authenticationRepository;
+  late UserRepository userRepository;
+  @override
+  void initState() {
+    authenticationRepository = AuthenticationRepository();
+    userRepository = UserRepository();
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    authenticationRepository.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return App(
+      authenticationRepository: authenticationRepository,
+      userRepository: userRepository,
+    );
+  }
 }


### PR DESCRIPTION
Repository dispose updated 

## Breaking Changes

NO

## Description
AuthenticationRepository shouldn't be disposed from bloc. 
So best practice [comment](https://github.com/felangel/bloc/issues/952#issuecomment-598793189) by @felangel  

create a StatefulWidget to create the repository and handle releasing resources in the dispose.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
