### PR TITLE
test(bloc_selector): add test case for rebuild on selector change 

### DIFF
--- a/packages/flutter_bloc/test/bloc_selector_test.dart
+++ b/packages/flutter_bloc/test/bloc_selector_test.dart
@@ -207,5 +207,32 @@ void main() {
         ],
       );
     });
+
+    testWidgets('rebuild when selector changes', (tester) async {
+      final counterCubit = CounterCubit();
+      late bool Function(int) selector;
+
+      Widget buildSelector() => MaterialApp(
+            home: BlocSelector<CounterCubit, int, bool>(
+              bloc: counterCubit,
+              selector: selector,
+              builder: (context, state) => Text('Selected: $state'),
+            ),
+          );
+
+      counterCubit.increment(); // makes 0 -> 1
+
+      selector = (state) => state.isEven;
+      await tester.pumpWidget(buildSelector());
+      expect(find.text('Selected: false'), findsOneWidget);
+
+      selector = (state) => state.isOdd;
+      await tester.pumpWidget(buildSelector());
+      expect(find.text('Selected: true'), findsOneWidget);
+
+      counterCubit.increment(); // makes 1 -> 2
+      await tester.pumpAndSettle();
+      expect(find.text('Selected: false'), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
**Add new test case: ensure rebuild when selector function changes** (#4414)

---

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

This PR adds a new test case to ensure that the BlocSelector widget correctly refers the latest selector function. The new test verifies that when the selector function is updated, the widget rebuilds with the updated state. This enhances the test coverage for the BlocSelector widget and ensures more reliable behavior in dynamic selector scenarios.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore (test case addition)
