### PR TITLE
docs: Add direct link to FAQ for Equatable usage

### DIFF
--- a/docs/src/content/docs/tutorials/flutter-timer.mdx
+++ b/docs/src/content/docs/tutorials/flutter-timer.mdx
@@ -119,6 +119,8 @@ You can use the [IntelliJ](https://plugins.jetbrains.com/plugin/12129-bloc-code-
 
 Note that all of the `TimerStates` extend the abstract base class `TimerState` which has a duration property. This is because no matter what state our `TimerBloc` is in, we want to know how much time is remaining. Additionally, `TimerState` extends `Equatable` to optimize our code by ensuring that our app does not trigger rebuilds if the same state occurs.
 
+FAQ: [When to use Equatable](/faqs#when-to-use-equatable)
+
 Next up, let's define and implement the `TimerEvents` which our `TimerBloc` will be processing.
 
 ### TimerEvent


### PR DESCRIPTION
## Status

READY

## Breaking Changes

NO

## Description

This update adds a direct link to the FAQ section that explains when to use Equatable. This will help readers easily find the relevant information, addressing a common question. Although the link is mentioned in the "Key Topics" section, its current placement do not clearly indicate that it leads to the FAQ.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
