### PR TITLE
docs: fixed docs for custom storage

### DIFF
--- a/packages/hydrated_bloc/README.md
+++ b/packages/hydrated_bloc/README.md
@@ -125,7 +125,7 @@ You can override the global storage instance for specific `HydratedBloc` or `Hyd
 
 ```dart
 class CounterCubit extends HydratedCubit<int> {
-  CounterCubit() : super(0, storage: EncryptedStorage());
+  CounterCubit() : super(0, EncryptedStorage());
 
   void increment() => emit(state + 1);
 


### PR DESCRIPTION

## Status

**READY**

## Breaking Changes

NO

## Description

Just fixed the docs to reflect the actual behaviour.
the `storage` super parameter is not named.
```dart
abstract class HydratedCubit<State> extends Cubit<State>
    with HydratedMixin<State> {
  /// {@macro hydrated_cubit}
  HydratedCubit(State state, [Storage? storage]) : super(state) {
    hydrate(storage: storage);
  }
}
```
## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
