### PR TITLE
docs: use optimized astro `Image` in `SponsorsGrid.astro`

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -26,6 +26,7 @@
     "prettier": "^3.2.5",
     "prettier-plugin-astro": "^0.13.0",
     "prettier-plugin-tailwindcss": "^0.5.11",
-    "starlight-links-validator": "^0.5.3"
+    "starlight-links-validator": "^0.5.3",
+    "@types/node": "^20.11.19"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,7 +26,6 @@
     "prettier": "^3.2.5",
     "prettier-plugin-astro": "^0.13.0",
     "prettier-plugin-tailwindcss": "^0.5.11",
-    "starlight-links-validator": "^0.5.3",
-    "@types/node": "^20.11.19"
+    "starlight-links-validator": "^0.5.3"
   }
 }

--- a/docs/src/components/landing/SponsorsGrid.astro
+++ b/docs/src/components/landing/SponsorsGrid.astro
@@ -5,6 +5,7 @@ export type Props = {
 };
 
 import { LinkCard } from '@astrojs/starlight/components';
+import { Image } from "astro:assets";
 
 import miquido from '~/assets/sponsors/miquido.png';
 import monterail from '~/assets/sponsors/monterail.png';
@@ -64,10 +65,10 @@ const sponsors: Sponsor[] = [
 
 <style>
 	:global([data-theme='dark']) .invert-logo {
-		filter: invert() grayscale() contrast(200%) saturate(200%);
+		filter: invert() grayscale(0) contrast(200%) saturate(200%);
 	}
 	:global([data-theme='dark']) .logo {
-		filter: grayscale() contrast(200%) saturate(200%);
+		filter: grayscale(0) contrast(200%) saturate(200%);
 	}
 </style>
 
@@ -81,9 +82,9 @@ const sponsors: Sponsor[] = [
 				return (
 					<div class="flex flex-row justify-center items-center">
 						<a href={sponsor.href} aria-label={sponsor.alt} target="_blank" rel="noreferrer">
-							<img
+							<Image
 								class={sponsor.invert ? 'invert-logo' : 'logo'}
-								src={sponsor.img.src}
+								src={sponsor.img}
 								width="150"
 								alt={sponsor.alt}
 							/>

--- a/docs/src/components/landing/SponsorsGrid.astro
+++ b/docs/src/components/landing/SponsorsGrid.astro
@@ -4,8 +4,8 @@ export type Props = {
 	becomeASponsor: string;
 };
 
+import { Image } from 'astro:assets';
 import { LinkCard } from '@astrojs/starlight/components';
-import { Image } from "astro:assets";
 
 import miquido from '~/assets/sponsors/miquido.png';
 import monterail from '~/assets/sponsors/monterail.png';
@@ -65,10 +65,10 @@ const sponsors: Sponsor[] = [
 
 <style>
 	:global([data-theme='dark']) .invert-logo {
-		filter: invert() grayscale(0) contrast(200%) saturate(200%);
+		filter: invert() grayscale() contrast(200%) saturate(200%);
 	}
 	:global([data-theme='dark']) .logo {
-		filter: grayscale(0) contrast(200%) saturate(200%);
+		filter: grayscale() contrast(200%) saturate(200%);
 	}
 </style>
 
@@ -80,12 +80,13 @@ const sponsors: Sponsor[] = [
 		{
 			sponsors.map((sponsor) => {
 				return (
-					<div class="flex flex-row justify-center items-center">
+					<div class="flex flex-row justify-center items-center max-w-52">
 						<a href={sponsor.href} aria-label={sponsor.alt} target="_blank" rel="noreferrer">
 							<Image
 								class={sponsor.invert ? 'invert-logo' : 'logo'}
 								src={sponsor.img}
-								width="150"
+								width={300}
+								style="width:150px;height:auto"
 								alt={sponsor.alt}
 							/>
 						</a>

--- a/docs/src/components/landing/SponsorsGrid.astro
+++ b/docs/src/components/landing/SponsorsGrid.astro
@@ -80,7 +80,7 @@ const sponsors: Sponsor[] = [
 		{
 			sponsors.map((sponsor) => {
 				return (
-					<div class="flex flex-row justify-center items-center max-w-52">
+					<div class="flex flex-row justify-center items-center">
 						<a href={sponsor.href} aria-label={sponsor.alt} target="_blank" rel="noreferrer">
 							<Image
 								class={sponsor.invert ? 'invert-logo' : 'logo'}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->
In the `Sponsor` interface there is an img property with the `ImageMetadata` type, we can specify it as a parameter for `<Image />`. `<Image />`is more optimized than the usual `<img />` tag and therefore I replaced it with `Image`

With this [commit](https://github.com/felangel/bloc/commit/0380353d822ce957fcc50d05cd1038451c7d316b), errors with types in TS are removed `Corresponding file not included in tsconfig.json`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
