### PR TITLE
refactor: update BlocObserver instances to use const constructors

### DIFF
--- a/examples/angular_counter/web/main.dart
+++ b/examples/angular_counter/web/main.dart
@@ -1,8 +1,10 @@
 import 'package:angular/angular.dart';
-import 'package:bloc/bloc.dart';
 import 'package:angular_counter/app_component.template.dart' as ng;
+import 'package:bloc/bloc.dart';
 
 class SimpleBlocObserver extends BlocObserver {
+  const SimpleBlocObserver();
+
   @override
   void onEvent(Bloc bloc, Object? event) {
     print(event);
@@ -23,6 +25,6 @@ class SimpleBlocObserver extends BlocObserver {
 }
 
 void main() {
-  Bloc.observer = SimpleBlocObserver();
+  Bloc.observer = const SimpleBlocObserver();
   runApp(ng.AppComponentNgFactory);
 }

--- a/examples/flutter_complex_list/lib/main.dart
+++ b/examples/flutter_complex_list/lib/main.dart
@@ -6,6 +6,6 @@ import 'package:flutter_complex_list/repository.dart';
 import 'package:flutter_complex_list/simple_bloc_observer.dart';
 
 void main() {
-  Bloc.observer = SimpleBlocObserver();
+  Bloc.observer = const SimpleBlocObserver();
   runApp(App(repository: Repository()));
 }

--- a/examples/flutter_complex_list/lib/simple_bloc_observer.dart
+++ b/examples/flutter_complex_list/lib/simple_bloc_observer.dart
@@ -1,6 +1,8 @@
 import 'package:bloc/bloc.dart';
 
 class SimpleBlocObserver extends BlocObserver {
+  const SimpleBlocObserver();
+
   @override
   void onError(BlocBase<dynamic> bloc, Object error, StackTrace stackTrace) {
     // ignore: avoid_print

--- a/examples/flutter_counter/lib/counter_observer.dart
+++ b/examples/flutter_counter/lib/counter_observer.dart
@@ -5,6 +5,9 @@ import 'package:bloc/bloc.dart';
 /// observes all state changes.
 /// {@endtemplate}
 class CounterObserver extends BlocObserver {
+  /// {@macro counter_observer}
+  const CounterObserver();
+
   @override
   void onChange(BlocBase<dynamic> bloc, Change<dynamic> change) {
     super.onChange(bloc, change);

--- a/examples/flutter_counter/lib/main.dart
+++ b/examples/flutter_counter/lib/main.dart
@@ -4,6 +4,6 @@ import 'package:flutter_counter/app.dart';
 import 'package:flutter_counter/counter_observer.dart';
 
 void main() {
-  Bloc.observer = CounterObserver();
+  Bloc.observer = const CounterObserver();
   runApp(const CounterApp());
 }

--- a/examples/flutter_firebase_login/lib/app/bloc_observer.dart
+++ b/examples/flutter_firebase_login/lib/app/bloc_observer.dart
@@ -2,6 +2,8 @@
 import 'package:bloc/bloc.dart';
 
 class AppBlocObserver extends BlocObserver {
+  const AppBlocObserver();
+
   @override
   void onEvent(Bloc<dynamic, dynamic> bloc, Object? event) {
     super.onEvent(bloc, event);

--- a/examples/flutter_firebase_login/lib/main.dart
+++ b/examples/flutter_firebase_login/lib/main.dart
@@ -6,7 +6,7 @@ import 'package:flutter_firebase_login/app/app.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  Bloc.observer = AppBlocObserver();
+  Bloc.observer = const AppBlocObserver();
 
   await Firebase.initializeApp();
 

--- a/examples/flutter_infinite_list/lib/main.dart
+++ b/examples/flutter_infinite_list/lib/main.dart
@@ -5,6 +5,6 @@ import 'package:flutter_infinite_list/app.dart';
 import 'package:flutter_infinite_list/simple_bloc_observer.dart';
 
 void main() {
-  Bloc.observer = SimpleBlocObserver();
+  Bloc.observer = const SimpleBlocObserver();
   runApp(const App());
 }

--- a/examples/flutter_infinite_list/lib/simple_bloc_observer.dart
+++ b/examples/flutter_infinite_list/lib/simple_bloc_observer.dart
@@ -3,6 +3,8 @@
 import 'package:bloc/bloc.dart';
 
 class SimpleBlocObserver extends BlocObserver {
+  const SimpleBlocObserver();
+
   @override
   void onTransition(
     Bloc<dynamic, dynamic> bloc,

--- a/examples/flutter_shopping_cart/lib/main.dart
+++ b/examples/flutter_shopping_cart/lib/main.dart
@@ -5,6 +5,6 @@ import 'package:flutter_shopping_cart/shopping_repository.dart';
 import 'package:flutter_shopping_cart/simple_bloc_observer.dart';
 
 void main() {
-  Bloc.observer = SimpleBlocObserver();
+  Bloc.observer = const SimpleBlocObserver();
   runApp(App(shoppingRepository: ShoppingRepository()));
 }

--- a/examples/flutter_shopping_cart/lib/simple_bloc_observer.dart
+++ b/examples/flutter_shopping_cart/lib/simple_bloc_observer.dart
@@ -3,6 +3,8 @@ import 'dart:developer';
 import 'package:bloc/bloc.dart';
 
 class SimpleBlocObserver extends BlocObserver {
+  const SimpleBlocObserver();
+
   @override
   void onEvent(Bloc<dynamic, dynamic> bloc, Object? event) {
     super.onEvent(bloc, event);

--- a/examples/flutter_todos/lib/app/app_bloc_observer.dart
+++ b/examples/flutter_todos/lib/app/app_bloc_observer.dart
@@ -3,6 +3,8 @@ import 'dart:developer';
 import 'package:bloc/bloc.dart';
 
 class AppBlocObserver extends BlocObserver {
+  const AppBlocObserver();
+
   @override
   void onChange(BlocBase<dynamic> bloc, Change<dynamic> change) {
     super.onChange(bloc, change);

--- a/examples/flutter_todos/lib/bootstrap.dart
+++ b/examples/flutter_todos/lib/bootstrap.dart
@@ -13,7 +13,7 @@ void bootstrap({required TodosApi todosApi}) {
     log(details.exceptionAsString(), stackTrace: details.stack);
   };
 
-  Bloc.observer = AppBlocObserver();
+  Bloc.observer = const AppBlocObserver();
 
   final todosRepository = TodosRepository(todosApi: todosApi);
 

--- a/examples/flutter_todos/pubspec.lock
+++ b/examples/flutter_todos/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: "direct main"
     description:
       name: bloc
-      sha256: bd4f8027bfa60d96c8046dec5ce74c463b2c918dce1b0d36593575995344534a
+      sha256: "658a5ae59edcf1e58aac98b000a71c762ad8f46f1394c34a52050cafb3e11a80"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.0"
+    version: "8.1.1"
   bloc_test:
     dependency: "direct dev"
     description:

--- a/examples/flutter_todos/pubspec.yaml
+++ b/examples/flutter_todos/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.19.0 <3.0.0"
 
 dependencies:
-  bloc: ^8.1.0
+  bloc: ^8.1.1
   equatable: ^2.0.5
   flutter:
     sdk: flutter

--- a/examples/flutter_weather/lib/main.dart
+++ b/examples/flutter_weather/lib/main.dart
@@ -8,7 +8,7 @@ import 'package:weather_repository/weather_repository.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  Bloc.observer = WeatherBlocObserver();
+  Bloc.observer = const WeatherBlocObserver();
   HydratedBloc.storage = await HydratedStorage.build(
     storageDirectory: kIsWeb
         ? HydratedStorage.webStorageDirectory

--- a/examples/flutter_weather/lib/weather_bloc_observer.dart
+++ b/examples/flutter_weather/lib/weather_bloc_observer.dart
@@ -3,6 +3,8 @@ import 'dart:developer';
 import 'package:bloc/bloc.dart';
 
 class WeatherBlocObserver extends BlocObserver {
+  const WeatherBlocObserver();
+
   @override
   void onEvent(Bloc<dynamic, dynamic> bloc, Object? event) {
     super.onEvent(bloc, event);

--- a/packages/bloc_test/lib/src/bloc_test.dart
+++ b/packages/bloc_test/lib/src/bloc_test.dart
@@ -249,7 +249,7 @@ Alternatively, consider using Matchers in the expect of the blocTest rather than
 }
 
 class _TestBlocObserver extends BlocObserver {
-  _TestBlocObserver(this._localObserver, this._onError);
+  const _TestBlocObserver(this._localObserver, this._onError);
 
   final BlocObserver _localObserver;
   final void Function(Object error) _onError;

--- a/packages/flutter_bloc/example/lib/main.dart
+++ b/packages/flutter_bloc/example/lib/main.dart
@@ -2,12 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 void main() {
-  Bloc.observer = AppBlocObserver();
+  Bloc.observer = const AppBlocObserver();
   runApp(const App());
 }
 
+/// {@template app_bloc_observer}
+
 /// Custom [BlocObserver] that observes all bloc and cubit state changes.
+/// {@endtemplate}
 class AppBlocObserver extends BlocObserver {
+  /// {@macro app_bloc_observer}
+  const AppBlocObserver();
+
   @override
   void onChange(BlocBase bloc, Change change) {
     super.onChange(bloc, change);

--- a/packages/flutter_bloc/example/lib/main.dart
+++ b/packages/flutter_bloc/example/lib/main.dart
@@ -7,7 +7,6 @@ void main() {
 }
 
 /// {@template app_bloc_observer}
-
 /// Custom [BlocObserver] that observes all bloc and cubit state changes.
 /// {@endtemplate}
 class AppBlocObserver extends BlocObserver {

--- a/packages/replay_bloc/example/lib/main.dart
+++ b/packages/replay_bloc/example/lib/main.dart
@@ -13,6 +13,7 @@ void main() {
 class AppBlocObserver extends BlocObserver {
   /// {@macro app_bloc_observer}
   const AppBlocObserver();
+
   @override
   void onChange(BlocBase bloc, Change change) {
     super.onChange(bloc, change);

--- a/packages/replay_bloc/example/lib/main.dart
+++ b/packages/replay_bloc/example/lib/main.dart
@@ -3,12 +3,16 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:replay_bloc/replay_bloc.dart';
 
 void main() {
-  Bloc.observer = AppBlocObserver();
+  Bloc.observer = const AppBlocObserver();
   runApp(const App());
 }
 
+/// {@template app_bloc_observer}
 /// Custom [BlocObserver] that observes all bloc and cubit state changes.
+/// {@endtemplate}
 class AppBlocObserver extends BlocObserver {
+  /// {@macro app_bloc_observer}
+  const AppBlocObserver();
   @override
   void onChange(BlocBase bloc, Change change) {
     super.onChange(bloc, change);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

Follows https://github.com/felangel/bloc/pull/3704 and relates to https://github.com/felangel/bloc/issues/3703

This PR updates all the bloc observers to have and use a const constructor.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
