### PR TITLE
Replace deprecated headline1 with displayLarge in TimerPageSnippet component

### DIFF
--- a/docs/src/components/tutorials/flutter-timer/TimerPageSnippet.astro
+++ b/docs/src/components/tutorials/flutter-timer/TimerPageSnippet.astro
@@ -54,7 +54,7 @@ class TimerText extends StatelessWidget {
     final secondsStr = (duration % 60).floor().toString().padLeft(2, '0');
     return Text(
       '$minutesStr:$secondsStr',
-      style: Theme.of(context).textTheme.headline1,
+      style: Theme.of(context).textTheme.displayLarge,
     );
   }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY/IN DEVELOPMENT/HOLD**

## Breaking Changes

No

## Description

I was working on Flutter Timer tutorial and found that headline1 does not exist on textTheme anymore.
[headline1 is deprecated after 3.19](https://docs.flutter.dev/release/breaking-changes/3-19-deprecations) so I replaced the documentation with `displayLarge`.
I am quite new to both Flutter and Bloc so tell me if I am doing something wrong.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
