### PR TITLE
docs: add ko `flutter-timer.mdx` translations

### DIFF
--- a/docs/src/content/docs/ko/tutorials/flutter-timer.mdx
+++ b/docs/src/content/docs/ko/tutorials/flutter-timer.mdx
@@ -32,7 +32,8 @@ import BackgroundSnippet from '~/components/tutorials/flutter-timer/BackgroundSn
   제공하기.
 - [BlocBuilder](/ko/flutter-bloc-concepts#blocbuilder)로 상태 변화에 따라 위젯
   다시 그리기.
-- [Equatable](/ko/faqs#언제-equatable를-사용해야-하나요)로 불필요한 rebuild 방지하기.
+- [Equatable](/ko/faqs#언제-equatable를-사용해야-하나요)로 불필요한 rebuild
+  방지하기.
 - Bloc에서 `StreamSubscription` 사용하기.
 - `buildWhen`으로 불필요한 rebuild 방지하기.
 


### PR DESCRIPTION
## Summary
- Add Korean translation for the Flutter Timer tutorial
- Create `docs/src/content/docs/ko/tutorials/flutter-timer.mdx`

## Test plan
- [x] Verified docs build successfully