### PR TITLE
docs(architecture): add missing semicolon in snippet

### DIFF
--- a/docs/_snippets/architecture/do_not_do_this_at_home.dart.md
+++ b/docs/_snippets/architecture/do_not_do_this_at_home.dart.md
@@ -7,7 +7,7 @@ class BadBloc extends Bloc {
     // No matter how much you are tempted to do this, you should not do this!
     // Keep reading for better alternatives!
     otherBlocSubscription = otherBloc.stream.listen((state) {
-      add(MyEvent())
+      add(MyEvent());
     });
   }
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

READY

## Breaking Changes

NO

## Description

While implementing lint rules for Bloc, I noticed that the copied example code doesn't compile due to a missing semicolon.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
