### PR TITLE
feat: add "Don't Show Again" option in the VSCode extension

### DIFF
--- a/extensions/vscode/src/utils/analyze-dependencies.ts
+++ b/extensions/vscode/src/utils/analyze-dependencies.ts
@@ -1,6 +1,6 @@
 import * as _ from "lodash";
 import * as semver from "semver";
-import { window, env, Uri } from "vscode";
+import { window, env, Uri, workspace } from "vscode";
 import { getLatestPackageVersion, getPubspecLock } from ".";
 import { updatePubspecDependency } from "./update-pubspec-dependency";
 
@@ -90,7 +90,7 @@ function showUpdateMessage(dependency : Dependency, dependencyVersion : string) 
     window
       .showWarningMessage(
         `This workspace contains an outdated version of ${dependency.name}. Please update to ${dependency.version}.`,
-        ...dependency.actions.map((action) => action.name).concat("Update")
+        ...dependency.actions.map((action) => action.name).concat("Update", "Don't Show Again")
       )
       .then((invokedAction) => {
         if (invokedAction === "Update") {
@@ -99,6 +99,9 @@ function showUpdateMessage(dependency : Dependency, dependencyVersion : string) 
             latestVersion: `^${dependency.version}`,
             currentVersion: dependencyVersion,
           });
+        }
+        if (invokedAction === "Don't Show Again") {
+          return workspace.getConfiguration("bloc").update("checkForUpdates", false, true);
         }
         const action = dependency.actions.find(
           (action) => action.name === invokedAction


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->

Add `Don't Show Again` option in the VSCode update notification, to suppress update notification which after a while becomes annoying.

Resolves #4726  

<img width="1337" height="947" alt="dontshow" src="https://github.com/user-attachments/assets/3992ffb8-9297-49c0-9646-af6bdf9957e4" />

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
