### PR TITLE
Improve the UI that matches the flutter_timer tutorial examples

### DIFF
--- a/examples/flutter_timer/lib/app.dart
+++ b/examples/flutter_timer/lib/app.dart
@@ -9,9 +9,11 @@ class App extends StatelessWidget {
     return MaterialApp(
       title: 'Flutter Timer',
       theme: ThemeData(
-        primaryColor: const Color.fromRGBO(109, 234, 255, 1),
-        colorScheme: const ColorScheme.light(
-          secondary: Color.fromRGBO(72, 74, 126, 1),
+        primarySwatch: Colors.blue,
+        // Set global FAB theme
+        floatingActionButtonTheme: FloatingActionButtonThemeData(
+          backgroundColor: Color.fromARGB(255, 50, 42, 83),
+          foregroundColor: Colors.white,
         ),
       ),
       home: const TimerPage(),

--- a/examples/flutter_timer/lib/app.dart
+++ b/examples/flutter_timer/lib/app.dart
@@ -10,7 +10,6 @@ class App extends StatelessWidget {
       title: 'Flutter Timer',
       theme: ThemeData(
         primarySwatch: Colors.blue,
-        // Set global FAB theme
         floatingActionButtonTheme: FloatingActionButtonThemeData(
           backgroundColor: Color.fromARGB(255, 50, 42, 83),
           foregroundColor: Colors.white,

--- a/examples/flutter_timer/lib/timer/view/timer_page.dart
+++ b/examples/flutter_timer/lib/timer/view/timer_page.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_timer/ticker.dart';
 import 'package:flutter_timer/timer/timer.dart';
-import 'package:wave/wave.dart';
 import 'package:wave/config.dart';
+import 'package:wave/wave.dart';
 
 class TimerPage extends StatelessWidget {
   const TimerPage({super.key});
@@ -35,8 +35,8 @@ class TimerView extends StatelessWidget {
                 child: Center(child: TimerText()),
               ),
               SizedBox(
-                width: 300.0,
-                height: 50.0,
+                width: 300,
+                height: 50,
                 child: Actions(),
               )
             ],
@@ -58,9 +58,9 @@ class TimerText extends StatelessWidget {
     final secondsStr = (duration % 60).toString().padLeft(2, '0');
     return Text(
       '$minutesStr:$secondsStr',
-      style: TextStyle(
+      style: const TextStyle(
         color: Colors.white, 
-        fontSize: 48.0, 
+        fontSize: 48, 
       ),
     );
   }
@@ -126,7 +126,7 @@ class Actions extends StatelessWidget {
 }
 
 class Background extends StatelessWidget {
-  const Background({Key? key}) : super(key: key);
+  const Background({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -134,19 +134,19 @@ class Background extends StatelessWidget {
       config: CustomConfig(
         gradients: [
           [
-            Color.fromRGBO(72, 74, 126, 1),
-            Color.fromRGBO(125, 170, 206, 1),
-            Color.fromRGBO(184, 189, 245, 0.7)
+            const Color.fromRGBO(72, 74, 126, 1),
+            const Color.fromRGBO(125, 170, 206, 1),
+            const Color.fromRGBO(184, 189, 245, 0.7)
           ],
           [
-            Color.fromRGBO(72, 74, 126, 1),
-            Color.fromRGBO(125, 170, 206, 1),
-            Color.fromRGBO(172, 182, 219, 0.7)
+            const Color.fromRGBO(72, 74, 126, 1),
+            const Color.fromRGBO(125, 170, 206, 1),
+            const Color.fromRGBO(172, 182, 219, 0.7)
           ],
           [
-            Color.fromRGBO(72, 73, 126, 1),
-            Color.fromRGBO(125, 170, 206, 1),
-            Color.fromRGBO(190, 238, 246, 0.7)
+            const Color.fromRGBO(72, 73, 126, 1),
+            const Color.fromRGBO(125, 170, 206, 1),
+            const Color.fromRGBO(190, 238, 246, 0.7)
           ],
         ],
         durations: [19440, 10800, 6000],
@@ -154,7 +154,8 @@ class Background extends StatelessWidget {
         gradientBegin: Alignment.bottomCenter,
         gradientEnd: Alignment.topCenter,
       ),
-      size: Size(double.infinity, double.infinity),
+     
+      size: Size.infinite,
       waveAmplitude: 25,
       backgroundColor: Colors.blue[50],
     );

--- a/examples/flutter_timer/lib/timer/view/timer_page.dart
+++ b/examples/flutter_timer/lib/timer/view/timer_page.dart
@@ -59,8 +59,8 @@ class TimerText extends StatelessWidget {
     return Text(
       '$minutesStr:$secondsStr',
       style: TextStyle(
-        color: Colors.white, // 设置文本颜色
-        fontSize: 48.0, // 设置字体大小
+        color: Colors.white, 
+        fontSize: 48.0, 
       ),
     );
   }

--- a/examples/flutter_timer/lib/timer/view/timer_page.dart
+++ b/examples/flutter_timer/lib/timer/view/timer_page.dart
@@ -89,8 +89,6 @@ class Actions extends StatelessWidget {
               TimerRunInProgress() => [
                   FloatingActionButton(
                     child: const Icon(Icons.pause),
-                    // backgroundColor: Colors.white,
-                    // foregroundColor: Colors.black, // icon color
                     onPressed: () =>
                         context.read<TimerBloc>().add(const TimerPaused()),
                   ),

--- a/examples/flutter_timer/lib/timer/view/timer_page.dart
+++ b/examples/flutter_timer/lib/timer/view/timer_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_timer/ticker.dart';
 import 'package:flutter_timer/timer/timer.dart';
+import 'package:wave/wave.dart';
+import 'package:wave/config.dart';
 
 class TimerPage extends StatelessWidget {
   const TimerPage({super.key});
@@ -32,7 +34,11 @@ class TimerView extends StatelessWidget {
                 padding: EdgeInsets.symmetric(vertical: 100),
                 child: Center(child: TimerText()),
               ),
-              Actions(),
+              SizedBox(
+                width: 300.0,
+                height: 50.0,
+                child: Actions(),
+              )
             ],
           ),
         ],
@@ -52,7 +58,10 @@ class TimerText extends StatelessWidget {
     final secondsStr = (duration % 60).toString().padLeft(2, '0');
     return Text(
       '$minutesStr:$secondsStr',
-      style: Theme.of(context).textTheme.displayLarge,
+      style: TextStyle(
+        color: Colors.white, // 设置文本颜色
+        fontSize: 48.0, // 设置字体大小
+      ),
     );
   }
 }
@@ -80,6 +89,8 @@ class Actions extends StatelessWidget {
               TimerRunInProgress() => [
                   FloatingActionButton(
                     child: const Icon(Icons.pause),
+                    // backgroundColor: Colors.white,
+                    // foregroundColor: Colors.black, // icon color
                     onPressed: () =>
                         context.read<TimerBloc>().add(const TimerPaused()),
                   ),
@@ -117,23 +128,37 @@ class Actions extends StatelessWidget {
 }
 
 class Background extends StatelessWidget {
-  const Background({super.key});
+  const Background({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox.expand(
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-            colors: [
-              Colors.blue.shade50,
-              Colors.blue.shade500,
-            ],
-          ),
-        ),
+    return WaveWidget(
+      config: CustomConfig(
+        gradients: [
+          [
+            Color.fromRGBO(72, 74, 126, 1),
+            Color.fromRGBO(125, 170, 206, 1),
+            Color.fromRGBO(184, 189, 245, 0.7)
+          ],
+          [
+            Color.fromRGBO(72, 74, 126, 1),
+            Color.fromRGBO(125, 170, 206, 1),
+            Color.fromRGBO(172, 182, 219, 0.7)
+          ],
+          [
+            Color.fromRGBO(72, 73, 126, 1),
+            Color.fromRGBO(125, 170, 206, 1),
+            Color.fromRGBO(190, 238, 246, 0.7)
+          ],
+        ],
+        durations: [19440, 10800, 6000],
+        heightPercentages: [0.03, 0.01, 0.02],
+        gradientBegin: Alignment.bottomCenter,
+        gradientEnd: Alignment.topCenter,
       ),
+      size: Size(double.infinity, double.infinity),
+      waveAmplitude: 25,
+      backgroundColor: Colors.blue[50],
     );
   }
 }

--- a/examples/flutter_timer/pubspec.yaml
+++ b/examples/flutter_timer/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_bloc: ^8.1.1
+  wave: ^0.2.2
 
 dev_dependencies:
   bloc_test: ^9.0.0


### PR DESCRIPTION

## Status

READY

## Description

I found that the background in flutter_timer doesn't match the one shown in the tutorial.
Only the linear change of blue and white background.

in  /timer/view/timer.dart
1.in line 131-161,I found the flutter wave code from felangel's previous single page code and modified it to the now background class
web: https://medium.com/flutter-community/flutter-timer-with-flutter-bloc-a464e8332ceb

2.  in line 61-64, And the font color and size of the time have been modified to better match the example 

3.  in line 37-41, And modified the button size to better match the example

in app.dart

4.And modified the button color  to better match the example



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x ] 🗑️ Chore
