### PR TITLE
make rethrow error optional

### DIFF
--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -47,6 +47,9 @@ abstract class Bloc<Event, State> extends BlocBase<State>
   /// The current [BlocObserver] instance.
   static BlocObserver observer = const _DefaultBlocObserver();
 
+  /// weather to rethrow any error occured on event, defaults to true
+  static bool rethrowError = true;
+
   /// The default [EventTransformer] used for all event handlers.
   /// By default all events are processed concurrently.
   ///
@@ -97,7 +100,7 @@ abstract class Bloc<Event, State> extends BlocBase<State>
       _eventController.add(event);
     } catch (error, stackTrace) {
       onError(error, stackTrace);
-      rethrow;
+      if (rethrowError) rethrow;
     }
   }
 

--- a/packages/bloc/lib/src/bloc_base.dart
+++ b/packages/bloc/lib/src/bloc_base.dart
@@ -59,6 +59,8 @@ abstract class BlocBase<State>
 
   final _blocObserver = Bloc.observer;
 
+  final _rethrowError = Bloc.rethrowError;
+
   late final _stateController = StreamController<State>.broadcast();
 
   State _state;
@@ -102,7 +104,7 @@ abstract class BlocBase<State>
       _emitted = true;
     } catch (error, stackTrace) {
       onError(error, stackTrace);
-      rethrow;
+      if (_rethrowError) rethrow;
     }
   }
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

By default, bloc will rethrow any error caught during the event, which can't be configured. Now suppose, you have multiple events doing similar things (like making an API request), so you wrote a reusable error handler that can handle errors for all these events. But now you have to to wrap each of these event handlers in try catch and call the error handler in catch block of each event handler. If we make rethrow configurable, we can just override the  `onError` of the bloc and handle error from just single place. Note: You can still handle error in `onError` without adding try catch but Dart will complain about an uncaught error for every error throw, even though you have handled it in `onError`. This PR tries to make that rethrow optional with a condition that end developers can configure as per their needs. By default condition is true, so it will work as it works now.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
