### PR TITLE
docs: Removed encouragement of simulating `MultiBlocBuilder` with mutliple `context.watch`es

### DIFF
--- a/docs/src/content/docs/ar/flutter-bloc-concepts.mdx
+++ b/docs/src/content/docs/ar/flutter-bloc-concepts.mdx
@@ -430,20 +430,6 @@ Widget build(BuildContext context) {
 }
 ```
 
-✅ **افعل** استخدام `Builder` و `context.watch` كـ `MultiBlocBuilder`.
-
-```dart
-Builder(
-  builder: (context) {
-    final stateA = context.watch<BlocA>().state;
-    final stateB = context.watch<BlocB>().state;
-    final stateC = context.watch<BlocC>().state;
-
-    // return a Widget which depends on the state of BlocA, BlocB, and BlocC
-  }
-);
-```
-
 ❌ **تجنب** استخدام `context.watch` عندما لا يعتمد الـ Widget الأب (parent
 widget) في دالة `build` على الحالة.
 

--- a/docs/src/content/docs/ar/migration.mdx
+++ b/docs/src/content/docs/ar/migration.mdx
@@ -1157,6 +1157,9 @@ Builder(
     final stateC = context.watch<BlocC>().state;
 
     // إرجاع Widget يعتمد على حالة BlocA و BlocB و BlocC
+    //
+    // يُنصح باستخدام context.select في هذا السيناريو
+    // لتحديد الأجزاء المطلوبة فقط من الحالة التي تؤدي إلى إعادة البناء
   }
 );
 ```

--- a/docs/src/content/docs/bn/flutter-bloc-concepts.mdx
+++ b/docs/src/content/docs/bn/flutter-bloc-concepts.mdx
@@ -440,21 +440,6 @@ Widget build(BuildContext context) {
 }
 ```
 
-✅ **করুন** `MultiBlocBuilder` হিসেবে `Builder` এবং `context.watch` ব্যবহার
-করুন।
-
-```dart
-Builder(
-  builder: (context) {
-    final stateA = context.watch<BlocA>().state;
-    final stateB = context.watch<BlocB>().state;
-    final stateC = context.watch<BlocC>().state;
-
-    // return a Widget which depends on the state of BlocA, BlocB, and BlocC
-  }
-);
-```
-
 ❌ **এড়িয়ে চলুন** `build` method-এ parent widget state-এর উপর নির্ভর না করলে
 `context.watch` ব্যবহার করা।
 

--- a/docs/src/content/docs/bn/migration.mdx
+++ b/docs/src/content/docs/bn/migration.mdx
@@ -1166,6 +1166,9 @@ Builder(
     final stateC = context.watch<BlocC>().state;
 
     // return a Widget which depends on the state of BlocA, BlocB, and BlocC
+    //
+    // it is encouraged to use `context.select` in this scenario to be more
+    // selective about what parts of the state you want to rebuild on
   }
 );
 ```

--- a/docs/src/content/docs/es/flutter-bloc-concepts.mdx
+++ b/docs/src/content/docs/es/flutter-bloc-concepts.mdx
@@ -414,20 +414,6 @@ Widget build(BuildContext context) {
 }
 ```
 
-✅ **USA** `Builder` y `context.watch` como `MultiBlocBuilder`.
-
-```dart
-Builder(
-  builder: (context) {
-    final stateA = context.watch<BlocA>().state;
-    final stateB = context.watch<BlocB>().state;
-    final stateC = context.watch<BlocC>().state;
-
-    // devuelve un Widget que depende del estado de BlocA, BlocB y BlocC
-  }
-);
-```
-
 ❌ **EVITA** usar `context.watch` cuando el widget padre en el método `build` no
 depende del estado.
 

--- a/docs/src/content/docs/es/migration.mdx
+++ b/docs/src/content/docs/es/migration.mdx
@@ -1189,6 +1189,9 @@ Builder(
     final stateC = context.watch<BlocC>().state;
 
     // return a Widget which depends on the state of BlocA, BlocB, and BlocC
+    //
+    // it is encouraged to use `context.select` in this scenario to be more
+    // selective about what parts of the state you want to rebuild on
   }
 );
 ```

--- a/docs/src/content/docs/fa/flutter-bloc-concepts.mdx
+++ b/docs/src/content/docs/fa/flutter-bloc-concepts.mdx
@@ -441,21 +441,6 @@ Widget build(BuildContext context) {
 }
 ```
 
-✅ **انجام دهید:** از `Builder` و `context.watch` به عنوان `MultiBlocBuilder`
-استفاده کنید.
-
-```dart
-Builder(
-  builder: (context) {
-    final stateA = context.watch<BlocA>().state;
-    final stateB = context.watch<BlocB>().state;
-    final stateC = context.watch<BlocC>().state;
-
-    // return a Widget which depends on the state of BlocA, BlocB, and BlocC
-  }
-);
-```
-
 ❌ **پرهیز کنید:** استفاده از `context.watch` وقتی ویجت والد در متد `build` به
 حالت وابسته نیست.
 

--- a/docs/src/content/docs/fa/migration.mdx
+++ b/docs/src/content/docs/fa/migration.mdx
@@ -1163,6 +1163,9 @@ Builder(
     final stateC = context.watch<BlocC>().state;
 
     // return a Widget which depends on the state of BlocA, BlocB, and BlocC
+    //
+    // it is encouraged to use `context.select` in this scenario to be more
+    // selective about what parts of the state you want to rebuild on
   }
 );
 ```

--- a/docs/src/content/docs/flutter-bloc-concepts.mdx
+++ b/docs/src/content/docs/flutter-bloc-concepts.mdx
@@ -438,20 +438,6 @@ Widget build(BuildContext context) {
 }
 ```
 
-✅ **DO** use `Builder` and `context.watch` as `MultiBlocBuilder`.
-
-```dart
-Builder(
-  builder: (context) {
-    final stateA = context.watch<BlocA>().state;
-    final stateB = context.watch<BlocB>().state;
-    final stateC = context.watch<BlocC>().state;
-
-    // return a Widget which depends on the state of BlocA, BlocB, and BlocC
-  }
-);
-```
-
 ❌ **AVOID** using `context.watch` when the parent widget in the `build` method
 doesn't depend on the state.
 

--- a/docs/src/content/docs/ko/flutter-bloc-concepts.mdx
+++ b/docs/src/content/docs/ko/flutter-bloc-concepts.mdx
@@ -402,20 +402,6 @@ Widget build(BuildContext context) {
 }
 ```
 
-✅ **DO** `Builder`와 `context.watch`를 `MultiBlocBuilder`처럼 사용하세요.
-
-```dart
-Builder(
-  builder: (context) {
-    final stateA = context.watch<BlocA>().state;
-    final stateB = context.watch<BlocB>().state;
-    final stateC = context.watch<BlocC>().state;
-
-    // return a Widget which depends on the state of BlocA, BlocB, and BlocC
-  }
-);
-```
-
 ❌ **AVOID** `build` 메서드 내의 상위 위젯이 state에 의존하지 않는 경우
 `context.watch`를 사용하지 마세요.
 

--- a/docs/src/content/docs/migration.mdx
+++ b/docs/src/content/docs/migration.mdx
@@ -1168,6 +1168,9 @@ Builder(
     final stateC = context.watch<BlocC>().state;
 
     // return a Widget which depends on the state of BlocA, BlocB, and BlocC
+    //
+    // it is encouraged to use `context.select` in this scenario to be more
+    // selective about what parts of the state you want to rebuild on
   }
 );
 ```

--- a/docs/src/content/docs/pt-br/flutter-bloc-concepts.mdx
+++ b/docs/src/content/docs/pt-br/flutter-bloc-concepts.mdx
@@ -442,20 +442,6 @@ Widget build(BuildContext context) {
 }
 ```
 
-✅ **USE** `Builder` e `context.watch` como `MultiBlocBuilder`.
-
-```dart
-Builder(
-  builder: (context) {
-    final stateA = context.watch<BlocA>().state;
-    final stateB = context.watch<BlocB>().state;
-    final stateC = context.watch<BlocC>().state;
-
-    // retorna um Widget que depende do estado de BlocA, BlocB e BlocC
-  }
-);
-```
-
 ❌ **EVITE** usar `context.watch` quando o widget pai no método `build` não
 depende do estado.
 

--- a/docs/src/content/docs/zh-cn/flutter-bloc-concepts.mdx
+++ b/docs/src/content/docs/zh-cn/flutter-bloc-concepts.mdx
@@ -393,21 +393,6 @@ Widget build(BuildContext context) {
 }
 ```
 
-✅ **建议** 将 `Builder` 和 `context.watch` 一起使用，类似于 `MultiBlocBuilder`
-的效果.
-
-```dart
-Builder(
-  builder: (context) {
-    final stateA = context.watch<BlocA>().state;
-    final stateB = context.watch<BlocB>().state;
-    final stateC = context.watch<BlocC>().state;
-
-    // 返回一个依赖于 BlocA 、BlocB, 和 BlocC 状态的 Widget。
-  }
-);
-```
-
 ❌ **避免** 使用 `context.watch` 当父 Widget 的 build 方法不依赖于状态
 
 ```dart


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

Removed mention of simulating `MultiBlocBuilder` with watching multiple blocs in a `Builder`.
In the migrations documentation I think its important to leave in, but do think its important to steer into better practices like `context.select` to avoid excessive rebuilds. 

Chose not to add `MultiBlocSelector` to the documentation as a replacement, as I think it should really be used sparingly but feel free to ask me to do this. 👍 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
