### PR TITLE
refactor(weather_example): use named extension

### DIFF
--- a/examples/flutter_weather/lib/weather/cubit/weather_cubit.dart
+++ b/examples/flutter_weather/lib/weather/cubit/weather_cubit.dart
@@ -96,7 +96,7 @@ class WeatherCubit extends HydratedCubit<WeatherState> {
   Map<String, dynamic> toJson(WeatherState state) => state.toJson();
 }
 
-extension on double {
+extension TemperatureConversion on double {
   double toFahrenheit() => (this * 9 / 5) + 32;
   double toCelsius() => (this - 32) * 5 / 9;
 }

--- a/examples/flutter_weather/test/weather/cubit/weather_cubit_test.dart
+++ b/examples/flutter_weather/test/weather/cubit/weather_cubit_test.dart
@@ -341,8 +341,3 @@ void main() {
     });
   });
 }
-
-extension on double {
-  double toFahrenheit() => (this * 9 / 5) + 32;
-  double toCelsius() => (this - 32) * 5 / 9;
-}


### PR DESCRIPTION
Name the `double` extension to make it available through imports in other files (i.e. in weather_cubit_test.dart).

## Status

**READY**

## Breaking Changes

NO

## Description

I’m following the `flutter_weather` example, and I encountered an error in the `weather_cubit_test.dart` file:

```
The method 'toFahrenheit' isn't defined for the type 'double'.
Try correcting the name to the name of an existing method, or defining a method named 'toFahrenheit'.dart[undefined_method](https://dart.dev/diagnostics/undefined_method)
Type: InvalidType
```

However exports and imports are correct (I double-checked them).

Just naming the extension fixes this error.

EDIT: I realized a bit later that the extension was added again in the test file. So the current code is fully functional and my PR is less necessary.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
