### PR TITLE
update timer_state.dart

### DIFF
--- a/examples/flutter_timer/lib/timer/bloc/timer_state.dart
+++ b/examples/flutter_timer/lib/timer/bloc/timer_state.dart
@@ -1,32 +1,30 @@
 part of 'timer_bloc.dart';
 
 abstract class TimerState extends Equatable {
-  const TimerState(this.duration);
   final int duration;
+
+  const TimerState(this.duration);
 
   @override
   List<Object> get props => [duration];
 }
 
 class TimerInitial extends TimerState {
-  const TimerInitial(super.duration);
-
+  const TimerInitial(int duration) : super(duration);
   @override
   String toString() => 'TimerInitial { duration: $duration }';
 }
 
-class TimerRunPause extends TimerState {
-  const TimerRunPause(super.duration);
-
-  @override
-  String toString() => 'TimerRunPause { duration: $duration }';
-}
-
 class TimerRunInProgress extends TimerState {
-  const TimerRunInProgress(super.duration);
-
+  const TimerRunInProgress(int duration) : super(duration);
   @override
   String toString() => 'TimerRunInProgress { duration: $duration }';
+}
+
+class TimerRunPause extends TimerState {
+  const TimerRunPause(int duration) : super(duration);
+  @override
+  String toString() => 'TimerRunPause { duration: $duration }';
 }
 
 class TimerRunComplete extends TimerState {


### PR DESCRIPTION
the duration value would never be updated that way as it would always get either 60 when the timer gets initiated or 0 when it is completed but since it should be updated accordingly when TimerRunInProgress gets called and when TimerRunPause gets called so we need to pass the duration argument to the parent constructor to update its value.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

 NO

## Description

changed the constructor to update the time values accordinlgy 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
