### PR TITLE
fix(flutter_firebase_login): prevent repeated error snackbars after failure

### DIFF
--- a/examples/flutter_firebase_login/lib/login/view/login_form.dart
+++ b/examples/flutter_firebase_login/lib/login/view/login_form.dart
@@ -11,6 +11,8 @@ class LoginForm extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocListener<LoginCubit, LoginState>(
+      listenWhen: (previous, current) =>
+          previous.status != current.status && current.status.isFailure,
       listener: (context, state) {
         if (state.status.isFailure) {
           ScaffoldMessenger.of(context)

--- a/examples/flutter_firebase_login/lib/sign_up/view/sign_up_form.dart
+++ b/examples/flutter_firebase_login/lib/sign_up/view/sign_up_form.dart
@@ -9,6 +9,8 @@ class SignUpForm extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocListener<SignUpCubit, SignUpState>(
+      listenWhen: (previous, current) =>
+          previous.status != current.status && current.status.isFailure,
       listener: (context, state) {
         if (state.status.isSuccess) {
           Navigator.of(context).pop();


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

This fix adds a `listenWhen` condition to the `BlocListener` in the login and sign up form to ensure the error snackbar only appears when the login status changes to failure.

Fixes #4396

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
