### PR TITLE
docs: fix chinese lang translation

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -46,7 +46,7 @@ const locales = {
 		lang: 'ru',
 	},
 	'zh-cn': {
-		label: '中国人',
+		label: '简体中文',
 		lang: 'zh-CN',
 	},
 };


### PR DESCRIPTION
“中国人” means Chinese people rather than a language. 