### PR TITLE
chore(hydrated_bloc): add `platforms` to `pubspec.yaml`

### DIFF
--- a/examples/flutter_weather/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/examples/flutter_weather/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,7 +5,7 @@
 import FlutterMacOS
 import Foundation
 
-import path_provider_macos
+import path_provider_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))

--- a/packages/hydrated_bloc/README.md
+++ b/packages/hydrated_bloc/README.md
@@ -63,7 +63,11 @@ Our top sponsors are shown below! [[Become a Sponsor](https://github.com/sponsor
 ```dart
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  HydratedBloc.storage = await HydratedStorage.build(storageDirectory: ...);
+  HydratedBloc.storage = await HydratedStorage.build(
+    storageDirectory: kIsWeb
+        ? HydratedStorage.webStorageDirectory
+        : await getApplicationDocumentsDirectory(),
+  );
   runApp(App());
 }
 ```

--- a/packages/hydrated_bloc/pubspec.yaml
+++ b/packages/hydrated_bloc/pubspec.yaml
@@ -7,6 +7,14 @@ homepage: https://bloclibrary.dev
 documentation: https://bloclibrary.dev/#/gettingstarted
 topics: [bloc, cache, state-management]
 
+platforms:
+  android:
+  ios:
+  linux:
+  macos:
+  web:
+  windows:
+
 environment:
   sdk: ">=2.12.0 <4.0.0"
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY/IN DEVELOPMENT/HOLD**

## Breaking Changes

There are no breaking changes

## Description

It's simple, first of all, it adds all the platforms as supported in `pubspec.yaml`
Because in [pub.dev](https://pub.dev/packages/hydrated_bloc):

![image](https://github.com/felangel/bloc/assets/73608287/557880de-cf9e-416a-83a7-68cd368804e5)

The analysis in the pub page package indicates the package does not support web

Also in `README.md` it didn't say that there is `HydratedStorage.webStorageDirectory` for the web so this simple pull request updates the `README.md` to make it more clear there is support for Flutter web

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
