### PR TITLE
feat(bloc_concurrency): sequentialDroppable transformer

### DIFF
--- a/packages/bloc_concurrency/CHANGELOG.md
+++ b/packages/bloc_concurrency/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.1
+
+- feat: added sequentialDroppable transformer
+ 
 # 0.2.1
 
 - chore: add screenshots to `pubspec.yaml`

--- a/packages/bloc_concurrency/README.md
+++ b/packages/bloc_concurrency/README.md
@@ -63,6 +63,7 @@ Our top sponsors are shown below! [[Become a Sponsor](https://github.com/sponsor
 - `sequential` - process events sequentially
 - `droppable` - ignore any events added while an event is processing
 - `restartable` - process only the latest event and cancel previous event handlers
+- `sequentialDroppable` - a combination of `sequential` and `droppable` which will drop specified events by type if one is already being processed in sequence
 
 ## Usage
 

--- a/packages/bloc_concurrency/lib/bloc_concurrency.dart
+++ b/packages/bloc_concurrency/lib/bloc_concurrency.dart
@@ -8,3 +8,4 @@ export 'src/concurrent.dart';
 export 'src/droppable.dart';
 export 'src/restartable.dart';
 export 'src/sequential.dart';
+export 'src/sequential_droppable.dart';

--- a/packages/bloc_concurrency/lib/src/sequential_droppable.dart
+++ b/packages/bloc_concurrency/lib/src/sequential_droppable.dart
@@ -38,7 +38,7 @@ class _SequentialAndDroppable<Event>
         ? StreamController<Event>.broadcast(sync: true)
         : StreamController<Event>(sync: true);
     Completer<void>? completer;
-    Type? activeDroppableEvenType;
+    Type? activeDroppableEventType;
 
     final subscription = stream.listen(
       null,
@@ -58,7 +58,7 @@ class _SequentialAndDroppable<Event>
     void disposeDroppable() {
       completer!.complete();
       completer = null;
-      activeDroppableEvenType = null;
+      activeDroppableEventType = null;
     }
 
     controller.onListen = () {
@@ -81,16 +81,16 @@ class _SequentialAndDroppable<Event>
         }
 
         final isDifferentDroppableEventInProgress =
-            completer != null && activeDroppableEvenType != event.runtimeType;
+            completer != null && activeDroppableEventType != event.runtimeType;
 
         if (isDifferentDroppableEventInProgress) await freeze();
 
         final shouldDrop =
-            completer != null && activeDroppableEvenType == event.runtimeType;
+            completer != null && activeDroppableEventType == event.runtimeType;
 
         if (shouldDrop) return;
 
-        activeDroppableEvenType = event.runtimeType;
+        activeDroppableEventType = event.runtimeType;
         completer = Completer<void>();
 
         final mappedStream = _mapEventToStream(event, controller);

--- a/packages/bloc_concurrency/lib/src/sequential_droppable.dart
+++ b/packages/bloc_concurrency/lib/src/sequential_droppable.dart
@@ -1,0 +1,130 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:bloc_concurrency/bloc_concurrency.dart';
+
+/// Combination of [sequential] and [droppable].
+///
+/// This will drop any events that match the types provided in the
+/// [droppableEvents] list if an event of the same type is already
+/// being processed.
+EventTransformer<Event> sequentialDroppable<Event>({
+  required List<Type> droppableEvents,
+}) {
+  return (events, mapper) {
+    return events.transform(
+      _SequentialAndDroppable(
+        mapper,
+        droppableTypes: droppableEvents,
+      ),
+    );
+  };
+}
+
+class _SequentialAndDroppable<Event>
+    extends StreamTransformerBase<Event, Event> {
+  _SequentialAndDroppable(
+    this.mapper, {
+    required List<Type> droppableTypes,
+  })  : assert(droppableTypes.isNotEmpty, 'droppableTypes should not be empty'),
+        _droppableTypes = Set.unmodifiable(droppableTypes);
+
+  final EventMapper<Event> mapper;
+  final Set<Type> _droppableTypes;
+
+  @override
+  Stream<Event> bind(Stream<Event> stream) {
+    final controller = stream.isBroadcast
+        ? StreamController<Event>.broadcast(sync: true)
+        : StreamController<Event>(sync: true);
+    Completer<void>? completer;
+    Type? activeDroppableEvenType;
+
+    final subscription = stream.listen(
+      null,
+      onError: controller.addError,
+      onDone: () {
+        controller.close();
+        completer = null;
+      },
+    );
+
+    Future<void> freeze() async {
+      subscription.pause();
+      await completer!.future;
+      subscription.resume();
+    }
+
+    void unfreeze() {
+      completer!.complete();
+      completer = null;
+    }
+
+    void disposeDroppable() {
+      unfreeze();
+      activeDroppableEvenType = null;
+    }
+
+    controller.onListen = () {
+      subscription.onData((Event event) async {
+        final isDroppable = _droppableTypes.contains(event.runtimeType);
+        if (completer != null && !isDroppable) await freeze();
+
+        if (isDroppable) {
+          final isDifferentDroppableEventInProgress =
+              completer != null && activeDroppableEvenType != event.runtimeType;
+
+          if (isDifferentDroppableEventInProgress) await freeze();
+
+          final shouldDrop =
+              completer != null && activeDroppableEvenType == event.runtimeType;
+
+          if (shouldDrop) return;
+
+          activeDroppableEvenType = event.runtimeType;
+          completer = Completer<void>();
+
+          final mappedStream = _mapEventToStream(event, controller);
+
+          if (mappedStream == null) return;
+
+          await controller
+              .addStream(mappedStream)
+              .whenComplete(disposeDroppable);
+
+          return;
+        }
+
+        final mappedStream = _mapEventToStream(event, controller);
+
+        if (mappedStream == null) return;
+
+        subscription.pause();
+        await controller
+            .addStream(mappedStream)
+            .whenComplete(subscription.resume);
+      });
+
+      controller.onCancel = subscription.cancel;
+      if (!stream.isBroadcast) {
+        controller
+          ..onPause = subscription.pause
+          ..onResume = subscription.resume;
+      }
+    };
+
+    return controller.stream;
+  }
+
+  Stream<Event>? _mapEventToStream(
+    Event event,
+    StreamController<Event> controller,
+  ) {
+    try {
+      return mapper(event);
+    } catch (e, s) {
+      controller.addError(e, s);
+      return null;
+    }
+  }
+}

--- a/packages/bloc_concurrency/pubspec.yaml
+++ b/packages/bloc_concurrency/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc_concurrency
 description: Custom event transformers inspired by ember concurrency. Built to be used with the bloc state management package.
-version: 0.2.1
+version: 0.3.1
 repository: https://github.com/felangel/bloc/tree/master/packages/bloc_concurrency
 issue_tracker: https://github.com/felangel/bloc/issues
 homepage: https://github.com/felangel/bloc

--- a/packages/bloc_concurrency/test/src/sequential_droppable_test.dart
+++ b/packages/bloc_concurrency/test/src/sequential_droppable_test.dart
@@ -288,6 +288,35 @@ void main() {
         states: [1, 2, 3, 4, 5, 6],
       );
     });
+
+    test('process droppable events after one is processed in correct order',
+        () async {
+      final states = <int>[];
+      final bloc = CounterBloc(
+        sequentialDroppable(droppableEvents: [_EventA]),
+      )
+        ..stream.listen(states.add)
+        ..add(_EventA())
+        ..add(_EventA())
+        ..add(_EventA());
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [_EventA()],
+        states: [1],
+      );
+
+      bloc.add(_EventA());
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [
+          _EventA(),
+          _EventA(),
+        ],
+        states: [1, 2],
+      );
+    });
   });
 }
 

--- a/packages/bloc_concurrency/test/src/sequential_droppable_test.dart
+++ b/packages/bloc_concurrency/test/src/sequential_droppable_test.dart
@@ -1,0 +1,336 @@
+// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
+
+import 'dart:async';
+
+import 'package:bloc_concurrency/bloc_concurrency.dart';
+import 'package:test/test.dart';
+
+import 'helpers.dart';
+
+void main() {
+  group('sequentialDroppable', () {
+    Future<void> verifyEventsAndStates({
+      required CounterBloc bloc,
+      required List<Increment> events,
+      required List<int> states,
+    }) async {
+      await tick();
+
+      expect(bloc.onCalls, events);
+
+      await wait();
+
+      expect(bloc.onEmitCalls, events);
+
+      expect(states, equals(states));
+    }
+
+    test('create without specified events', () {
+      expect(
+        () => sequentialDroppable<int>(droppableEvents: []).call(
+          const Stream.empty(),
+          (_) => const Stream.empty(),
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('processes in sequence', () async {
+      final states = <int>[];
+      final bloc = CounterBloc(sequentialDroppable(droppableEvents: [_EventA]))
+        ..stream.listen(states.add)
+        ..add(_EventA())
+        ..add(_EventB())
+        ..add(_EventC())
+        ..add(_EventD());
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [_EventA()],
+        states: [1],
+      );
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [
+          _EventA(),
+          _EventB(),
+        ],
+        states: [1, 2],
+      );
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [
+          _EventA(),
+          _EventB(),
+          _EventC(),
+        ],
+        states: [1, 2, 3],
+      );
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [
+          _EventA(),
+          _EventB(),
+          _EventC(),
+          _EventD(),
+        ],
+        states: [1, 2, 3, 4],
+      );
+    });
+
+    test('ignore specified event in sequence', () async {
+      final states = <int>[];
+      final bloc = CounterBloc(sequentialDroppable(droppableEvents: [_EventA]))
+        ..stream.listen(states.add)
+        ..add(_EventB())
+        ..add(_EventA())
+        ..add(_EventA())
+        ..add(_EventA())
+        ..add(_EventC())
+        ..add(_EventC());
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [_EventB()],
+        states: [1],
+      );
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [
+          _EventB(),
+          _EventA(),
+        ],
+        states: [1, 2],
+      );
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [
+          _EventB(),
+          _EventA(),
+          _EventC(),
+        ],
+        states: [1, 2, 3],
+      );
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [
+          _EventB(),
+          _EventA(),
+          _EventC(),
+          _EventC(),
+        ],
+        states: [1, 2, 3, 4],
+      );
+    });
+
+    test('ignore specified multiple events in sequence', () async {
+      final states = <int>[];
+      final bloc =
+          CounterBloc(sequentialDroppable(droppableEvents: [_EventA, _EventD]))
+            ..stream.listen(states.add)
+            ..add(_EventB())
+            ..add(_EventA())
+            ..add(_EventA())
+            ..add(_EventA())
+            ..add(_EventC())
+            ..add(_EventC())
+            ..add(_EventD())
+            ..add(_EventD())
+            ..add(_EventD())
+            ..add(_EventB());
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [_EventB()],
+        states: [1],
+      );
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [
+          _EventB(),
+          _EventA(),
+        ],
+        states: [1, 2],
+      );
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [
+          _EventB(),
+          _EventA(),
+          _EventC(),
+        ],
+        states: [1, 2, 3],
+      );
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [
+          _EventB(),
+          _EventA(),
+          _EventC(),
+          _EventC(),
+        ],
+        states: [1, 2, 3, 4],
+      );
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [
+          _EventB(),
+          _EventA(),
+          _EventC(),
+          _EventC(),
+          _EventD(),
+        ],
+        states: [1, 2, 3, 4, 5],
+      );
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [
+          _EventB(),
+          _EventA(),
+          _EventC(),
+          _EventC(),
+          _EventD(),
+          _EventB(),
+        ],
+        states: [1, 2, 3, 4, 5, 6],
+      );
+    });
+
+    test('process multiple droppable events in a row with correct sequence',
+        () async {
+      final states = <int>[];
+      final bloc = CounterBloc(
+        sequentialDroppable(droppableEvents: [_EventA, _EventD, _EventC]),
+      )
+        ..stream.listen(states.add)
+        ..add(_EventB())
+        ..add(_EventA())
+        ..add(_EventA())
+        ..add(_EventA())
+        ..add(_EventD())
+        ..add(_EventD())
+        ..add(_EventD())
+        ..add(_EventC())
+        ..add(_EventC())
+        ..add(_EventC())
+        ..add(_EventB())
+        ..add(_EventA());
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [_EventB()],
+        states: [1],
+      );
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [
+          _EventB(),
+          _EventA(),
+        ],
+        states: [1, 2],
+      );
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [
+          _EventB(),
+          _EventA(),
+          _EventD(),
+        ],
+        states: [1, 2, 3],
+      );
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [
+          _EventB(),
+          _EventA(),
+          _EventD(),
+          _EventC(),
+        ],
+        states: [1, 2, 3, 4],
+      );
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [
+          _EventB(),
+          _EventA(),
+          _EventD(),
+          _EventC(),
+          _EventB(),
+        ],
+        states: [1, 2, 3, 4, 5],
+      );
+
+      await verifyEventsAndStates(
+        bloc: bloc,
+        events: [
+          _EventB(),
+          _EventA(),
+          _EventD(),
+          _EventC(),
+          _EventB(),
+          _EventA(),
+        ],
+        states: [1, 2, 3, 4, 5, 6],
+      );
+    });
+  });
+}
+
+class _EventA implements Increment {
+  @override
+  String toString() => 'EventA';
+
+  @override
+  bool operator ==(Object value) => identical(this, value) || value is _EventA;
+
+  @override
+  int get hashCode => 0;
+}
+
+class _EventB implements Increment {
+  @override
+  String toString() => 'EventB';
+
+  @override
+  bool operator ==(Object value) => identical(this, value) || value is _EventB;
+
+  @override
+  int get hashCode => 1;
+}
+
+class _EventC implements Increment {
+  @override
+  String toString() => 'EventC';
+
+  @override
+  bool operator ==(Object value) => identical(this, value) || value is _EventC;
+
+  @override
+  int get hashCode => 3;
+}
+
+class _EventD implements Increment {
+  @override
+  String toString() => 'EventD';
+
+  @override
+  bool operator ==(Object value) => identical(this, value) || value is _EventD;
+
+  @override
+  int get hashCode => 4;
+}


### PR DESCRIPTION

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

Added new kind of transformer which was requested in #3435.  

## Status

**READY**

## Breaking Changes

NO

## Description

The main point is that sometimes we need to drop certain events in sequential order by type. Once I faced this problem myself and other people also asked about it, so I decided to create a solution.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
