### PR TITLE
feat: Add `force` to emit

### DIFF
--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -148,7 +148,8 @@ abstract class Bloc<Event, State> extends BlocBase<State>
   /// {@endtemplate}
   @visibleForTesting
   @override
-  void emit(State state, {bool force = false}) => super.emit(state, force: force);
+  void emit(State state, {bool force = false}) =>
+      super.emit(state, force: force);
 
   /// Register event handler for an event of type `E`.
   /// There should only ever be one event handler per event type `E`.

--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -148,7 +148,7 @@ abstract class Bloc<Event, State> extends BlocBase<State>
   /// {@endtemplate}
   @visibleForTesting
   @override
-  void emit(State state) => super.emit(state);
+  void emit(State state, {bool force = false}) => super.emit(state, force: force);
 
   /// Register event handler for an event of type `E`.
   /// There should only ever be one event handler per event type `E`.
@@ -195,9 +195,9 @@ abstract class Bloc<Event, State> extends BlocBase<State>
     final subscription = (transformer ?? _eventTransformer)(
       _eventController.stream.where((event) => event is E).cast<E>(),
       (dynamic event) {
-        void onEmit(State state) {
+        void onEmit(State state, {bool force = false}) {
           if (isClosed) return;
-          if (this.state == state && _emitted) return;
+          if (!force && this.state == state && _emitted) return;
           onTransition(
             Transition(
               currentState: this.state,
@@ -205,7 +205,7 @@ abstract class Bloc<Event, State> extends BlocBase<State>
               nextState: state,
             ),
           );
-          emit(state);
+          emit(state, force: force);
         }
 
         final emitter = _Emitter(onEmit);

--- a/packages/bloc/lib/src/bloc_base.dart
+++ b/packages/bloc/lib/src/bloc_base.dart
@@ -32,7 +32,7 @@ abstract class Closable {
 // ignore: one_member_abstracts
 abstract class Emittable<State extends Object?> {
   /// Emits a new [state].
-  void emit(State state);
+  void emit(State state, {bool force});
 }
 
 /// A generic destination for errors.
@@ -80,7 +80,7 @@ abstract class BlocBase<State>
 
   /// Updates the [state] to the provided [state].
   /// [emit] does nothing if the [state] being emitted
-  /// is equal to the current [state].
+  /// is equal to the current [state], unless [force] is true.
   ///
   /// To allow for the possibility of notifying listeners of the initial state,
   /// emitting a state which is equal to the initial state is allowed as long
@@ -90,12 +90,12 @@ abstract class BlocBase<State>
   @protected
   @visibleForTesting
   @override
-  void emit(State state) {
+  void emit(State state, {bool force = false}) {
     try {
       if (isClosed) {
         throw StateError('Cannot emit new states after calling close');
       }
-      if (state == _state && _emitted) return;
+      if (!force && state == _state && _emitted) return;
       onChange(Change<State>(currentState: this.state, nextState: state));
       _state = state;
       _stateController.add(_state);

--- a/packages/bloc/lib/src/emitter.dart
+++ b/packages/bloc/lib/src/emitter.dart
@@ -58,13 +58,13 @@ abstract class Emitter<State> {
   bool get isDone;
 
   /// Emits the provided [state].
-  void call(State state);
+  void call(State state, {bool force});
 }
 
 class _Emitter<State> implements Emitter<State> {
   _Emitter(this._emit);
 
-  final void Function(State state) _emit;
+  final void Function(State state, {bool force}) _emit;
   final _completer = Completer<void>();
   final _disposables = <FutureOr<void> Function()>[];
 
@@ -109,7 +109,7 @@ class _Emitter<State> implements Emitter<State> {
   }
 
   @override
-  void call(State state) {
+  void call(State state, {bool force = false}) {
     assert(
       !_isCompleted,
       '''
@@ -132,7 +132,7 @@ ensure the event handler has not completed.
   });
 ''',
     );
-    if (!_isCanceled) _emit(state);
+    if (!_isCanceled) _emit(state, force: force);
   }
 
   @override

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -142,6 +142,30 @@ void main() {
       });
     });
 
+    group('Simple Bloc Forcible', () {
+      late SimpleBlocForcible simpleBloc;
+      late MockBlocObserver observer;
+
+      setUp(() {
+        simpleBloc = SimpleBlocForcible();
+        observer = MockBlocObserver();
+        Bloc.observer = observer;
+      });
+
+      test('setting force will emit, even if the state is the same', () {
+        const expectedStates = <String>['data', 'data'];
+
+        expectLater(simpleBloc.stream, emitsInOrder(expectedStates));
+        expectLater(simpleBloc.stream, emitsInOrder(expectedStates));
+        expectLater(simpleBloc.stream, emitsInOrder(expectedStates));
+
+        simpleBloc
+          ..add(false)
+          ..add(true)
+          ..add(false);
+      });
+    });
+
     group('Complex Bloc', () {
       late ComplexBloc complexBloc;
       late MockBlocObserver observer;

--- a/packages/bloc/test/blocs/blocs.dart
+++ b/packages/bloc/test/blocs/blocs.dart
@@ -3,5 +3,6 @@ export './complex/complex_bloc.dart';
 export './counter/counter.dart';
 export './seeded/seeded_bloc.dart';
 export './simple/simple_bloc.dart';
+export './simple/simple_bloc_forcible.dart';
 export './stream/stream.dart';
 export './unawaited/unawaited_bloc.dart';

--- a/packages/bloc/test/blocs/simple/simple_bloc_forcible.dart
+++ b/packages/bloc/test/blocs/simple/simple_bloc_forcible.dart
@@ -1,0 +1,7 @@
+import 'package:bloc/bloc.dart';
+
+class SimpleBlocForcible extends Bloc<bool, String> {
+  SimpleBlocForcible() : super('') {
+    on<bool>((force, emit) => emit('data', force: force));
+  }
+}

--- a/packages/replay_bloc/lib/src/replay_bloc.dart
+++ b/packages/replay_bloc/lib/src/replay_bloc.dart
@@ -94,7 +94,7 @@ mixin ReplayBlocMixin<Event extends ReplayEvent, State> on Bloc<Event, State> {
   }
 
   @override
-  void emit(State state) {
+  void emit(State state, {bool force = false}) {
     _changeStack.add(
       _Change<State>(
         this.state,
@@ -110,7 +110,7 @@ mixin ReplayBlocMixin<Event extends ReplayEvent, State> on Bloc<Event, State> {
             ),
           );
           // ignore: invalid_use_of_visible_for_testing_member
-          super.emit(state);
+          super.emit(state, force: force);
         },
         (val) {
           final event = _Undo();
@@ -123,12 +123,12 @@ mixin ReplayBlocMixin<Event extends ReplayEvent, State> on Bloc<Event, State> {
             ),
           );
           // ignore: invalid_use_of_visible_for_testing_member
-          super.emit(val);
+          super.emit(val, force: force);
         },
       ),
     );
     // ignore: invalid_use_of_visible_for_testing_member
-    super.emit(state);
+    super.emit(state, force: force);
   }
 
   /// Undo the last change.

--- a/packages/replay_bloc/lib/src/replay_cubit.dart
+++ b/packages/replay_bloc/lib/src/replay_cubit.dart
@@ -63,16 +63,16 @@ mixin ReplayCubitMixin<State> on Cubit<State> {
   set limit(int limit) => _changeStack.limit = limit;
 
   @override
-  void emit(State state) {
+  void emit(State state, {bool force = false}) {
     _changeStack.add(
       _Change<State>(
         this.state,
         state,
-        () => super.emit(state),
-        (val) => super.emit(val),
+        () => super.emit(state, force: force),
+        (val) => super.emit(val, force: force),
       ),
     );
-    super.emit(state);
+    super.emit(state, force: force);
   }
 
   /// Undo the last change.


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

Adds an optional `force` parameter to `emit` to signal the state has updated without needing to do equality comparison.

Closes: https://github.com/felangel/bloc/issues/4136


- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
