### PR TITLE
feat(vscode): add useUnionTypes setting

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -68,6 +68,11 @@
             "default": true,
             "description": "Whether to use sealed classes when creating a new bloc."
           },
+          "bloc.newBlocTemplate.useUnionTypes": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether to use union types for state or a single class relying on copyWith. Only works with \"freezed\"."
+          },
           "bloc.newCubitTemplate.type": {
             "type": "string",
             "default": "auto",
@@ -93,6 +98,11 @@
             "type": "boolean",
             "default": true,
             "description": "Whether to use sealed classes when creating a new cubit."
+          },
+          "bloc.newCubitTemplate.useUnionTypes": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether to use union types for state or a single class relying on copyWith. Only works with \"freezed\"."
           }
         }
       }

--- a/extensions/vscode/src/commands/new-bloc.command.ts
+++ b/extensions/vscode/src/commands/new-bloc.command.ts
@@ -90,6 +90,11 @@ async function generateBlocCode(
   const useSealedClasses = workspace
     .getConfiguration("bloc")
     .get<boolean>("newBlocTemplate.useSealedClasses", true);
+
+  const useUnionTypes = workspace
+    .getConfiguration("bloc")
+    .get<boolean>("newBlocTemplate.useUnionTypes", true);
+
   await Promise.all([
     createBlocEventTemplate(
       blocName,
@@ -101,7 +106,8 @@ async function generateBlocCode(
       blocName,
       blocDirectoryPath,
       type,
-      useSealedClasses
+      useSealedClasses,
+      useUnionTypes,
     ),
     createBlocTemplate(blocName, blocDirectoryPath, type),
   ]);
@@ -149,7 +155,8 @@ function createBlocStateTemplate(
   blocName: string,
   targetDirectory: string,
   type: BlocType,
-  useSealedClasses: boolean
+  useSealedClasses: boolean,
+  useUnionTypes: boolean,
 ) {
   const snakeCaseBlocName = changeCase.snakeCase(blocName);
   const targetPath = `${targetDirectory}/${snakeCaseBlocName}_state.dart`;
@@ -159,7 +166,7 @@ function createBlocStateTemplate(
   return new Promise<void>(async (resolve, reject) => {
     writeFile(
       targetPath,
-      getBlocStateTemplate(blocName, type, useSealedClasses),
+      getBlocStateTemplate(blocName, type, useSealedClasses, useUnionTypes),
       "utf8",
       (error) => {
         if (error) {

--- a/extensions/vscode/src/commands/new-cubit.command.ts
+++ b/extensions/vscode/src/commands/new-cubit.command.ts
@@ -87,8 +87,18 @@ async function generateCubitCode(
   const useSealedClasses = workspace
     .getConfiguration("bloc")
     .get<boolean>("newCubitTemplate.useSealedClasses", true);
+
+  const useUnionTypes = workspace
+    .getConfiguration("bloc")
+    .get<boolean>("newCubitTemplate.useUnionTypes", true);
   await Promise.all([
-    createCubitStateTemplate(cubitName, cubitDirectoryPath, type, useSealedClasses),
+    createCubitStateTemplate(
+      cubitName,
+      cubitDirectoryPath,
+      type,
+      useSealedClasses,
+      useUnionTypes,
+    ),
     createCubitTemplate(cubitName, cubitDirectoryPath, type),
   ]);
 }
@@ -108,7 +118,8 @@ function createCubitStateTemplate(
   cubitName: string,
   targetDirectory: string,
   type: BlocType,
-  useSealedClasses: boolean
+  useSealedClasses: boolean,
+  useUnionTypes: boolean,
 ) {
   const snakeCaseCubitName = changeCase.snakeCase(cubitName);
   const targetPath = `${targetDirectory}/${snakeCaseCubitName}_state.dart`;
@@ -118,7 +129,7 @@ function createCubitStateTemplate(
   return new Promise<void>(async (resolve, reject) => {
     writeFile(
       targetPath,
-      getCubitStateTemplate(cubitName, type, useSealedClasses),
+      getCubitStateTemplate(cubitName, type, useSealedClasses, useUnionTypes),
       "utf8",
       (error) => {
         if (error) {

--- a/extensions/vscode/src/templates/bloc-state.template.ts
+++ b/extensions/vscode/src/templates/bloc-state.template.ts
@@ -4,11 +4,16 @@ import { BlocType } from "../utils";
 export function getBlocStateTemplate(
   blocName: string,
   type: BlocType,
-  useSealedClasses: boolean
+  useSealedClasses: boolean,
+  useUnionTypes: boolean,
 ): string {
   switch (type) {
     case BlocType.Freezed:
-      return getFreezedBlocStateTemplate(blocName);
+      return getFreezedBlocStateTemplate(
+        blocName,
+        useSealedClasses,
+        useUnionTypes,
+      );
     case BlocType.Equatable:
       return getEquatableBlocStateTemplate(blocName, useSealedClasses);
     default:
@@ -54,14 +59,29 @@ ${subclassPrefix}class ${pascalCaseBlocName}Initial extends ${pascalCaseBlocName
 `;
 }
 
-function getFreezedBlocStateTemplate(blocName: string): string {
+function getFreezedBlocStateTemplate(
+  blocName: string,
+  useSealedClasses: boolean,
+  useUnionTypes: boolean,
+): string {
   const pascalCaseBlocName = changeCase.pascalCase(blocName) + "State";
   const snakeCaseBlocName = changeCase.snakeCase(blocName);
+  const classPrefix = useSealedClasses ? "sealed " : "";
+
+  if (useUnionTypes) {
+    return `part of '${snakeCaseBlocName}_bloc.dart';
+
+@freezed
+${classPrefix}class ${pascalCaseBlocName} with _\$${pascalCaseBlocName} {
+  const factory ${pascalCaseBlocName}.initial() = _Initial;
+}
+`;
+  }
   return `part of '${snakeCaseBlocName}_bloc.dart';
 
 @freezed
-class ${pascalCaseBlocName} with _\$${pascalCaseBlocName} {
-  const factory ${pascalCaseBlocName}.initial() = _Initial;
+${classPrefix}class ${pascalCaseBlocName} with _\$${pascalCaseBlocName} {
+  const factory ${pascalCaseBlocName}() = _${pascalCaseBlocName};
 }
 `;
 }

--- a/extensions/vscode/src/templates/cubit-state.template.ts
+++ b/extensions/vscode/src/templates/cubit-state.template.ts
@@ -4,11 +4,16 @@ import { BlocType } from "../utils";
 export function getCubitStateTemplate(
   cubitName: string,
   type: BlocType,
-  useSealedClasses: boolean
+  useSealedClasses: boolean,
+  useUnionTypes: boolean,
 ): string {
   switch (type) {
     case BlocType.Freezed:
-      return getFreezedCubitStateTemplate(cubitName);
+      return getFreezedCubitStateTemplate(
+        cubitName,
+        useSealedClasses,
+        useUnionTypes,
+      );
     case BlocType.Equatable:
       return getEquatableCubitStateTemplate(cubitName, useSealedClasses);
     default:
@@ -54,14 +59,30 @@ ${subclassPrefix}class ${pascalCaseCubitName}Initial extends ${pascalCaseCubitNa
 `;
 }
 
-function getFreezedCubitStateTemplate(cubitName: string): string {
+function getFreezedCubitStateTemplate(
+  cubitName: string,
+  useSealedClasses: boolean,
+  useUnionTypes: boolean,
+): string {
   const pascalCaseCubitName = changeCase.pascalCase(cubitName);
   const snakeCaseCubitName = changeCase.snakeCase(cubitName);
+  const classPrefix = useSealedClasses ? "sealed " : "";
+
+  if (useUnionTypes) {
+    return `part of '${snakeCaseCubitName}_cubit.dart';
+
+@freezed
+${classPrefix}class ${pascalCaseCubitName}State with _\$${pascalCaseCubitName}State {
+  const factory ${pascalCaseCubitName}State.initial() = _Initial;
+}
+`;
+  }
+
   return `part of '${snakeCaseCubitName}_cubit.dart';
 
 @freezed
-class ${pascalCaseCubitName}State with _\$${pascalCaseCubitName}State {
-  const factory ${pascalCaseCubitName}State.initial() = _Initial;
+${classPrefix}class ${pascalCaseCubitName}State with _\$${pascalCaseCubitName}State {
+  const factory ${pascalCaseCubitName}State() = _${pascalCaseCubitName}State;
 }
 `;
 }


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

Adds a new `useUnionTypes` setting to both `newBlocTemplate` and `newCubitTemplate`. Defaults to `true` to backwards compatibility. When turned off, state classes will be generated as a single freezed class rather than using unions.

Also brings support for the existing `useSealedClasses` to freezed state generation. I'm happy to remove this from the change set if you'd prefer not changing two things in the same PR but it did seem harmless enough...

Example class generated with the setting as `true` (the default)

```
part of 'foo_cubit.dart';

@freezed
sealed class FooState with _$FooState {
  const factory FooState.initial() = _Initial;
}
```

Example class generated with the setting as `false` (the default)

```
part of 'foo_bloc.dart';

@freezed
sealed class FooState with _$FooState {
  const factory FooState() = _FooState;
}
```

This is useful for states that can rely solely on the `copyWith` generated from freezed to emit state changes. For example:

```
@freezed
sealed class CounterState with _$CounterState {
  const factory CounterState({ required int count }) = _CounterState;
}
```

No need for an initial state here and for changes we can just use `emit(state.copyWith( count: state.count + 1 ))`.


## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
