### PR TITLE
chore: call `addError` by default on error in `Emitter`'s `forEach`

### DIFF
--- a/packages/bloc/lib/src/emitter.dart
+++ b/packages/bloc/lib/src/emitter.dart
@@ -102,6 +102,7 @@ class _Emitter<State> implements Emitter<State> {
       onData: (data) => call(onData(data)),
       onError: onError != null
           ? (Object error, StackTrace stackTrace) {
+              addError(error, stackTrace);
               call(onError(error, stackTrace));
             }
           : null,


### PR DESCRIPTION
## Status

READY

## Breaking Changes

NO

## Description

Add a default `addError` call to `BlocObserver` with error and stackTrace from `onError` function that comes from `Emitter`'s `forEach` function.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
