### PR TITLE
fix(docs): remove stray backtick in RepositoryProvider example code comment

### DIFF
--- a/packages/flutter_bloc/lib/src/repository_provider.dart
+++ b/packages/flutter_bloc/lib/src/repository_provider.dart
@@ -19,7 +19,7 @@ import 'package:provider/provider.dart';
 ///
 /// ```dart
 /// RepositoryProvider(
-///   lazy: false,`
+///   lazy: false,
 ///   create: (context) => RepositoryA(),
 ///   child: ChildA(),
 /// );


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

This is a super nit and very minor, I found it while I was looking into the doc comment of `RepositoryProvider`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
