### PR TITLE
fix(bloc): make isClosed return true immediately when close is called

### DIFF
--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -126,6 +126,9 @@ abstract class Bloc<Event, State> extends BlocBase<State>
     _blocObserver.onEvent(this, event);
   }
 
+  @override
+  bool get isClosed => _closed || _eventController.isClosed;
+
   /// {@template emit}
   /// **[emit] is only for internal use and should never be called directly
   /// outside of tests. The [Emitter] instance provided to each [EventHandler]
@@ -196,7 +199,7 @@ abstract class Bloc<Event, State> extends BlocBase<State>
       _eventController.stream.where((event) => event is E).cast<E>(),
       (dynamic event) {
         void onEmit(State state) {
-          if (isClosed) return;
+          if (_stateController.isClosed) return;
           if (this.state == state && _emitted) return;
           onTransition(
             Transition(

--- a/packages/bloc/lib/src/bloc_base.dart
+++ b/packages/bloc/lib/src/bloc_base.dart
@@ -69,6 +69,8 @@ abstract class BlocBase<State>
 
   bool _emitted = false;
 
+  bool _closed = false;
+
   @override
   State get state => _state;
 
@@ -80,7 +82,7 @@ abstract class BlocBase<State>
   /// A bloc is considered closed once [close] is called.
   /// Subsequent state changes cannot occur within a closed bloc.
   @override
-  bool get isClosed => _stateController.isClosed;
+  bool get isClosed => _closed;
 
   /// Updates the [state] to the provided [state].
   /// [emit] does nothing if the [state] being emitted
@@ -96,7 +98,7 @@ abstract class BlocBase<State>
   @override
   void emit(State state) {
     try {
-      if (isClosed) {
+      if (_stateController.isClosed) {
         throw StateError('Cannot emit new states after calling close');
       }
       if (state == _state && _emitted) return;
@@ -171,6 +173,7 @@ abstract class BlocBase<State>
   @mustCallSuper
   @override
   Future<void> close() async {
+    _closed = true;
     // ignore: invalid_use_of_protected_member
     _blocObserver.onClose(this);
     await _stateController.close();

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -1656,8 +1656,95 @@ void main() {
         bloc.close();
         expect(bloc.isClosed, isTrue);
       });
+
+      test(
+        'returns true during close teardown so add() guard works '
+        'in onEach callbacks',
+        () async {
+          // Reproduces https://github.com/felangel/bloc/issues/4749
+          //
+          // Scenario: a Bloc uses emit.onEach to listen to an external
+          // stream. In the onData callback, it guards add() with
+          // if (!isClosed). When the bloc is closed, the external stream
+          // may still emit data during teardown. Previously, isClosed
+          // returned false during this window (because it checked
+          // _stateController.isClosed, which closes last), causing
+          // add() to throw a StateError on the already-closed
+          // _eventController.
+          final streamController = StreamController<int>.broadcast();
+
+          final bloc = _OnEachAddBloc(streamController.stream);
+          bloc.add(const _Subscribe());
+          await tick();
+
+          // Start closing the bloc. This closes _eventController first.
+          final closeFuture = bloc.close();
+
+          // Emit data on the external stream during teardown.
+          // Without the fix, onData fires, isClosed returns false,
+          // add() throws StateError.
+          streamController.add(42);
+          await tick();
+
+          await closeFuture;
+          await streamController.close();
+
+          // The bloc should have closed without any StateError.
+          expect(bloc.isClosed, isTrue);
+          expect(bloc.addErrors, isEmpty);
+        },
+      );
     });
   });
+}
+
+abstract class _OnEachAddEvent {
+  const _OnEachAddEvent();
+}
+
+class _Subscribe extends _OnEachAddEvent {
+  const _Subscribe();
+}
+
+class _DataReceived extends _OnEachAddEvent {
+  const _DataReceived(this.value);
+  final int value;
+}
+
+class _OnEachAddBloc extends Bloc<_OnEachAddEvent, int> {
+  _OnEachAddBloc(this._stream) : super(0) {
+    on<_Subscribe>(_onSubscribe);
+    on<_DataReceived>(_onDataReceived);
+  }
+
+  final Stream<int> _stream;
+  final addErrors = <Object>[];
+
+  Future<void> _onSubscribe(
+    _Subscribe event,
+    Emitter<int> emit,
+  ) async {
+    await emit.onEach<int>(
+      _stream,
+      onData: (value) {
+        // This is the pattern from issue #4749.
+        // The user checks isClosed before calling add().
+        if (!isClosed) {
+          add(_DataReceived(value));
+        }
+      },
+    );
+  }
+
+  void _onDataReceived(_DataReceived event, Emitter<int> emit) {
+    emit(event.value);
+  }
+
+  @override
+  void onError(Object error, StackTrace stackTrace) {
+    addErrors.add(error);
+    super.onError(error, stackTrace);
+  }
 }
 
 void unawaited(Future<void> future) {}

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -1649,6 +1649,13 @@ void main() {
         await bloc.close();
         expect(bloc.isClosed, isTrue);
       });
+
+      test('returns true immediately when close is called', () {
+        final bloc = CounterBloc();
+        expect(bloc.isClosed, isFalse);
+        bloc.close();
+        expect(bloc.isClosed, isTrue);
+      });
     });
   });
 }

--- a/packages/bloc/test/cubit_test.dart
+++ b/packages/bloc/test/cubit_test.dart
@@ -297,6 +297,13 @@ void main() {
         await cubit.close();
         expect(cubit.isClosed, isTrue);
       });
+
+      test('returns true immediately when close is called', () {
+        final cubit = CounterCubit();
+        expect(cubit.isClosed, isFalse);
+        cubit.close();
+        expect(cubit.isClosed, isTrue);
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary

- Fixes a race condition where `isClosed` returned `false` during `Bloc.close()` teardown, but `add()` would throw a `StateError` because the internal `_eventController` was already closed.
- Root cause: `isClosed` was based on `_stateController.isClosed`, but `Bloc.close()` closes `_eventController` first. This created a window where checking `isClosed` before `add()` was unreliable.
- Introduces a `_closed` flag in `BlocBase` set at the start of `close()`, and overrides `isClosed` in `Bloc` to also check `_eventController.isClosed`.
- Internal `emit`/`onEmit` checks use `_stateController.isClosed` directly so in-progress event handlers can still emit states during teardown.

Closes #4749

## Test plan

- [x] All 118 existing tests pass
- [x] New test: `Bloc.isClosed` returns true immediately when `close()` is called (without await)
- [x] New test: `Cubit.isClosed` returns true immediately when `close()` is called (without await)
- [x] `dart analyze` clean (no errors or warnings)