### PR TITLE
feat(vscode_extension): Dynamic bloc import path base on package in pubspec

### DIFF
--- a/extensions/vscode/src/commands/new-bloc.command.ts
+++ b/extensions/vscode/src/commands/new-bloc.command.ts
@@ -16,6 +16,7 @@ import {
   getBlocTemplate,
 } from "../templates";
 import { getBlocType, BlocType, TemplateType } from "../utils";
+import { getBlocImportPath } from "../utils/get-bloc-import-path";
 
 export const newBloc = async (uri: Uri) => {
   const blocName = await promptForBlocName();
@@ -158,7 +159,7 @@ function createBlocStateTemplate(
   });
 }
 
-function createBlocTemplate(
+async function createBlocTemplate(
   blocName: string,
   targetDirectory: string,
   type: BlocType
@@ -168,8 +169,11 @@ function createBlocTemplate(
   if (existsSync(targetPath)) {
     throw Error(`${snakeCaseBlocName}_bloc.dart already exists`);
   }
+
+  const blocImportPath = await getBlocImportPath();
+
   return new Promise<void>(async (resolve, reject) => {
-    writeFile(targetPath, getBlocTemplate(blocName, type), "utf8", (error) => {
+    writeFile(targetPath, getBlocTemplate(blocName, type, blocImportPath), "utf8", (error) => {
       if (error) {
         reject(error);
         return;

--- a/extensions/vscode/src/commands/new-cubit.command.ts
+++ b/extensions/vscode/src/commands/new-cubit.command.ts
@@ -12,6 +12,7 @@ import {
 import { existsSync, lstatSync, writeFile } from "fs";
 import { getCubitStateTemplate, getCubitTemplate } from "../templates";
 import { getBlocType, BlocType, TemplateType } from "../utils";
+import { getBlocImportPath } from "../utils/get-bloc-import-path";
 
 export const newCubit = async (uri: Uri) => {
   const cubitName = await promptForCubitName();
@@ -127,7 +128,7 @@ function createCubitStateTemplate(
   });
 }
 
-function createCubitTemplate(
+async function createCubitTemplate(
   cubitName: string,
   targetDirectory: string,
   type: BlocType
@@ -137,10 +138,13 @@ function createCubitTemplate(
   if (existsSync(targetPath)) {
     throw Error(`${snakeCaseCubitName}_cubit.dart already exists`);
   }
+
+  const blocImportPath = await getBlocImportPath();
+
   return new Promise<void>(async (resolve, reject) => {
     writeFile(
       targetPath,
-      getCubitTemplate(cubitName, type),
+      getCubitTemplate(cubitName, type, blocImportPath),
       "utf8",
       (error) => {
         if (error) {

--- a/extensions/vscode/src/templates/bloc.template.ts
+++ b/extensions/vscode/src/templates/bloc.template.ts
@@ -1,23 +1,23 @@
 import * as changeCase from "change-case";
 import { BlocType } from "../utils";
 
-export function getBlocTemplate(blocName: string, type: BlocType): string {
+export function getBlocTemplate(blocName: string, type: BlocType, blocImportPath: string): string {
   switch (type) {
     case BlocType.Freezed:
-      return getFreezedBlocTemplate(blocName);
+      return getFreezedBlocTemplate(blocName, blocImportPath);
     case BlocType.Equatable:
-      return getEquatableBlocTemplate(blocName);
+      return getEquatableBlocTemplate(blocName, blocImportPath);
     default:
-      return getDefaultBlocTemplate(blocName);
+      return getDefaultBlocTemplate(blocName, blocImportPath);
   }
 }
 
-function getEquatableBlocTemplate(blocName: string) {
+function getEquatableBlocTemplate(blocName: string, blocImportPath: string) {
   const pascalCaseBlocName = changeCase.pascalCase(blocName);
   const snakeCaseBlocName = changeCase.snakeCase(blocName);
   const blocState = `${pascalCaseBlocName}State`;
   const blocEvent = `${pascalCaseBlocName}Event`;
-  return `import 'package:bloc/bloc.dart';
+  return `${blocImportPath}
 import 'package:equatable/equatable.dart';
 
 part '${snakeCaseBlocName}_event.dart';
@@ -33,12 +33,12 @@ class ${pascalCaseBlocName}Bloc extends Bloc<${blocEvent}, ${blocState}> {
 `;
 }
 
-function getDefaultBlocTemplate(blocName: string) {
+function getDefaultBlocTemplate(blocName: string, blocImportPath: string) {
   const pascalCaseBlocName = changeCase.pascalCase(blocName);
   const snakeCaseBlocName = changeCase.snakeCase(blocName);
   const blocState = `${pascalCaseBlocName}State`;
   const blocEvent = `${pascalCaseBlocName}Event`;
-  return `import 'package:bloc/bloc.dart';
+  return `${blocImportPath}
 import 'package:meta/meta.dart';
 
 part '${snakeCaseBlocName}_event.dart';
@@ -54,12 +54,12 @@ class ${pascalCaseBlocName}Bloc extends Bloc<${blocEvent}, ${blocState}> {
 `;
 }
 
-export function getFreezedBlocTemplate(blocName: string) {
+export function getFreezedBlocTemplate(blocName: string, blocImportPath: string) {
   const pascalCaseBlocName = changeCase.pascalCase(blocName);
   const snakeCaseBlocName = changeCase.snakeCase(blocName);
   const blocState = `${pascalCaseBlocName}State`;
   const blocEvent = `${pascalCaseBlocName}Event`;
-  return `import 'package:bloc/bloc.dart';
+  return `${blocImportPath}
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part '${snakeCaseBlocName}_event.dart';

--- a/extensions/vscode/src/templates/cubit.template.ts
+++ b/extensions/vscode/src/templates/cubit.template.ts
@@ -1,22 +1,22 @@
 import * as changeCase from "change-case";
 import { BlocType } from "../utils";
 
-export function getCubitTemplate(cubitName: string, type: BlocType): string {
+export function getCubitTemplate(cubitName: string, type: BlocType, blocImportPath: string): string {
   switch (type) {
     case BlocType.Freezed:
-      return getFreezedCubitTemplate(cubitName);
+      return getFreezedCubitTemplate(cubitName, blocImportPath);
     case BlocType.Equatable:
-      return getEquatableCubitTemplate(cubitName);
+      return getEquatableCubitTemplate(cubitName, blocImportPath);
     default:
-      return getDefaultCubitTemplate(cubitName);
+      return getDefaultCubitTemplate(cubitName, blocImportPath);
   }
 }
 
-function getEquatableCubitTemplate(cubitName: string) {
+function getEquatableCubitTemplate(cubitName: string, blocImportPath: string) {
   const pascalCaseCubitName = changeCase.pascalCase(cubitName);
   const snakeCaseCubitName = changeCase.snakeCase(cubitName);
   const cubitState = `${pascalCaseCubitName}State`;
-  return `import 'package:bloc/bloc.dart';
+  return `${blocImportPath}
 import 'package:equatable/equatable.dart';
 
 part '${snakeCaseCubitName}_state.dart';
@@ -27,11 +27,11 @@ class ${pascalCaseCubitName}Cubit extends Cubit<${cubitState}> {
 `;
 }
 
-function getDefaultCubitTemplate(cubitName: string) {
+function getDefaultCubitTemplate(cubitName: string, blocImportPath: string) {
   const pascalCaseCubitName = changeCase.pascalCase(cubitName);
   const snakeCaseCubitName = changeCase.snakeCase(cubitName);
   const cubitState = `${pascalCaseCubitName}State`;
-  return `import 'package:bloc/bloc.dart';
+  return `${blocImportPath}
 import 'package:meta/meta.dart';
 
 part '${snakeCaseCubitName}_state.dart';
@@ -42,11 +42,11 @@ class ${pascalCaseCubitName}Cubit extends Cubit<${cubitState}> {
 `;
 }
 
-export function getFreezedCubitTemplate(cubitName: string) {
+export function getFreezedCubitTemplate(cubitName: string, blocImportPath: string) {
   const pascalCaseCubitName = changeCase.pascalCase(cubitName);
   const snakeCaseCubitName = changeCase.snakeCase(cubitName);
   const cubitState = `${pascalCaseCubitName}State`;
-  return `import 'package:bloc/bloc.dart';
+  return `${blocImportPath}
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part '${snakeCaseCubitName}_state.dart';

--- a/extensions/vscode/src/utils/get-bloc-import-path.ts
+++ b/extensions/vscode/src/utils/get-bloc-import-path.ts
@@ -1,0 +1,11 @@
+import { hasDependency } from "./has-dependency";
+
+
+
+export async function getBlocImportPath(): Promise<string> {
+    if (await hasDependency('flutter_bloc')) {
+        return `import 'package:flutter_bloc/flutter_bloc.dart';`;
+    }
+    return `import 'package:bloc/bloc.dart';`;
+
+}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

Change `import 'package:bloc/bloc.dart';` to match the package currently used pubspec. For example when `flutter_bloc` is in pubspec, it will use `import 'package:flutter_bloc/flutter_bloc.dart';` instead. This change solves the [depend_on_referenced_packages](https://dart.dev/tools/linter-rules/depend_on_referenced_packages) linting rule when using the extesion with `flutter_bloc` package.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
