### PR TITLE
add syncStateController param to BlocBase

### DIFF
--- a/packages/bloc/lib/src/bloc_base.dart
+++ b/packages/bloc/lib/src/bloc_base.dart
@@ -52,7 +52,9 @@ abstract class ErrorSink implements Closable {
 abstract class BlocBase<State>
     implements StateStreamableSource<State>, Emittable<State>, ErrorSink {
   /// {@macro bloc_base}
-  BlocBase(this._state) {
+  BlocBase(this._state, {bool syncStateController = false})
+      : _stateController =
+            StreamController<State>.broadcast(sync: syncStateController) {
     // ignore: invalid_use_of_protected_member
     _blocObserver.onCreate(this);
   }
@@ -60,7 +62,7 @@ abstract class BlocBase<State>
   // ignore: deprecated_member_use_from_same_package
   final _blocObserver = BlocOverrides.current?.blocObserver ?? Bloc.observer;
 
-  late final _stateController = StreamController<State>.broadcast();
+  final StreamController<State> _stateController;
 
   State _state;
 

--- a/packages/bloc/lib/src/cubit.dart
+++ b/packages/bloc/lib/src/cubit.dart
@@ -20,5 +20,6 @@ import 'package:bloc/bloc.dart';
 /// {@endtemplate}
 abstract class Cubit<State> extends BlocBase<State> {
   /// {@macro cubit}
-  Cubit(State initialState) : super(initialState);
+  Cubit(State initialState, {bool syncStateController = false})
+      : super(initialState, syncStateController: syncStateController);
 }

--- a/packages/bloc/test/cubit_test.dart
+++ b/packages/bloc/test/cubit_test.dart
@@ -261,6 +261,33 @@ void main() {
         await cubit.close();
         expect(states, [equals(1), equals(1)]);
       });
+
+      test('state changes are not available in the same event loop', () async {
+        final states = <int>[];
+        final cubit = CounterCubit()
+          ..stream.listen(states.add)
+          ..increment()
+          ..increment();
+
+        expect(states, isEmpty);
+        await cubit.close();
+        expect(states, [equals(1), equals(2)]);
+      });
+    });
+
+    group('sync listen', () {
+      test('state changes are available in the same event loop', () async {
+        final expectedStates = [equals(1), equals(2)];
+
+        final states = <int>[];
+        final cubit = CounterCubit(syncStateController: true)
+          ..stream.listen(states.add)
+          ..increment()
+          ..increment();
+        expect(states, expectedStates);
+        await cubit.close();
+        expect(states, expectedStates);
+      });
     });
 
     group('close', () {

--- a/packages/bloc/test/cubits/counter_cubit.dart
+++ b/packages/bloc/test/cubits/counter_cubit.dart
@@ -1,7 +1,11 @@
 import 'package:bloc/bloc.dart';
 
 class CounterCubit extends Cubit<int> {
-  CounterCubit({this.onChangeCallback, this.onErrorCallback}) : super(0);
+  CounterCubit({
+    this.onChangeCallback,
+    this.onErrorCallback,
+    bool syncStateController = false,
+  }) : super(0, syncStateController: syncStateController);
 
   final void Function(Change<int>)? onChangeCallback;
   final void Function(Object error, StackTrace stackTrace)? onErrorCallback;


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

In some cases, `BlocBase._stateController` should be synchronous, for instance, when interacting with `ReorderableListView`. This is because a new state will be emitted in a later frame (_not in the same event loop_), which leads to flickering on the screen.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

fixes #3896