### PR TITLE
Fixing a typo in Cubit Error Handling section

### DIFF
--- a/docs/src/content/docs/bloc-concepts.mdx
+++ b/docs/src/content/docs/bloc-concepts.mdx
@@ -276,7 +276,7 @@ In `BlocObserver` we have access to the `Cubit` instance in addition to the
 
 ### Cubit Error Handling
 
-Every `Cubit` has an `addError` method which can be used to indicate that an
+Every `Cubit` has an `onError` method which can be used to indicate that an
 error has occurred.
 
 <CounterCubitOnErrorSnippet />


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

While reading the docs, came across a typo in the sentence under the subtitle "Cubit Error Handling" - "Every Cubit has an addError method which can be used to indicate that an error has occurred". I believe based on the code snippet this should say "_onError_" instead of "_addError_".

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore

## Screenshot for reference

<img width="692" height="597" alt="pr_screenshot" src="https://github.com/user-attachments/assets/6881dc8c-de60-4b5e-9fe6-2f8f722d5a81" />