### PR TITLE
fix(intellij): apache commons text missing on some IJ versions

### DIFF
--- a/extensions/intellij/intellij_generator_plugin/build.gradle.kts
+++ b/extensions/intellij/intellij_generator_plugin/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     java
     id("org.jetbrains.intellij.platform") version "2.5.0"
-    kotlin("jvm") version "1.9.25"
+    kotlin("jvm") version "2.1.0"
     idea
 }
 
@@ -11,6 +11,7 @@ version = "4.1.1"
 val lsp4ijVersion: String by project
 val lsp4jVersion: String by project
 val caseFormatVersion: String by project
+val apacheCommonsTextVersion: String by project
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17
@@ -53,6 +54,7 @@ dependencies {
     compileOnly("com.redhat.devtools.intellij:lsp4ij:$lsp4ijVersion")
     compileOnly("org.eclipse.lsp4j:org.eclipse.lsp4j:$lsp4jVersion")
     implementation("com.fleshgrinder.kotlin:case-format:$caseFormatVersion")
+    implementation("org.apache.commons:commons-text:$apacheCommonsTextVersion")
 }
 
 tasks {

--- a/extensions/intellij/intellij_generator_plugin/build.gradle.kts
+++ b/extensions/intellij/intellij_generator_plugin/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     java
     id("org.jetbrains.intellij.platform") version "2.5.0"
@@ -59,10 +61,14 @@ dependencies {
 
 tasks {
     compileKotlin {
-        kotlinOptions.jvmTarget = "17"
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
     }
 
     compileTestKotlin {
-        kotlinOptions.jvmTarget = "17"
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
     }
 }

--- a/extensions/intellij/intellij_generator_plugin/gradle.properties
+++ b/extensions/intellij/intellij_generator_plugin/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=true
-
 # Libraries versions
 lsp4jVersion=0.21.1
 lsp4ijVersion=0.12.0
 caseFormatVersion=0.2.0
+apacheCommonsTextVersion=1.13.1


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

Fix #4479 : Apache Commons Text seems to not being available in the ClassPath on 2025.1.1 of IntelliJ.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
