### PR TITLE
feat(bloc_tools): support disabling update checks

### DIFF
--- a/packages/bloc_tools/lib/src/command_runner.dart
+++ b/packages/bloc_tools/lib/src/command_runner.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:bloc_lint/bloc_lint.dart';
@@ -10,17 +12,24 @@ import 'package:pub_updater/pub_updater.dart';
 /// The package name.
 const packageName = 'bloc_tools';
 
+/// Environment variable that can be used to disable update checks.
+/// Update checks are enabled by default.
+/// To disable them, export `BLOC_UPDATE_CHECK=false`.
+const updateCheckEnv = 'BLOC_UPDATE_CHECK';
+
 /// {@template bloc_tools_command_runner}
 /// A [CommandRunner] for the Bloc Tools CLI.
 /// {@endtemplate}
 class BlocToolsCommandRunner extends CommandRunner<int> {
   /// {@macro bloc_tools_command_runner}
   BlocToolsCommandRunner({
+    Map<String, String>? environment,
     Logger? logger,
     PubUpdater? pubUpdater,
     Linter linter = const Linter(),
     LanguageServer Function()? languageServerBuilder,
-  }) : _logger = logger ?? Logger(),
+  }) : _environment = environment ?? Platform.environment,
+       _logger = logger ?? Logger(),
        _pubUpdater = pubUpdater ?? PubUpdater(),
        super('bloc', 'Command Line Tools for the Bloc Library.') {
     argParser.addFlag(
@@ -37,6 +46,7 @@ class BlocToolsCommandRunner extends CommandRunner<int> {
 
   final Logger _logger;
   final PubUpdater _pubUpdater;
+  final Map<String, String> _environment;
 
   @override
   Future<int> run(Iterable<String> args) async {
@@ -70,6 +80,7 @@ class BlocToolsCommandRunner extends CommandRunner<int> {
     }
     // Avoid disrupting stdout when running the language server.
     if (topLevelResults.command?.name == 'language-server') return exitCode;
+    if (_environment[updateCheckEnv] == 'false') return exitCode;
     await _checkForUpdates();
     return exitCode;
   }

--- a/packages/bloc_tools/lib/src/command_runner.dart
+++ b/packages/bloc_tools/lib/src/command_runner.dart
@@ -44,9 +44,9 @@ class BlocToolsCommandRunner extends CommandRunner<int> {
     addCommand(LintCommand(linter: linter, logger: _logger));
   }
 
+  final Map<String, String> _environment;
   final Logger _logger;
   final PubUpdater _pubUpdater;
-  final Map<String, String> _environment;
 
   @override
   Future<int> run(Iterable<String> args) async {

--- a/packages/bloc_tools/test/src/command_runner_test.dart
+++ b/packages/bloc_tools/test/src/command_runner_test.dart
@@ -143,6 +143,10 @@ void main() {
       });
 
       test('skips update check when $updateCheckEnv=false', () async {
+        when(
+          () => pubUpdater.getLatestVersion(any()),
+        ).thenAnswer((_) async => latestVersion);
+
         commandRunner = BlocToolsCommandRunner(
           logger: logger,
           pubUpdater: pubUpdater,

--- a/packages/bloc_tools/test/src/command_runner_test.dart
+++ b/packages/bloc_tools/test/src/command_runner_test.dart
@@ -108,6 +108,27 @@ void main() {
         verify(() => logger.confirm('Would you like to update?')).called(1);
       });
 
+      test('prompts for update when newer version exists '
+          'and $updateCheckEnv=true', () async {
+        commandRunner = BlocToolsCommandRunner(
+          logger: logger,
+          pubUpdater: pubUpdater,
+          languageServerBuilder: () => languageServer,
+          environment: {updateCheckEnv: 'true'},
+        );
+
+        when(
+          () => pubUpdater.getLatestVersion(any()),
+        ).thenAnswer((_) async => latestVersion);
+
+        when(() => logger.confirm(any())).thenReturn(false);
+
+        final result = await commandRunner.run(['--version']);
+        expect(result, equals(ExitCode.success.code));
+        verify(() => logger.info(updatePrompt)).called(1);
+        verify(() => logger.confirm('Would you like to update?')).called(1);
+      });
+
       test('skips update check when running language-server', () async {
         when(
           () => pubUpdater.getLatestVersion(any()),
@@ -116,6 +137,20 @@ void main() {
         when(() => logger.confirm(any())).thenReturn(false);
 
         final result = await commandRunner.run(['language-server']);
+        expect(result, equals(ExitCode.success.code));
+        verifyNever(() => logger.info(updatePrompt));
+        verifyNever(() => logger.confirm('Would you like to update?'));
+      });
+
+      test('skips update check when $updateCheckEnv=false', () async {
+        commandRunner = BlocToolsCommandRunner(
+          logger: logger,
+          pubUpdater: pubUpdater,
+          languageServerBuilder: () => languageServer,
+          environment: {updateCheckEnv: 'false'},
+        );
+
+        final result = await commandRunner.run(['--version']);
         expect(result, equals(ExitCode.success.code));
         verifyNever(() => logger.info(updatePrompt));
         verifyNever(() => logger.confirm('Would you like to update?'));


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->
- Adds support for disabling bloc_tools update checks by setting `BLOC_UPDATE_CHECK=false`
  - closes https://github.com/felangel/bloc/issues/4787
  
Usage
  
```sh
# one time
BLOC_UPDATE_CHECK=false bloc <command>

# per session
export BLOC_UPDATE_CHECK=false
bloc <command>

# Or update your .zshrc, .bashrc, etc. to disable update checks globally
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
