### PR TITLE
refactor(angular_bloc)!: upgrade ngdart to v8 pre-release

### DIFF
--- a/.github/workflows/angular_bloc.yaml
+++ b/.github/workflows/angular_bloc.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 2.17.6
+          sdk: 2.19.0
 
       - name: Install Dependencies
         run: dart pub get

--- a/.github/workflows/angular_dart_examples.yaml
+++ b/.github/workflows/angular_dart_examples.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 2.17.6
+          sdk: 2.19.0
 
       - name: Install Dependencies
         working-directory: ${{ matrix.folder }}

--- a/examples/angular_counter/pubspec.yaml
+++ b/examples/angular_counter/pubspec.yaml
@@ -2,12 +2,12 @@ name: angular_counter
 description: A web app that uses angular_bloc
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.19.0 <3.0.0"
 
 dependencies:
   angular_bloc: ^8.0.0
   bloc: ^8.1.1
-  ngdart: ^7.0.0
+  ngdart: ^8.0.0-dev.0
 
 dev_dependencies:
   build_runner: ^2.0.0

--- a/examples/github_search/angular_github_search/analysis_options.yaml
+++ b/examples/github_search/angular_github_search/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:very_good_analysis/analysis_options.3.0.0.yaml
+include: package:very_good_analysis/analysis_options.4.0.0.yaml
 analyzer:
   exclude: [build/**]
   errors:

--- a/examples/github_search/angular_github_search/pubspec.yaml
+++ b/examples/github_search/angular_github_search/pubspec.yaml
@@ -14,4 +14,4 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.0.0
   build_web_compilers: ^3.0.0
-  very_good_analysis: ^3.0.0
+  very_good_analysis: ^4.0.0

--- a/examples/github_search/angular_github_search/pubspec.yaml
+++ b/examples/github_search/angular_github_search/pubspec.yaml
@@ -2,14 +2,14 @@ name: angular_github_search
 description: A web app that uses AngularDart Components
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.19.0 <3.0.0"
 
 dependencies:
   angular_bloc: ^8.0.0
   bloc: ^8.1.0
   common_github_search:
     path: ../common_github_search
-  ngdart: ^7.0.0
+  ngdart: ^8.0.0-dev.0
 
 dev_dependencies:
   build_runner: ^2.0.0

--- a/examples/github_search/common_github_search/analysis_options.yaml
+++ b/examples/github_search/common_github_search/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:very_good_analysis/analysis_options.3.0.0.yaml
+include: package:very_good_analysis/analysis_options.4.0.0.yaml
 linter:
   rules:
     public_member_api_docs: false

--- a/examples/github_search/common_github_search/pubspec.yaml
+++ b/examples/github_search/common_github_search/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.19.0 <3.0.0"
 
 dependencies:
   bloc: ^8.1.0
@@ -17,4 +17,4 @@ dependency_overrides:
     path: ../../../packages/bloc
 
 dev_dependencies:
-  very_good_analysis: ^3.0.0
+  very_good_analysis: ^4.0.0

--- a/packages/angular_bloc/pubspec.yaml
+++ b/packages/angular_bloc/pubspec.yaml
@@ -7,14 +7,14 @@ homepage: https://bloclibrary.dev
 documentation: https://bloclibrary.dev/#/gettingstarted
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.19.0 <3.0.0"
 
 dependencies:
-  ngdart: ^7.0.0
+  ngdart: ^8.0.0-dev.0
   bloc: ^8.0.0
 
 dev_dependencies:
-  ngtest: ^4.1.1
+  ngtest: ^5.0.0-dev.0
   build_runner: ^2.0.0
   build_test: ^2.0.0
   build_web_compilers: ^3.0.0


### PR DESCRIPTION
Hi @felangel! Sorry for the delay. I just published an AngularDart v8 pre-release that uses analyzer v5, so this should allow `angular_bloc` to use Dart 2.19 now.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

YES

## Description

Bump AngularDart to `v8.0.0-dev.0` to allow upgrading the minimum Dart SDK to 2.19

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
