### PR TITLE
FIX: unprocessed events added to eventStream when isClosed is false

### DIFF
--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -277,12 +277,12 @@ abstract class Bloc<Event, State> extends BlocBase<State>
   @mustCallSuper
   @override
   Future<void> close() async {
-    await _eventController.close();
     for (final emitter in _emitters) {
       emitter.cancel();
     }
     await Future.wait<void>(_emitters.map((e) => e.future));
     await Future.wait<void>(_subscriptions.map((s) => s.cancel()));
+    await _eventController.close();
     return super.close();
   }
 }

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -128,6 +128,9 @@ abstract class Bloc<Event, State> extends BlocBase<State>
     _blocObserver.onEvent(this, event);
   }
 
+  @override
+  bool get isClosed => super.isClosed || _eventController.isClosed;
+
   /// {@template emit}
   /// **[emit] is only for internal use and should never be called directly
   /// outside of tests. The [Emitter] instance provided to each [EventHandler]
@@ -277,12 +280,12 @@ abstract class Bloc<Event, State> extends BlocBase<State>
   @mustCallSuper
   @override
   Future<void> close() async {
+    await _eventController.close();
     for (final emitter in _emitters) {
       emitter.cancel();
     }
     await Future.wait<void>(_emitters.map((e) => e.future));
     await Future.wait<void>(_subscriptions.map((s) => s.cancel()));
-    await _eventController.close();
     return super.close();
   }
 }


### PR DESCRIPTION
## Status
READY

## Breaking Changes
NO

## Description

https://github.com/felangel/bloc/issues/3756

This PR fixes the issue in the comment, the problem is that the Bloc is closed during the event processing.

I'm not sure if this is the best solution, but maybe set the isClosed when the close be called could be better. The solution solves the problem because the event is just closed after the emitters, and is processed.

> 
> I'm also encountering the same issue. In my implementation, I have a widget tree with a Screen widget that contains a MultiBlocProvider with a CustomTabBarView as its child. Each CustomTabBarView has some blocs that are necessary for it to function properly. In the dispose method of the widget, I add a new event to the blocs to perform some necessary cleanup.
> 
> However, when attempting to add an event to another bloc inside one of the blocs, a StateError is thrown because the event stream appears to be closed. This is problematic because the isClosed property of the bloc always returns false, as it only checks the StateStream and not the eventStream.
> 
> My Widget Tree:
> ```
> Screen(
>    TabBuilder(
>      MultiBlocProvider(
>        providers: [
>            BlocProvider<BlocA>(),
>            BlocProvider<BlocB>(),
>            ...
>        ],
>        child: CustomTabBarView()
>      )
>    )
> )
> ```


```
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following StateError was thrown running a test:
Bad state: Cannot add new events after calling close

When the exception was thrown, this was the stack:
#1      Bloc.add (package:bloc/src/bloc.dart:99:24)
#2      FeedItemBloc._mapFeedItemPausedToState (package:indaband/feed/widgets/feed_item_view/bloc/feed_item_bloc.dart:639:20)
#3      Bloc.on.<anonymous closure>.handleEvent (package:bloc/src/bloc.dart:226:26)
#4      Bloc.on.<anonymous closure> (package:bloc/src/bloc.dart:235:9)
#13     CastStreamSubscription._onData (dart:_internal/async_cast.dart:85:11)
#41     FakeAsync.flushMicrotasks (package:fake_async/fake_async.dart:197:32)
#42     AutomatedTestWidgetsFlutterBinding.scheduleWarmUpFrame (package:flutter_test/src/binding.dart:1283:24)
#43     runApp (package:flutter/src/widgets/binding.dart:1019:7)
#44     TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:942:7)
<asynchronous suspension>
(elided 36 frames from dart:async and package:stack_trace)
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
