### PR TITLE
fix(bloc_tools): add --no-version-check flag

### DIFF
--- a/packages/bloc_tools/lib/src/command_runner.dart
+++ b/packages/bloc_tools/lib/src/command_runner.dart
@@ -28,6 +28,11 @@ class BlocToolsCommandRunner extends CommandRunner<int> {
       negatable: false,
       help: 'Print the current version.',
     );
+    argParser.addFlag(
+      'no-version-check',
+      negatable: false,
+      help: 'Skip the version check.',
+    );
     addCommand(
       LanguageServerCommand(languageServerBuilder: languageServerBuilder),
     );
@@ -70,6 +75,7 @@ class BlocToolsCommandRunner extends CommandRunner<int> {
     }
     // Avoid disrupting stdout when running the language server.
     if (topLevelResults.command?.name == 'language-server') return exitCode;
+    if (topLevelResults['no-version-check'] == true) return exitCode;
     await _checkForUpdates();
     return exitCode;
   }

--- a/packages/bloc_tools/test/src/command_runner_test.dart
+++ b/packages/bloc_tools/test/src/command_runner_test.dart
@@ -26,8 +26,9 @@ const expectedUsage = [
       'Usage: bloc <command> [arguments]\n'
       '\n'
       'Global options:\n'
-      '-h, --help       Print this usage information.\n'
-      '    --version    Print the current version.\n'
+      '-h, --help                Print this usage information.\n'
+      '    --version             Print the current version.\n'
+      '    --no-version-check    Skip the version check.\n'
       '\n'
       'Available commands:\n'
       '  lint   bloc lint [arguments]\n'
@@ -206,6 +207,35 @@ void main() {
           final result = await commandRunner.run(['--version']);
           expect(result, equals(ExitCode.success.code));
           verify(() => logger.info(packageVersion)).called(1);
+        });
+      });
+
+      group('--no-version-check', () {
+        test('skips version check when flag is provided', () async {
+          when(
+            () => pubUpdater.getLatestVersion(any()),
+          ).thenAnswer((_) async => latestVersion);
+
+          when(() => logger.confirm(any())).thenReturn(false);
+
+          final result = await commandRunner.run([
+            '--no-version-check',
+            '--version',
+          ]);
+          expect(result, equals(ExitCode.success.code));
+          verifyNever(() => pubUpdater.getLatestVersion(any()));
+          verifyNever(() => logger.info(updatePrompt));
+          verifyNever(() => logger.confirm('Would you like to update?'));
+        });
+
+        test('does not update when flag is provided', () async {
+          final result = await commandRunner.run([
+            '--no-version-check',
+            '--version',
+          ]);
+          expect(result, equals(ExitCode.success.code));
+          verifyNever(() => pubUpdater.getLatestVersion(any()));
+          verifyNever(() => pubUpdater.update(packageName: any(named: 'packageName')));
         });
       });
     });


### PR DESCRIPTION
## Status
READY

## Breaking Changes
NO

## Description
Fixes #4787

Added `--no-version-check` flag to `bloc_tools` to allow users 
to skip the version check prompt in non-interactive environments 
or when the behavior is undesired.

### Usage
```sh
bloc --no-version-check new bloc my_bloc
```

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)