### PR TITLE
docs(getting-started): use `flutter pub add` for `flutter_bloc` installation

### DIFF
--- a/docs/src/components/getting-started/InstallationTabs.astro
+++ b/docs/src/components/getting-started/InstallationTabs.astro
@@ -6,7 +6,7 @@ dart pub add bloc
 `;
 const installFlutterBloc = `
 # Add flutter_bloc to your project.
-dart pub add flutter_bloc
+flutter pub add flutter_bloc
 `;
 const installAngularBloc = `
 # Add angular_bloc to your project.


### PR DESCRIPTION
just replaced "dart pub add" for "flutter pub add" in flutter installation command

## Status

READY

## Breaking Changes

No

## Description

just documentation update

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
