### PR TITLE
feat(bloc, flutter_bloc): Extend block to support handling side effects from bloc.

### DIFF
--- a/packages/bloc/lib/bloc.dart
+++ b/packages/bloc/lib/bloc.dart
@@ -7,4 +7,5 @@ export 'src/bloc.dart';
 export 'src/bloc_observer.dart';
 export 'src/change.dart';
 export 'src/cubit.dart';
+export 'src/side_effect_bloc.dart';
 export 'src/transition.dart';

--- a/packages/bloc/lib/src/side_effect_bloc.dart
+++ b/packages/bloc/lib/src/side_effect_bloc.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:meta/meta.dart';
+
+/// A BLoC base class that extends `Bloc` to support emitting side effects
+/// alongside state updates, enabling decoupled handling of transient events
+/// (e.g., navigation, toasts) in a Flutter application.
+///
+/// This class introduces a separate stream for side effects, allowing the UI
+/// to react to non-state changes without bloating the state model.
+///
+/// Type parameters:
+/// - `Event`: The type of events the BLoC handles.
+/// - `State`: The type of state the BLoC manages.
+/// - `Effect`: The type of side effects emitted by the BLoC.
+abstract class SideEffectBloc<Event, State, Effect> extends Bloc<Event, State> {
+  /// Creates a `SideEffectBloc` with the specified [initialState].
+  SideEffectBloc(State initialState) : super(initialState) {
+    _effectController = StreamController<Effect>.broadcast();
+  }
+
+  /// The internal controller managing the stream of side effects.
+  late final StreamController<Effect> _effectController;
+
+  /// Stream of side effects emitted by the BLoC.
+  ///
+  /// Widgets can listen to this stream to react to side effects, such as
+  /// showing a snackbar or navigating to a new route.
+  Stream<Effect> get effectsStream => _effectController.stream;
+
+  /// Emits a new [effect] to the [effectsStream].
+  ///
+  /// This method should be called by subclasses to trigger side effects.
+  /// Throws a [StateError] if called after the BLoC is closed.
+  @visibleForTesting
+  @protected
+  void emitEffect(Effect effect) {
+    if (isClosed) throw StateError('Cannot add effects after close');
+    _effectController.add(effect);
+    onEffect(effect);
+  }
+
+  /// Called whenever an [effect] is emitted.
+  ///
+  /// Subclasses can override this method to perform additional logic
+  /// when a side effect is emitted. By default, it does nothing.
+  @protected
+  void onEffect(Effect effect) {}
+
+  /// Closes the BLoC and its resources.
+  ///
+  /// Ensures the [effectsStream] is properly closed before closing the BLoC.
+  /// Must be called by subclasses overriding this method.
+  @override
+  @mustCallSuper
+  Future<void> close() async {
+    await _effectController.close();
+    await super.close();
+  }
+}

--- a/packages/bloc/test/side_effect_bloc_test.dart
+++ b/packages/bloc/test/side_effect_bloc_test.dart
@@ -1,0 +1,58 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class MockBlocObserver extends Mock implements BlocObserver {}
+
+Future<void> tick() => Future<void>.delayed(Duration.zero);
+
+class TestSideEffectBloc extends SideEffectBloc<String, String, String> {
+  TestSideEffectBloc() : super('initial_state') {
+    on<String>((event, emit) {
+      emit('new_state');
+      emitEffect('new_effect');
+    });
+  }
+}
+
+void main() {
+  group('SideEffectBloc', () {
+    late TestSideEffectBloc bloc;
+
+    setUp(() {
+      bloc = TestSideEffectBloc();
+    });
+
+    tearDown(() async {
+      await bloc.close();
+    });
+
+    test('emits initial state', () {
+      expect(bloc.state, 'initial_state');
+    });
+
+    test('emits state and effect on event', () async {
+      unawaited(expectLater(bloc.stream, emitsInOrder(['new_state'])));
+      unawaited(expectLater(bloc.effectsStream, emitsInOrder(['new_effect'])));
+
+      bloc.add('event');
+      await tick();
+      expect(bloc.state, 'new_state');
+    });
+
+    test('throws StateError for effect after close', () async {
+      await bloc.close();
+      expect(() => bloc.emitEffect('effect'), throwsA(isA<StateError>()));
+    });
+
+    test('closes streams properly', () async {
+      unawaited(expectLater(bloc.stream, emitsDone));
+      unawaited(expectLater(bloc.effectsStream, emitsDone));
+      await bloc.close();
+    });
+  });
+}
+
+void unawaited(Future<void> future) {}

--- a/packages/flutter_bloc/lib/flutter_bloc.dart
+++ b/packages/flutter_bloc/lib/flutter_bloc.dart
@@ -17,3 +17,4 @@ export './src/multi_bloc_listener.dart';
 export './src/multi_bloc_provider.dart';
 export './src/multi_repository_provider.dart';
 export './src/repository_provider.dart';
+export './src/side_effect_bloc_builder.dart';

--- a/packages/flutter_bloc/lib/src/side_effect_bloc_builder.dart
+++ b/packages/flutter_bloc/lib/src/side_effect_bloc_builder.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+/// A callback type for handling side effects with the current state.
+///
+/// Takes the current [state] and emitted [effect] as parameters.
+typedef EffectHandler<T, S> = void Function(S state, T effect);
+
+/// A Flutter widget that builds UI based on the state of a [SideEffectBloc]
+/// and handles its side effects.
+///
+/// This widget listens to the [effectsStream] of the provided [SideEffectBloc]
+/// and triggers the [effectHandler] when a side effect is emitted, while using
+/// [BlocBuilder] to rebuild the UI based on state changes.
+///
+/// Type parameters:
+/// - `B`: The type of [SideEffectBloc] handling events, state, and effects.
+/// - `S`: The type of state managed by the BLoC.
+/// - `E`: The type of side effects emitted by the BLoC.
+class SideEffectBlocBuilder<B extends SideEffectBloc<dynamic, S, E>, S, E>
+    extends StatefulWidget {
+  /// Creates a [SideEffectBlocBuilder] widget.
+  ///
+  /// - [bloc]: The [SideEffectBloc] instance to listen to. If null, it is read
+  ///   from the context using [BlocProvider].
+  /// - [builder]: A function that builds the UI based on the current state.
+  /// - [effectHandler]: A callback to handle side effects with the current state.
+  /// - [buildWhen]: An optional condition to control when the widget rebuilds
+  ///   based on state changes.
+  const SideEffectBlocBuilder({
+    required this.builder,
+    required this.effectHandler,
+    this.bloc,
+    this.buildWhen,
+    Key? key,
+  }) : super(key: key);
+
+  /// The [SideEffectBloc] instance to listen to for state and effects.
+  final B? bloc;
+
+  /// A function that builds the UI based on the current state.
+  final BlocWidgetBuilder<S> builder;
+
+  /// An optional condition to determine whether to rebuild on state changes.
+  final BlocBuilderCondition<S>? buildWhen;
+
+  /// A callback to handle side effects with the current state.
+  final EffectHandler<S, E> effectHandler;
+
+  @override
+  State<SideEffectBlocBuilder<B, S, E>> createState() =>
+      _SideEffectBlocBuilderState<B, S, E>();
+}
+
+/// The state class for [SideEffectBlocBuilder].
+///
+/// Manages the subscription to the [effectsStream] and ensures proper cleanup.
+class _SideEffectBlocBuilderState<B extends SideEffectBloc<dynamic, S, E>, S, E>
+    extends State<SideEffectBlocBuilder<B, S, E>> {
+  /// The [SideEffectBloc] instance used for state and effect handling.
+  late final B effectBloc;
+
+  /// The subscription to the [effectsStream] for handling side effects.
+  late final StreamSubscription<E> _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    // Initialize the BLoC, either from widget.bloc or context.
+    effectBloc = widget.bloc ?? context.read<B>();
+
+    // Subscribe to the effects stream and invoke effectHandler on each effect.
+    _subscription = effectBloc.effectsStream.listen(
+          (effect) {
+        try {
+          widget.effectHandler(effect, effectBloc.state);
+        } catch (e) {
+          // Ignored exception to prevent crashes from effect handling errors.
+        }
+      },
+      onError: (err) => debugPrint('Error in effect stream: $err'),
+    );
+  }
+
+  @override
+  void dispose() {
+    // Cancel the effect stream subscription to prevent memory leaks.
+    _subscription.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Use BlocBuilder to rebuild the UI based on state changes.
+    return BlocBuilder<B, S>(
+      bloc: effectBloc,
+      buildWhen: widget.buildWhen,
+      builder: widget.builder,
+    );
+  }
+}

--- a/packages/flutter_bloc/test/side_effect_bloc_builder_test.dart
+++ b/packages/flutter_bloc/test/side_effect_bloc_builder_test.dart
@@ -1,0 +1,174 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class FakeSideEffectBloc extends Bloc<dynamic, String> implements SideEffectBloc<dynamic, String, int> {
+  FakeSideEffectBloc() : super('initial_state');
+
+  @override
+  final StreamController<int> _effectController = StreamController<int>.broadcast();
+
+  @override
+  Stream<int> get effectsStream => _effectController.stream;
+
+  void emitEffect(int effect) => _effectController.add(effect);
+
+  @override
+  Future<void> close() {
+    _effectController.close();
+    return super.close();
+  }
+
+  @override
+  void onEffect(int effect) {}
+}
+
+void main() {
+  late FakeSideEffectBloc fakeBloc;
+  const testState = 'initial_state';
+  const testEffect = 42;
+
+  setUp(() {
+    fakeBloc = FakeSideEffectBloc();
+  });
+
+  tearDown(() {
+    fakeBloc.close();
+  });
+
+  testWidgets('builds with provided bloc and calls builder with state', (tester) async {
+    const expectedWidget = Text('Built');
+    var builderCalled = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SideEffectBlocBuilder<FakeSideEffectBloc, String, int>(
+          bloc: fakeBloc,
+          builder: (context, state) {
+            builderCalled = true;
+            expect(state, testState);
+            return expectedWidget;
+          },
+          effectHandler: (state, effect) {},
+        ),
+      ),
+    );
+
+    expect(builderCalled, isTrue);
+    expect(find.byWidget(expectedWidget), findsOneWidget);
+  });
+
+  testWidgets('reads bloc from context if not provided', (tester) async {
+    const expectedWidget = Text('Built');
+    var builderCalled = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: BlocProvider.value(
+          value: fakeBloc,
+          child: SideEffectBlocBuilder<FakeSideEffectBloc, String, int>(
+            builder: (context, state) {
+              builderCalled = true;
+              expect(state, testState);
+              return expectedWidget;
+            },
+            effectHandler: (state, effect) {},
+          ),
+        ),
+      ),
+    );
+
+    expect(builderCalled, isTrue);
+    expect(find.byWidget(expectedWidget), findsOneWidget);
+  });
+
+  testWidgets('handles effects via effectHandler', (tester) async {
+    var effectHandled = false;
+    const expectedWidget = Text('Built');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SideEffectBlocBuilder<FakeSideEffectBloc, String, int>(
+          bloc: fakeBloc,
+          builder: (context, state) => expectedWidget,
+          effectHandler: (state, effect) {
+            effectHandled = true;
+            expect(state, testState);
+            expect(effect, testEffect);
+          },
+        ),
+      ),
+    );
+
+    fakeBloc.emitEffect(testEffect);
+    await tester.pump();
+
+    expect(effectHandled, isTrue);
+  });
+
+  testWidgets('respects buildWhen condition', (tester) async {
+    var buildCount = 0;
+    const expectedWidget = Text('Built');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: BlocProvider.value(
+          value: fakeBloc,
+          child: SideEffectBlocBuilder<FakeSideEffectBloc, String, int>(
+            buildWhen: (previous, current) => false,
+            builder: (context, state) {
+              buildCount++;
+              return expectedWidget;
+            },
+            effectHandler: (state, effect) {},
+          ),
+        ),
+      ),
+    );
+
+    fakeBloc.emit('new_state');
+    await tester.pump();
+
+    expect(buildCount, 1); // Should not rebuild due to buildWhen returning false
+  });
+
+  testWidgets('cancels effect stream subscription on dispose', (tester) async {
+    const expectedWidget = Text('Built');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SideEffectBlocBuilder<FakeSideEffectBloc, String, int>(
+          bloc: fakeBloc,
+          builder: (context, state) => expectedWidget,
+          effectHandler: (state, effect) {},
+        ),
+      ),
+    );
+
+    expect(fakeBloc._effectController.hasListener, isTrue);
+
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+
+    expect(fakeBloc._effectController.hasListener, isFalse);
+  });
+
+  testWidgets('handles effectHandler errors without crashing', (tester) async {
+    const expectedWidget = Text('Built');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SideEffectBlocBuilder<FakeSideEffectBloc, String, int>(
+          bloc: fakeBloc,
+          builder: (context, state) => expectedWidget,
+          effectHandler: (state, effect) => throw Exception('Test error'),
+        ),
+      ),
+    );
+
+    fakeBloc.emitEffect(testEffect);
+    await tester.pump();
+
+    expect(find.byWidget(expectedWidget), findsOneWidget); // Widget still builds
+  });
+}


### PR DESCRIPTION
 <!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title
Added a extension of the bloc to support emmitting side effects without juggling with the complex ui states
Added an extension widget of BlockBuilder to support a callback for the sideEffects
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
