### PR TITLE
refactor(flutter_todos): add `close` to `TodosApi`

### DIFF
--- a/examples/flutter_todos/packages/local_storage_todos_api/lib/src/local_storage_todos_api.dart
+++ b/examples/flutter_todos/packages/local_storage_todos_api/lib/src/local_storage_todos_api.dart
@@ -19,7 +19,9 @@ class LocalStorageTodosApi extends TodosApi {
 
   final SharedPreferences _plugin;
 
-  final _todoStreamController = BehaviorSubject<List<Todo>>.seeded(const []);
+  late final _todoStreamController = BehaviorSubject<List<Todo>>.seeded(
+    const [],
+  );
 
   /// The key used for storing the todos locally.
   ///
@@ -97,5 +99,10 @@ class LocalStorageTodosApi extends TodosApi {
     _todoStreamController.add(newTodos);
     await _setValue(kTodosCollectionKey, json.encode(newTodos));
     return changedTodosAmount;
+  }
+
+  @override
+  Future<void> close() {
+    return _todoStreamController.close();
   }
 }

--- a/examples/flutter_todos/packages/local_storage_todos_api/test/local_storage_todos_api_test.dart
+++ b/examples/flutter_todos/packages/local_storage_todos_api/test/local_storage_todos_api_test.dart
@@ -207,5 +207,20 @@ void main() {
         ).called(1);
       });
     });
+
+    group('close', () {
+      test('closes the instance', () async {
+        final subject = createSubject();
+
+        await subject.close();
+
+        expect(
+          () => subject.saveTodo(
+            Todo(id: '1', title: 'title 1'),
+          ),
+          throwsStateError,
+        );
+      });
+    });
   });
 }

--- a/examples/flutter_todos/packages/todos_api/lib/src/todos_api.dart
+++ b/examples/flutter_todos/packages/todos_api/lib/src/todos_api.dart
@@ -31,7 +31,7 @@ abstract class TodosApi {
   /// Returns the number of updated todos.
   Future<int> completeAll({required bool isCompleted});
 
-  /// Closes the client and cleans up any resources.
+  /// Closes the client and frees up any resources.
   Future<void> close();
 }
 

--- a/examples/flutter_todos/packages/todos_api/lib/src/todos_api.dart
+++ b/examples/flutter_todos/packages/todos_api/lib/src/todos_api.dart
@@ -30,6 +30,9 @@ abstract class TodosApi {
   ///
   /// Returns the number of updated todos.
   Future<int> completeAll({required bool isCompleted});
+
+  /// Closes the client and cleans up any resources.
+  Future<void> close();
 }
 
 /// Error thrown when a [Todo] with a given id is not found.


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->
Even though the lifetime of the `TodosApi` instance is tied to the application in this case, it's still valuable to add a `close` API to the interface since the `TodosApi` should expose a way to close the instance and free any allocated resources. (closes #4154)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
