### PR TITLE
feat(bloc_selector): BlocSelector only rebuilds when selected collection changes

### DIFF
--- a/packages/flutter_bloc/test/bloc_selector_test.dart
+++ b/packages/flutter_bloc/test/bloc_selector_test.dart
@@ -245,6 +245,7 @@ void main() {
           home: BlocSelector<ListCubit, ComplexState, List<int>>(
             bloc: listCubit,
             selector: (state) => state.items,
+            selectorEquality: listEquals,
             builder: (context, state) {
               builderCallCount++;
               final sum = state.fold<int>(0, (prev, item) => prev + item);


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

Dart collections, for example List, are only equal to themselves by default. [Dart API](https://api.flutter.dev/flutter/dart-core/List/operator_equals.html).

When using **BlocSelector** and the selected type is a **collection**, then we cannot guarantee the correct functioning of BlocSelector, and **the builder will be invoked every time the state of the Bloc changes**.

This scenario is very common. I have often seen in various projects a List being selected inside a state that contains many other variables.

This solution tries to be as simple as possible, reusing the official solution provided by Dart, for example [listEquals](https://api.flutter.dev/flutter/foundation/listEquals.html).

The proposed solution:
```dart
BlocSelector<BlocA, BlocAState, List<EntryState>>(
   selector: (state) { ... },
   builder: (context, state) { ... },
   selectorEquality: listEquals,
)
```

## Type of Change

- [ x ] ✨ New feature (non-breaking change which adds functionality)
- [ x ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
