### PR TITLE
docs(flutter_todos): include barrel files in tutorial for completeness

### DIFF
--- a/docs/src/content/docs/tutorials/flutter-todos.mdx
+++ b/docs/src/content/docs/tutorials/flutter-todos.mdx
@@ -145,7 +145,7 @@ The model of the `Todo` is defined in `todos_api/models/todo.dart` and is export
 
 #### Update Exports
 
-Our ToDo model and the ToDosApi is made available externally (and internally) through barrel files. Notice how we don't import the ToDo model directly, but we import it in `lib/src/todos_api.dart` with a reference to the package barrel file: `import 'package:todos_api/todos_api.dart';`. Now, update the barrel files to resolve any remaining import errors.
+Our `Todo` model and the `TodosApi` are exported via barrel files. Notice how we don't import the model directly, but we import it in `lib/src/todos_api.dart` with a reference to the package barrel file: `import 'package:todos_api/todos_api.dart';`. Update the barrel files to resolve any remaining import errors:
 
 <RemoteCode
 	url="https://raw.githubusercontent.com/felangel/bloc/master/examples/flutter_todos/packages/todos_api/lib/src/models/models.dart"


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

Small documentation update on the flutter_todos. I am making my way through the tutorial and noticed the barrel files are missing from the tutorial. It is easy to overlook this and have import issues without checking the source code directly.

This update to the tutorial contains a small section with a description above code references to the two barrel files in the todos_api package.

## Type of Change
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
