### PR TITLE
feat(bloc): Introduce maybeEmit to safely emit states

### DIFF
--- a/packages/bloc/lib/src/bloc_base.dart
+++ b/packages/bloc/lib/src/bloc_base.dart
@@ -33,6 +33,9 @@ abstract class Closable {
 abstract class Emittable<State extends Object?> {
   /// Emits a new [state].
   void emit(State state);
+
+  /// Safely emits a new [state] if the bloc is not closed.
+  void maybeEmit(State state);
 }
 
 /// A generic destination for errors.
@@ -109,6 +112,21 @@ abstract class BlocBase<State>
       rethrow;
     }
   }
+
+  /// Safely updates the [state] to the provided [state] if the block is not
+  /// closed.
+  /// [emit] does nothing if the [state] being emitted
+  /// is equal to the current [state].
+  ///
+  /// To allow for the possibility of notifying listeners of the initial state,
+  /// emitting a state which is equal to the initial state is allowed as long
+  /// as it is the first thing emitted by the instance.
+  ///
+  /// * Throws a [StateError] if the bloc is closed.
+  @protected
+  @visibleForTesting
+  @override
+  void maybeEmit(State state) => isClosed ? null : emit(state);
 
   /// Called whenever a [change] occurs with the given [change].
   /// A [change] occurs when a new `state` is emitted.

--- a/packages/bloc/test/cubits/counter_cubit.dart
+++ b/packages/bloc/test/cubits/counter_cubit.dart
@@ -8,6 +8,8 @@ class CounterCubit extends Cubit<int> {
 
   void increment() => emit(state + 1);
   void decrement() => emit(state - 1);
+  void maybeIncrement() => maybeEmit(state + 1);
+  void maybeDecrement() => maybeEmit(state - 1);
 
   @override
   void onChange(Change<int> change) {


### PR DESCRIPTION
Introduced method to safely emit state. The method allows to always trigger "maybeEmit" without a need to check if bloc is closed or not. In case if bloc is closed, the event will be ignored;

Resolves: #3069

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

YES

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] ~~🛠️ Bug fix (non-breaking change which fixes an issue)~~
- [ ] ~~❌ Breaking change (fix or feature that would cause existing functionality to change)~~
- [ ] ~~🧹 Code refactor~~
- [ ] ~~✅ Build configuration change~~
- [ ] ~~📝 Documentation~~
- [ ] ~~🗑️ Chore~~
