### PR TITLE
refactor(flutter_todos): simplify completedTodos logic

### DIFF
--- a/examples/flutter_todos/packages/local_storage_todos_api/lib/src/local_storage_todos_api.dart
+++ b/examples/flutter_todos/packages/local_storage_todos_api/lib/src/local_storage_todos_api.dart
@@ -82,10 +82,10 @@ class LocalStorageTodosApi extends TodosApi {
   Future<int> clearCompleted() async {
     final todos = [..._todoStreamController.value];
     final initialLength = todos.length;
-    
+
     todos.removeWhere((t) => t.isCompleted);
     final completedTodosAmount = initialLength - todos.length;
-    
+
     _todoStreamController.add(todos);
     await _setValue(kTodosCollectionKey, json.encode(todos));
     return completedTodosAmount;

--- a/examples/flutter_todos/packages/local_storage_todos_api/lib/src/local_storage_todos_api.dart
+++ b/examples/flutter_todos/packages/local_storage_todos_api/lib/src/local_storage_todos_api.dart
@@ -81,8 +81,11 @@ class LocalStorageTodosApi extends TodosApi {
   @override
   Future<int> clearCompleted() async {
     final todos = [..._todoStreamController.value];
-    final completedTodosAmount = todos.where((t) => t.isCompleted).length;
+    final initialLength = todos.length;
+    
     todos.removeWhere((t) => t.isCompleted);
+    final completedTodosAmount = initialLength - todos.length;
+    
     _todoStreamController.add(todos);
     await _setValue(kTodosCollectionKey, json.encode(todos));
     return completedTodosAmount;


### PR DESCRIPTION
- Simplified the calculation of completedTodosAmount by removing unnecessary iterations over the todos list.
- Instead of filtering the list first and then removing items, now we compute the count using the difference in list lengths.
- Improves performance by reducing redundant operations.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->
Simplified the calculation of `completedTodosAmount` by eliminating unnecessary iterations over the todos list. Instead of filtering the list first to count completed todos and then removing them, we now determine the count using the difference between the initial and final list lengths.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
