### PR TITLE
fix(hydrated_bloc)!: changing hydrated storage without manual close

### DIFF
--- a/packages/hydrated_bloc/lib/src/hydrated_bloc.dart
+++ b/packages/hydrated_bloc/lib/src/hydrated_bloc.dart
@@ -41,7 +41,11 @@ abstract class HydratedBloc<Event, State> extends Bloc<Event, State>
 
   /// Setter for instance of [Storage] which will be used to
   /// manage persisting/restoring the [Bloc] state.
-  static set storage(Storage? storage) => _storage = storage;
+  /// Closes the previous [Storage] instance if applicable.
+  static set storage(Storage? storage) {
+    _storage?.close();
+    _storage = storage;
+  }
 
   /// Instance of [Storage] which will be used to
   /// manage persisting/restoring the [Bloc] state.

--- a/packages/hydrated_bloc/test/e2e_test.dart
+++ b/packages/hydrated_bloc/test/e2e_test.dart
@@ -311,6 +311,30 @@ void main() {
         await storage.clear();
         expect(SimpleCubit().state, 0);
       });
+
+      test('can change storage', () async {
+        await HydratedBloc.storage.close();
+        final storageDirectoryA = Directory.systemTemp.createTempSync();
+        final storageA = await HydratedStorage.build(
+          storageDirectory: HydratedStorageDirectory(storageDirectoryA.path),
+        );
+
+        HydratedBloc.storage = storageA;
+        final cubit = SimpleCubit();
+        expect(cubit.state, 0);
+        cubit.increment();
+        expect(cubit.state, 1);
+        await sleep();
+        expect(SimpleCubit().state, 1);
+
+        final storageDirectoryB = Directory.systemTemp.createTempSync();
+        final storageB = await HydratedStorage.build(
+          storageDirectory: HydratedStorageDirectory(storageDirectoryB.path),
+        );
+        HydratedBloc.storage = storageB;
+
+        expect(SimpleCubit().state, 0);
+      });
     });
 
     group('CyclicCubit', () {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

YES

## Description

<!--- Describe your changes in detail -->
- fix(hydrated_bloc): changing hydrated storage without manual close (closes https://github.com/felangel/bloc/issues/3887)
  - technically this is a breaking change because assigning a storage instance via `HydratedBloc.storage = instance` will now automatically close the previous instance if applicable.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [X] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
