### PR TITLE
refactor: prefer `{List,Map}.of` over `{List,Map}.from`

### DIFF
--- a/docs/src/content/docs/faqs.mdx
+++ b/docs/src/content/docs/faqs.mdx
@@ -55,7 +55,7 @@ bloc.
 :::caution
 `Equatable` properties should always be copied rather than modified. If an
 `Equatable` class contains a `List` or `Map` as properties, be sure to use
-`List.from` or `Map.from` respectively to ensure that equality is evaluated
+`List.of` or `Map.of` respectively to ensure that equality is evaluated
 based on the values of the properties rather than the reference.
 :::
 

--- a/docs/src/content/docs/ko/faqs.mdx
+++ b/docs/src/content/docs/ko/faqs.mdx
@@ -50,7 +50,7 @@ import BlocExternalForEachSnippet from '~/components/faqs/BlocExternalForEachSni
 <StateNotUpdatingBad3Snippet />
 
 :::caution
-`Equatable` 프로퍼티는 항상 수정하지 말고 복사해야 합니다. `Equatable` 클래스에 `List` 또는 `Map`이 프로퍼티로 있는 경우, 참조가 아닌 프로퍼티 값을 기준으로 동등성이 평가되도록 `List.from` 또는 `Map.from`을 각각 사용해야 합니다.
+`Equatable` 프로퍼티는 항상 수정하지 말고 복사해야 합니다. `Equatable` 클래스에 `List` 또는 `Map`이 프로퍼티로 있는 경우, 참조가 아닌 프로퍼티 값을 기준으로 동등성이 평가되도록 `List.of` 또는 `Map.of`을 각각 사용해야 합니다.
 :::
 
 ## 언제 Equatable를 사용해야 하나요

--- a/packages/hydrated_bloc/test/cubits/list_cubit.dart
+++ b/packages/hydrated_bloc/test/cubits/list_cubit.dart
@@ -4,7 +4,7 @@ import 'package:meta/meta.dart';
 class ListCubit extends HydratedCubit<List<String>> {
   ListCubit() : super(const <String>[]);
 
-  void addItem(String item) => emit(List.from(state)..add(item));
+  void addItem(String item) => emit(List.of(state)..add(item));
 
   @override
   Map<String, dynamic> toJson(List<String> state) {
@@ -22,16 +22,14 @@ class ListCubitMap<T extends ToJsonMap<E>, E> extends HydratedCubit<List<T>> {
   final T Function(Map<String, dynamic> json) _fromJson;
   final bool explicit;
 
-  void addItem(T item) => emit(List.from(state)..add(item));
+  void addItem(T item) => emit(List.of(state)..add(item));
 
   @override
   Map<String, dynamic> toJson(List<T> state) {
     final map = <String, dynamic>{
       'state': explicit
-          ? List<Map<String, E>>.from(
-              state.map<dynamic>(
-                (x) => x.toJson(),
-              ),
+          ? List<Map<String, E>>.of(
+              state.map((x) => x.toJson()),
             )
           : state,
     };
@@ -53,17 +51,15 @@ class ListCubitList<T extends ToJsonList<E>, E> extends HydratedCubit<List<T>> {
   final T Function(List<dynamic> json) _fromJson;
   final bool explicit;
 
-  void addItem(T item) => emit(List.from(state)..add(item));
+  void addItem(T item) => emit(List.of(state)..add(item));
   void reset() => emit(<T>[]);
 
   @override
   Map<String, dynamic> toJson(List<T> state) {
     final map = <String, dynamic>{
       'state': explicit
-          ? List<List<E>>.from(
-              state.map<dynamic>(
-                (x) => x.toJson(),
-              ),
+          ? List<List<E>>.of(
+              state.map((x) => x.toJson()),
             )
           : state,
     };


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

Update the docs and a few test snippets to use `List.of` and `Map.of` instead of `List.from` and `Map.from`. The `of` factories offer better type-safety by enforcing the collection types at compile-time.

Some instances of the `from` factories remain, as they are used for type promotion. To find such cases, run the regex: `(List|Map).*[.]from`. These cases align with [Dart's documentation on `Map.from`](https://api.dart.dev/dart-core/Map/Map.from.html):

> Prefer using Map.of when possible, and only use Map.from to create a new map with more precise types than the original, and when it's known that all the keys and values have those more precise types.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
