### PR TITLE
fix(hydrated_bloc) clear HydratedStorage instance on close

### DIFF
--- a/packages/hydrated_bloc/lib/src/hydrated_storage.dart
+++ b/packages/hydrated_bloc/lib/src/hydrated_storage.dart
@@ -165,6 +165,7 @@ class HydratedStorage implements Storage {
   @override
   Future<void> close() async {
     if (_box.isOpen) {
+      _instance = null;
       return _lock.synchronized(_box.close);
     }
   }

--- a/packages/hydrated_bloc/test/hydrated_storage_test.dart
+++ b/packages/hydrated_bloc/test/hydrated_storage_test.dart
@@ -60,6 +60,17 @@ void main() {
         expect(instanceA, instanceB);
       });
 
+      test('creates new instance if storage was closed', () async {
+        final instanceA = await HydratedStorage.build(
+          storageDirectory: storageDirectory,
+        );
+        await instanceA.close();
+        final instanceB = storage = await HydratedStorage.build(
+          storageDirectory: storageDirectory,
+        );
+        expect(instanceA, isNot(instanceB));
+      });
+
       test(
           'does not call Hive.init '
           'when storageDirectory is webStorageDirectory', () async {


### PR DESCRIPTION
## Status

READY

## Breaking Changes

NO

## Description

When closing the HydratedStorage with `HydratedStorage.close()` the _instance is not set to null.
Calling `HydratedStorage.build` afterwards returns the old instance. Thus skipping reopening the HiveBox.

When the hydrated_box.hive file is modified/replaced/etc. in between these two steps. Changes would not be visible because the file would not be reopened.

This fix sets the instance back to null, when closing the HydratedStorage, to force a complete rebuild of the HiveBox when building a new Storage.

This enables the following use-cases without having to implement a custom Storage:
* export of .hive file to external storage
* import of .hive file from external storage

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
