### PR TITLE
docs: add ko `flutter-counter` tutorial translation

### DIFF
--- a/docs/src/content/docs/ko/tutorials/flutter-counter.mdx
+++ b/docs/src/content/docs/ko/tutorials/flutter-counter.mdx
@@ -11,15 +11,18 @@ import FlutterPubGetSnippet from '~/components/tutorials/FlutterPubGetSnippet.as
 
 ![beginner](https://img.shields.io/badge/level-beginner-green.svg)
 
-이 튜토리얼에서는 Bloc 라이브러리를 사용해서 Flutter로 카운터 앱을 만들어 봅니다.
+이 튜토리얼에서는 Bloc 라이브러리를 사용해서 Flutter로 카운터 앱을 만들어
+봅니다.
 
 ![demo](~/assets/tutorials/flutter-counter.gif)
 
 ## 핵심 주제
 
 - [BlocObserver](/ko/bloc-concepts#blocobserver)로 상태 변화 관찰하기.
-- [BlocProvider](/ko/flutter-bloc-concepts#blocprovider)로 하위 위젯에 bloc 제공하기.
-- [BlocBuilder](/ko/flutter-bloc-concepts#blocbuilder)로 상태 변화에 따라 위젯 다시 그리기.
+- [BlocProvider](/ko/flutter-bloc-concepts#blocprovider)로 하위 위젯에 bloc
+  제공하기.
+- [BlocBuilder](/ko/flutter-bloc-concepts#blocbuilder)로 상태 변화에 따라 위젯
+  다시 그리기.
 - Bloc 대신 Cubit 사용하기. [차이점이 뭔가요?](/ko/bloc-concepts#cubit-vs-bloc)
 - [context.read](/ko/flutter-bloc-concepts#contextread)로 이벤트 추가하기.
 
@@ -59,11 +62,14 @@ import FlutterPubGetSnippet from '~/components/tutorials/FlutterPubGetSnippet.as
 ├── pubspec.yaml
 ```
 
-이 프로젝트는 기능 기반 디렉토리 구조를 사용합니다. 이런 구조를 사용하면 각 기능이 독립적으로 구성되어 프로젝트 확장이 쉬워집니다. 이 예제에서는 카운터 기능 하나만 있지만, 실제 복잡한 앱에서는 수백 개의 기능이 있을 수 있습니다.
+이 프로젝트는 기능 기반 디렉토리 구조를 사용합니다. 이런 구조를 사용하면 각
+기능이 독립적으로 구성되어 프로젝트 확장이 쉬워집니다. 이 예제에서는 카운터 기능
+하나만 있지만, 실제 복잡한 앱에서는 수백 개의 기능이 있을 수 있습니다.
 
 ## BlocObserver
 
-먼저 `BlocObserver`를 만들어 봅니다. 이걸 사용하면 앱 전체의 상태 변화를 관찰할 수 있습니다.
+먼저 `BlocObserver`를 만들어 봅니다. 이걸 사용하면 앱 전체의 상태 변화를 관찰할
+수 있습니다.
 
 `lib/counter_observer.dart` 파일을 생성합니다:
 
@@ -89,7 +95,8 @@ import FlutterPubGetSnippet from '~/components/tutorials/FlutterPubGetSnippet.as
 	title="lib/main.dart"
 />
 
-방금 만든 `CounterObserver`를 초기화하고, `runApp`에 다음에 만들 `CounterApp` 위젯을 전달합니다.
+방금 만든 `CounterObserver`를 초기화하고, `runApp`에 다음에 만들 `CounterApp`
+위젯을 전달합니다.
 
 ## Counter App
 
@@ -104,7 +111,10 @@ import FlutterPubGetSnippet from '~/components/tutorials/FlutterPubGetSnippet.as
 
 :::note
 
-`CounterApp`이 `MaterialApp`을 상속하는 이유는 `CounterApp` 자체가 `MaterialApp`이기 때문입니다. 대부분의 경우 `StatelessWidget`이나 `StatefulWidget`을 만들고 `build` 메서드에서 위젯을 조합하지만, 여기서는 조합할 위젯이 없어서 `MaterialApp`을 직접 상속하는 게 더 간단합니다.
+`CounterApp`이 `MaterialApp`을 상속하는 이유는 `CounterApp` 자체가
+`MaterialApp`이기 때문입니다. 대부분의 경우 `StatelessWidget`이나
+`StatefulWidget`을 만들고 `build` 메서드에서 위젯을 조합하지만, 여기서는 조합할
+위젯이 없어서 `MaterialApp`을 직접 상속하는 게 더 간단합니다.
 
 :::
 
@@ -114,7 +124,8 @@ import FlutterPubGetSnippet from '~/components/tutorials/FlutterPubGetSnippet.as
 
 `lib/counter/view/counter_page.dart` 파일을 생성합니다:
 
-`CounterPage` 위젯은 `CounterCubit`(다음에 살펴볼 예정)을 생성하고 `CounterView`에 제공하는 역할을 합니다.
+`CounterPage` 위젯은 `CounterCubit`(다음에 살펴볼 예정)을 생성하고
+`CounterView`에 제공하는 역할을 합니다.
 
 <RemoteCode
 	url="https://raw.githubusercontent.com/felangel/bloc/master/examples/flutter_counter/lib/counter/view/counter_page.dart"
@@ -123,7 +134,8 @@ import FlutterPubGetSnippet from '~/components/tutorials/FlutterPubGetSnippet.as
 
 :::note
 
-`Cubit`의 생성과 사용을 분리하는 게 중요합니다. 이렇게 하면 코드 테스트와 재사용이 훨씬 쉬워집니다.
+`Cubit`의 생성과 사용을 분리하는 게 중요합니다. 이렇게 하면 코드 테스트와
+재사용이 훨씬 쉬워집니다.
 
 :::
 
@@ -145,28 +157,36 @@ import FlutterPubGetSnippet from '~/components/tutorials/FlutterPubGetSnippet.as
 
 :::tip
 
-[VSCode Extension](https://marketplace.visualstudio.com/items?itemName=FelixAngelov.bloc)이나 [IntelliJ Plugin](https://plugins.jetbrains.com/plugin/12129-bloc)을 사용하면 Cubit을 자동으로 생성할 수 있습니다.
+[VSCode Extension](https://marketplace.visualstudio.com/items?itemName=FelixAngelov.bloc)이나
+[IntelliJ Plugin](https://plugins.jetbrains.com/plugin/12129-bloc)을 사용하면
+Cubit을 자동으로 생성할 수 있습니다.
 
 :::
 
-다음으로 상태를 사용하고 `CounterCubit`과 상호작용하는 `CounterView`를 살펴봅니다.
+다음으로 상태를 사용하고 `CounterCubit`과 상호작용하는 `CounterView`를
+살펴봅니다.
 
 ## Counter View
 
 `lib/counter/view/counter_view.dart` 파일을 생성합니다:
 
-`CounterView`는 현재 카운트 값을 표시하고, 카운터를 증가/감소시키는 두 개의 FloatingActionButton을 렌더링합니다.
+`CounterView`는 현재 카운트 값을 표시하고, 카운터를 증가/감소시키는 두 개의
+FloatingActionButton을 렌더링합니다.
 
 <RemoteCode
 	url="https://raw.githubusercontent.com/felangel/bloc/master/examples/flutter_counter/lib/counter/view/counter_view.dart"
 	title="lib/counter/view/counter_view.dart"
 />
 
-`BlocBuilder`로 `Text` 위젯을 감싸서 `CounterCubit` 상태가 바뀔 때마다 텍스트를 업데이트합니다. 또한 `context.read<CounterCubit>()`을 사용해서 가장 가까운 `CounterCubit` 인스턴스를 찾습니다.
+`BlocBuilder`로 `Text` 위젯을 감싸서 `CounterCubit` 상태가 바뀔 때마다 텍스트를
+업데이트합니다. 또한 `context.read<CounterCubit>()`을 사용해서 가장 가까운
+`CounterCubit` 인스턴스를 찾습니다.
 
 :::note
 
-`BlocBuilder`로 `Text` 위젯만 감싼 이유는 `CounterCubit` 상태 변화에 반응해서 다시 그려야 하는 위젯이 `Text`뿐이기 때문입니다. 상태 변화에 다시 그릴 필요가 없는 위젯은 불필요하게 감싸지 마세요.
+`BlocBuilder`로 `Text` 위젯만 감싼 이유는 `CounterCubit` 상태 변화에 반응해서
+다시 그려야 하는 위젯이 `Text`뿐이기 때문입니다. 상태 변화에 다시 그릴 필요가
+없는 위젯은 불필요하게 감싸지 마세요.
 
 :::
 
@@ -190,8 +210,15 @@ import FlutterPubGetSnippet from '~/components/tutorials/FlutterPubGetSnippet.as
 	title="lib/counter/counter.dart"
 />
 
-끝입니다! 프레젠테이션 레이어와 비즈니스 로직 레이어를 분리했습니다. `CounterView`는 사용자가 버튼을 누를 때 무슨 일이 일어나는지 모릅니다. 단지 `CounterCubit`에 알릴 뿐입니다. 마찬가지로 `CounterCubit`은 상태(카운터 값)가 어떻게 표시되는지 모릅니다. 메서드 호출에 대한 응답으로 새로운 상태를 emit할 뿐입니다.
+끝입니다! 프레젠테이션 레이어와 비즈니스 로직 레이어를 분리했습니다.
+`CounterView`는 사용자가 버튼을 누를 때 무슨 일이 일어나는지 모릅니다. 단지
+`CounterCubit`에 알릴 뿐입니다. 마찬가지로 `CounterCubit`은 상태(카운터 값)가
+어떻게 표시되는지 모릅니다. 메서드 호출에 대한 응답으로 새로운 상태를 emit할
+뿐입니다.
 
-`flutter run`으로 앱을 실행하면 기기나 시뮬레이터/에뮬레이터에서 확인할 수 있습니다.
+`flutter run`으로 앱을 실행하면 기기나 시뮬레이터/에뮬레이터에서 확인할 수
+있습니다.
 
-이 예제의 전체 소스 코드(단위 테스트와 위젯 테스트 포함)는 [여기](https://github.com/felangel/Bloc/tree/master/examples/flutter_counter)에서 확인할 수 있습니다.
+이 예제의 전체 소스 코드(단위 테스트와 위젯 테스트 포함)는
+[여기](https://github.com/felangel/Bloc/tree/master/examples/flutter_counter)에서
+확인할 수 있습니다.


### PR DESCRIPTION
## Summary
- Add Korean translation for the Flutter Counter tutorial
- Create `docs/src/content/docs/ko/tutorials/flutter-counter.mdx`

## Test plan
- [x] Verified docs build successfully with `npm run build`
- [x] 496 pages built including the new Korean translation