### PR TITLE
Added to allow setting the validity period of hydrated data.

### DIFF
--- a/packages/hydrated_bloc/README.md
+++ b/packages/hydrated_bloc/README.md
@@ -145,6 +145,27 @@ class CounterCubit extends HydratedCubit<int> {
 }
 ```
 
+### Cubit storage set expireIn
+
+You can override the `hydrationExpiresIn` to customize the expiration period of a specific hydration using instances of `HydratedBloc` or `HydratedCubit`.
+
+```dart
+class CounterCubit extends HydratedCubit<int> {
+  CounterCubit() : super(0, storage: EncryptedStorage());
+
+  void increment() => emit(state + 1);
+
+  @override
+  int fromJson(Map<String, dynamic> json) => json['value'] as int;
+
+  @override
+  Map<String, int> toJson(int state) => { 'value': state };
+
+  @override
+  Duration? get hydrationExpiresIn => const Duration(minutes: 1);
+}
+```
+
 ## Custom Storage Directory
 
 Any `storageDirectory` can be used when creating an instance of `HydratedStorage`:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

- Added to allow setting the validity period of hydrated data.

## Example
```dart
class CounterCubit extends HydratedCubit<int> {
  CounterCubit() : super(0, storage: EncryptedStorage());

  void increment() => emit(state + 1);

  @override
  int fromJson(Map<String, dynamic> json) => json['value'] as int;

  @override
  Map<String, int> toJson(int state) => { 'value': state };

  @override
  Duration? get hydrationExpiresIn => const Duration(minutes: 1);
}
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
