### PR TITLE
feat(flutter_bloc): support listener current state

### DIFF
--- a/packages/flutter_bloc/test/bloc_listener_test.dart
+++ b/packages/flutter_bloc/test/bloc_listener_test.dart
@@ -507,6 +507,52 @@ void main() {
       expect(states, expectedStates);
     });
 
+    testWidgets(
+        'calls listener with initial state when startWithCurrentState is true',
+        (tester) async {
+      final counterCubit = CounterCubit();
+      final states = <int>[];
+      const expectedStates = [0];
+      await tester.pumpWidget(
+        BlocListener<CounterCubit, int>(
+          bloc: counterCubit,
+          startWithCurrentState: true,
+          listener: (_, state) {
+            states.add(state);
+          },
+          child: const SizedBox(),
+        ),
+      );
+
+      await tester.pump();
+
+      expect(states, expectedStates);
+    });
+
+    testWidgets(
+        'calls listener when further states emitted when startWithCurrentState '
+        'is true', (tester) async {
+      final counterCubit = CounterCubit();
+      final states = <int>[];
+      const expectedStates = [0, 1];
+      await tester.pumpWidget(
+        BlocListener<CounterCubit, int>(
+          bloc: counterCubit,
+          startWithCurrentState: true,
+          listener: (_, state) {
+            states.add(state);
+          },
+          child: const SizedBox(),
+        ),
+      );
+
+      await tester.pump();
+      counterCubit.increment();
+      await tester.pump();
+
+      expect(states, expectedStates);
+    });
+
     testWidgets('overrides debugFillProperties', (tester) async {
       final builder = DiagnosticPropertiesBuilder();
 
@@ -528,6 +574,7 @@ void main() {
           "bloc: Instance of 'CounterCubit'",
           'has listener',
           'has listenWhen',
+          'without current state',
         ],
       );
     });


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

Allows setting a `startWithCurrentState` flag on `BlocListener` which changes the behaviour to immediately call `listener` with the current `state` of the bloc before calling again with subsequent emissions.

This allows the view layer to react to whatever the current state is rather than only when it changes.

For example:

```dart
return BlocListener<AuthBloc, AuthState>(
  // Ensure the listener is checked immediately on creation with
  // current state in addition to future transitions.
  // If the user is somehow routed to this page when not logged in
  // they should be immediately kicked out, rather than only when
  // they transition from logged in to logged out.
  startWithCurrentState: true,
  listener: (context, state) {
    if(!state.isLoggedIn) {
      context.router.replace(const UnauthenticatedRoute());
    }
  },
  child: MyAuthenticatedPageContent(),
);
```

Closes #4347

I don't love the name of the flag itself but I couldn't come up with anything better (naming things, amirite?).

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
