### PR TITLE
docs: add trailing slash to introduction section links

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -106,39 +106,39 @@ export default defineConfig({
 					items: [
 						{
 							label: 'Getting Started',
-							link: '/getting-started',
+							link: '/getting-started/',
 						},
 						{
 							label: 'Why Bloc?',
-							link: '/why-bloc',
+							link: '/why-bloc/',
 						},
 						{
 							label: 'Bloc Concepts',
-							link: '/bloc-concepts',
+							link: '/bloc-concepts/',
 						},
 						{
 							label: 'Flutter Bloc Concepts',
-							link: '/flutter-bloc-concepts',
+							link: '/flutter-bloc-concepts/',
 						},
 						{
 							label: 'Architecture',
-							link: '/architecture',
+							link: '/architecture/',
 						},
 						{
 							label: 'Testing',
-							link: '/testing',
+							link: '/testing/',
 						},
 						{
 							label: 'Naming Conventions',
-							link: '/naming-conventions',
+							link: '/naming-conventions/',
 						},
 						{
 							label: 'FAQs',
-							link: '/faqs',
+							link: '/faqs/',
 						},
 						{
 							label: 'Migration Guide',
-							link: '/migration',
+							link: '/migration/',
 						},
 					],
 				},


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY/IN DEVELOPMENT/HOLD**

## Breaking Changes

NO

## Description

All the links in the left menu on https://bloclibrary.dev are broken -- require a trailing slash.

![image](https://github.com/felangel/bloc/assets/16327036/83f3c829-3bfe-4571-b9b5-a599090e9e9a)


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
