### PR TITLE
fix: vscode: freezed_bloc: remove const keyword

### DIFF
--- a/extensions/vscode/snippets/freezed_bloc.json
+++ b/extensions/vscode/snippets/freezed_bloc.json
@@ -1,10 +1,10 @@
 {
   "New freezed state": {
     "prefix": "fstate",
-    "body": "const factory ${TM_FILENAME_BASE/(.*)/${1:/pascalcase}/g}.${1:stateName}($2) = _${1/(.*)/${1:/capitalize}/};\n$3"
+    "body": "factory ${TM_FILENAME_BASE/(.*)/${1:/pascalcase}/g}.${1:stateName}($2) = _${1/(.*)/${1:/capitalize}/};\n$3"
   },
   "New freezed event": {
     "prefix": "fevent",
-    "body": "const factory ${TM_FILENAME_BASE/(.*)/${1:/pascalcase}/g}.${1:eventName}($2) = _${1/(.*)/${1:/capitalize}/};\n$3"
+    "body": "factory ${TM_FILENAME_BASE/(.*)/${1:/pascalcase}/g}.${1:eventName}($2) = _${1/(.*)/${1:/capitalize}/};\n$3"
   }  
 }

--- a/extensions/vscode/snippets/freezed_bloc.json
+++ b/extensions/vscode/snippets/freezed_bloc.json
@@ -1,7 +1,7 @@
 {
   "New freezed state": {
     "prefix": "fstate",
-    "body": "factory ${TM_FILENAME_BASE/(.*)/${1:/pascalcase}/g}.${1:stateName}($2) = _${1/(.*)/${1:/capitalize}/};\n$3"
+    "body": " factory ${TM_FILENAME_BASE/(.*)/${1:/pascalcase}/g}.${1:stateName}($2) = _${1/(.*)/${1:/capitalize}/};\n$3"
   },
   "New freezed event": {
     "prefix": "fevent",

--- a/extensions/vscode/snippets/freezed_bloc.json
+++ b/extensions/vscode/snippets/freezed_bloc.json
@@ -1,7 +1,7 @@
 {
   "New freezed state": {
     "prefix": "fstate",
-    "body": " factory ${TM_FILENAME_BASE/(.*)/${1:/pascalcase}/g}.${1:stateName}($2) = _${1/(.*)/${1:/capitalize}/};\n$3"
+    "body": "factory ${TM_FILENAME_BASE/(.*)/${1:/pascalcase}/g}.${1:stateName}($2) = _${1/(.*)/${1:/capitalize}/};\n$3"
   },
   "New freezed event": {
     "prefix": "fevent",


### PR DESCRIPTION
## Status

**READY/IN DEVELOPMENT/HOLD**

## Breaking Changes

YES | NO

## Description

<!--- Describe your changes in detail -->
Remove const because it often happens that emiting the data state is has no effect because the dart format will give suggestions to add const every time it creates a new object state with fixed properties. The bloc lib need new object for emit to make effect for BlocConsumer etc.

Example:
```dart
emit(const MyCustomStateLoaded(true));
// await Future.delayed...
emit(const MyCustomStateLoaded(true));
```
This only called once, eg in BlocConsumer.

This update will prevent using const for creating state object
```dart
emit(MyCustomStateLoaded(true));
// await Future.delayed...
emit(MyCustomStateLoaded(true));
```
Will called twice as expected eg in BlocConsumer.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
