### PR TITLE
fix(flutter_bloc): support breaking change in `provider` v6.1.3

### DIFF
--- a/packages/flutter_bloc/lib/src/multi_bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/multi_bloc_listener.dart
@@ -51,22 +51,21 @@ import 'package:provider/single_child_widget.dart';
 class MultiBlocListener extends StatelessWidget {
   /// {@macro multi_bloc_listener}
   const MultiBlocListener({
-    required this.listeners,
-    required this.child,
+    required List<SingleChildWidget> listeners,
+    required Widget child,
     Key? key,
-  }) : super(key: key);
+  })  : _listeners = listeners,
+        _child = child,
+        super(key: key);
 
-  /// The list of [BlocListener] instances.
-  final List<SingleChildWidget> listeners;
-
-  /// The [Widget] that will be rendered as a child.
-  final Widget child;
+  final List<SingleChildWidget> _listeners;
+  final Widget _child;
 
   @override
   Widget build(BuildContext context) {
     return MultiProvider(
-      providers: listeners,
-      child: child,
+      providers: _listeners,
+      child: _child,
     );
   }
 }

--- a/packages/flutter_bloc/lib/src/multi_bloc_listener.dart
+++ b/packages/flutter_bloc/lib/src/multi_bloc_listener.dart
@@ -48,11 +48,25 @@ import 'package:provider/single_child_widget.dart';
 /// As a result, the only advantage of using [MultiBlocListener] is improved
 /// readability due to the reduction in nesting and boilerplate.
 /// {@endtemplate}
-class MultiBlocListener extends MultiProvider {
+class MultiBlocListener extends StatelessWidget {
   /// {@macro multi_bloc_listener}
-  MultiBlocListener({
-    required List<SingleChildWidget> listeners,
-    required Widget child,
+  const MultiBlocListener({
+    required this.listeners,
+    required this.child,
     Key? key,
-  }) : super(key: key, providers: listeners, child: child);
+  }) : super(key: key);
+
+  /// The list of [BlocListener] instances.
+  final List<SingleChildWidget> listeners;
+
+  /// The [Widget] that will be rendered as a child.
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: listeners,
+      child: child,
+    );
+  }
 }

--- a/packages/flutter_bloc/lib/src/multi_bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/multi_bloc_provider.dart
@@ -48,11 +48,25 @@ import 'package:provider/single_child_widget.dart';
 /// As a result, the only advantage of using [MultiBlocProvider] is improved
 /// readability due to the reduction in nesting and boilerplate.
 /// {@endtemplate}
-class MultiBlocProvider extends MultiProvider {
+class MultiBlocProvider extends StatelessWidget {
   /// {@macro multi_bloc_provider}
-  MultiBlocProvider({
-    required List<SingleChildWidget> providers,
-    required Widget child,
+  const MultiBlocProvider({
+    required this.providers,
+    required this.child,
     Key? key,
-  }) : super(key: key, providers: providers, child: child);
+  }) : super(key: key);
+
+  /// The list of [BlocProvider] instances.
+  final List<SingleChildWidget> providers;
+
+  /// The [Widget] that will be rendered as a child.
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: providers,
+      child: child,
+    );
+  }
 }

--- a/packages/flutter_bloc/lib/src/multi_bloc_provider.dart
+++ b/packages/flutter_bloc/lib/src/multi_bloc_provider.dart
@@ -51,22 +51,21 @@ import 'package:provider/single_child_widget.dart';
 class MultiBlocProvider extends StatelessWidget {
   /// {@macro multi_bloc_provider}
   const MultiBlocProvider({
-    required this.providers,
-    required this.child,
+    required List<SingleChildWidget> providers,
+    required Widget child,
     Key? key,
-  }) : super(key: key);
+  })  : _providers = providers,
+        _child = child,
+        super(key: key);
 
-  /// The list of [BlocProvider] instances.
-  final List<SingleChildWidget> providers;
-
-  /// The [Widget] that will be rendered as a child.
-  final Widget child;
+  final List<SingleChildWidget> _providers;
+  final Widget _child;
 
   @override
   Widget build(BuildContext context) {
     return MultiProvider(
-      providers: providers,
-      child: child,
+      providers: _providers,
+      child: _child,
     );
   }
 }

--- a/packages/flutter_bloc/lib/src/multi_repository_provider.dart
+++ b/packages/flutter_bloc/lib/src/multi_repository_provider.dart
@@ -45,22 +45,21 @@ import 'package:provider/single_child_widget.dart';
 class MultiRepositoryProvider extends StatelessWidget {
   /// {@macro multi_repository_provider}
   const MultiRepositoryProvider({
-    required this.providers,
-    required this.child,
+    required List<SingleChildWidget> providers,
+    required Widget child,
     Key? key,
-  }) : super(key: key);
+  })  : _providers = providers,
+        _child = child,
+        super(key: key);
 
-  /// The list of [RepositoryProvider] instances.
-  final List<SingleChildWidget> providers;
-
-  /// The [Widget] that will be rendered as a child.
-  final Widget child;
+  final List<SingleChildWidget> _providers;
+  final Widget _child;
 
   @override
   Widget build(BuildContext context) {
     return MultiProvider(
-      providers: providers,
-      child: child,
+      providers: _providers,
+      child: _child,
     );
   }
 }

--- a/packages/flutter_bloc/lib/src/multi_repository_provider.dart
+++ b/packages/flutter_bloc/lib/src/multi_repository_provider.dart
@@ -42,11 +42,25 @@ import 'package:provider/single_child_widget.dart';
 /// As a result, the only advantage of using [MultiRepositoryProvider] is
 /// improved readability due to the reduction in nesting and boilerplate.
 /// {@endtemplate}
-class MultiRepositoryProvider extends MultiProvider {
+class MultiRepositoryProvider extends StatelessWidget {
   /// {@macro multi_repository_provider}
-  MultiRepositoryProvider({
-    required List<SingleChildWidget> providers,
-    required Widget child,
+  const MultiRepositoryProvider({
+    required this.providers,
+    required this.child,
     Key? key,
-  }) : super(key: key, providers: providers, child: child);
+  }) : super(key: key);
+
+  /// The list of [RepositoryProvider] instances.
+  final List<SingleChildWidget> providers;
+
+  /// The [Widget] that will be rendered as a child.
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: providers,
+      child: child,
+    );
+  }
 }

--- a/packages/flutter_bloc/pubspec.yaml
+++ b/packages/flutter_bloc/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   bloc: ^9.0.0
   flutter:
     sdk: flutter
-  provider: ^6.0.0
+  provider: ^6.1.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

YES

## Description

<!--- Describe your changes in detail -->
- refactor(flutter_bloc): support breaking change in `provider` v6.1.3
  - this is technically a breaking change because `MultiBlocProvider`, `MultiBlocListener`, and `MultiRepositoryProvider` are no longer subclasses of `MultiProvider` but we're forced to do so due to the breaking changes introduced in `pkg:provider` v6.1.3 (closes https://github.com/felangel/bloc/issues/4383 and related to https://github.com/rrousselGit/provider/issues/907).
  - I would have much preferred for @rrousselgit to have reverted the change and published 6.1.4 but it's been 5 hours since the breaking change was published and I don't want to keep waiting for an upstream fix since there hasn't been any update or indication that the change will be reverted and this is very disruptive change for all folks using `pkg:flutter_bloc`.
  

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
