### PR TITLE
add flag to catch states emitted from constructor

### DIFF
--- a/packages/bloc_test/lib/src/bloc_test.dart
+++ b/packages/bloc_test/lib/src/bloc_test.dart
@@ -149,6 +149,7 @@ void blocTest<B extends EmittableStateStreamableSource<State>, State>(
   dynamic Function()? errors,
   FutureOr<void> Function()? tearDown,
   dynamic tags,
+  bool allowInitialState = false,
 }) {
   test.test(
     description,
@@ -164,6 +165,7 @@ void blocTest<B extends EmittableStateStreamableSource<State>, State>(
         verify: verify,
         errors: errors,
         tearDown: tearDown,
+        allowInitialState: allowInitialState,
       );
     },
     tags: tags,
@@ -184,6 +186,7 @@ Future<void> testBloc<B extends EmittableStateStreamableSource<State>, State>({
   dynamic Function(B bloc)? verify,
   dynamic Function()? errors,
   FutureOr<void> Function()? tearDown,
+  bool allowInitialState = false,
 }) async {
   var shallowEquality = false;
   final unhandledErrors = <Object>[];
@@ -199,6 +202,9 @@ Future<void> testBloc<B extends EmittableStateStreamableSource<State>, State>({
       await setUp?.call();
       final states = <State>[];
       final bloc = build();
+      if (allowInitialState && bloc.state != null) {
+        states.add(bloc.state);
+      }
       // ignore: invalid_use_of_protected_member, invalid_use_of_visible_for_testing_member
       if (seed != null) bloc.emit(seed());
       final subscription = bloc.stream.skip(skip).listen(states.add);

--- a/packages/bloc_test/test/cubit_bloc_test_test.dart
+++ b/packages/bloc_test/test/cubit_bloc_test_test.dart
@@ -16,10 +16,25 @@ void main() {
       );
 
       blocTest<CounterCubit, int>(
+        'emits [0] when nothing is called but initial state is tracked',
+        build: () => CounterCubit(),
+        allowInitialState: true,
+        expect: () => <int>[0],
+      );
+
+      blocTest<CounterCubit, int>(
         'emits [1] when increment is called',
         build: () => CounterCubit(),
         act: (cubit) => cubit.increment(),
         expect: () => <int>[1],
+      );
+
+      blocTest<CounterCubit, int>(
+        'emits [0, 1] when increment is called while initial state was tracked',
+        build: () => CounterCubit(),
+        allowInitialState: true,
+        act: (cubit) => cubit.increment(),
+        expect: () => <int>[0, 1],
       );
 
       blocTest<CounterCubit, int>(
@@ -113,10 +128,25 @@ void main() {
       );
 
       blocTest<InstantEmitCubit, int>(
+        'emits [1] when initial state is tracked.',
+        build: () => InstantEmitCubit(),
+        allowInitialState: true,
+        expect: () => <int>[1],
+      );
+
+      blocTest<InstantEmitCubit, int>(
         'emits [2] when increment is called',
         build: () => InstantEmitCubit(),
         act: (cubit) => cubit.increment(),
         expect: () => <int>[2],
+      );
+
+      blocTest<InstantEmitCubit, int>(
+        'emits [1, 2] when increment is called while initial state was also tracked.',
+        build: () => InstantEmitCubit(),
+        allowInitialState: true,
+        act: (cubit) => cubit.increment(),
+        expect: () => <int>[1, 2],
       );
 
       blocTest<InstantEmitCubit, int>(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

I have added a flag "allowInitialState" in blocTest function to catch the states emitted by constructor. When this flag is true, it adds the initial state of bloc/cubit into the "states" array before starting to listen the stream.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
