### PR TITLE
fix(bloc): isClosed returns true synchronously once close() is called

### DIFF
--- a/packages/bloc/lib/src/bloc.dart
+++ b/packages/bloc/lib/src/bloc.dart
@@ -196,7 +196,7 @@ abstract class Bloc<Event, State> extends BlocBase<State>
       _eventController.stream.where((event) => event is E).cast<E>(),
       (dynamic event) {
         void onEmit(State state) {
-          if (isClosed) return;
+          if (_stateController.isClosed) return;
           if (this.state == state && _emitted) return;
           onTransition(
             Transition(
@@ -308,6 +308,7 @@ abstract class Bloc<Event, State> extends BlocBase<State>
   @mustCallSuper
   @override
   Future<void> close() async {
+    _closed = true;
     await _eventController.close();
     for (final emitter in _emitters) {
       emitter.cancel();

--- a/packages/bloc/lib/src/bloc_base.dart
+++ b/packages/bloc/lib/src/bloc_base.dart
@@ -24,7 +24,8 @@ abstract class Closable {
 
   /// Whether the object is closed.
   ///
-  /// An object is considered closed once [close] is called.
+  /// Returns `true` synchronously once [close] has been called,
+  /// even if asynchronous teardown is still in progress.
   bool get isClosed;
 }
 
@@ -69,6 +70,8 @@ abstract class BlocBase<State>
 
   bool _emitted = false;
 
+  bool _closed = false;
+
   @override
   State get state => _state;
 
@@ -77,10 +80,11 @@ abstract class BlocBase<State>
 
   /// Whether the bloc is closed.
   ///
-  /// A bloc is considered closed once [close] is called.
+  /// A bloc is considered closed as soon as [close] is called, even before
+  /// asynchronous teardown of internal streams completes.
   /// Subsequent state changes cannot occur within a closed bloc.
   @override
-  bool get isClosed => _stateController.isClosed;
+  bool get isClosed => _closed;
 
   /// Updates the [state] to the provided [state].
   /// [emit] does nothing if the [state] being emitted
@@ -96,7 +100,7 @@ abstract class BlocBase<State>
   @override
   void emit(State state) {
     try {
-      if (isClosed) {
+      if (_stateController.isClosed) {
         throw StateError('Cannot emit new states after calling close');
       }
       if (state == _state && _emitted) return;
@@ -171,6 +175,7 @@ abstract class BlocBase<State>
   @mustCallSuper
   @override
   Future<void> close() async {
+    _closed = true;
     // ignore: invalid_use_of_protected_member
     _blocObserver.onClose(this);
     await _stateController.close();

--- a/packages/bloc/test/bloc_test.dart
+++ b/packages/bloc/test/bloc_test.dart
@@ -1649,8 +1649,118 @@ void main() {
         await bloc.close();
         expect(bloc.isClosed, isTrue);
       });
+
+      test('returns true synchronously when close is called', () {
+        final bloc = CounterBloc();
+        expect(bloc.isClosed, isFalse);
+        bloc.close();
+        expect(bloc.isClosed, isTrue);
+      });
+
+      test(
+        'returns true during close teardown so add() guard works '
+        'in onEach callbacks (regression #4749)',
+        () async {
+          final streamController = StreamController<int>.broadcast();
+          final bloc = _OnEachAddBloc(streamController.stream)
+            ..add(const _Subscribe());
+          await tick();
+
+          final closeFuture = bloc.close();
+          streamController.add(42);
+          await tick();
+
+          await closeFuture;
+          await streamController.close();
+
+          expect(bloc.isClosed, isTrue);
+          expect(bloc.addErrors, isEmpty);
+        },
+      );
+
+      test(
+        'in-flight event handler can still emit during close teardown',
+        () async {
+          final resume = Completer<void>();
+          final bloc = _TeardownEmitBloc(resume);
+          final states = <int>[];
+          final subscription = bloc.stream.listen(states.add);
+
+          bloc.add(const _StartLongHandler());
+          await tick();
+
+          final closeFuture = bloc.close();
+          resume.complete();
+
+          await closeFuture;
+          await subscription.cancel();
+
+          expect(states, [99]);
+        },
+      );
     });
   });
+}
+
+abstract class _OnEachAddEvent {
+  const _OnEachAddEvent();
+}
+
+class _Subscribe extends _OnEachAddEvent {
+  const _Subscribe();
+}
+
+class _DataReceived extends _OnEachAddEvent {
+  const _DataReceived(this.value);
+  final int value;
+}
+
+class _OnEachAddBloc extends Bloc<_OnEachAddEvent, int> {
+  _OnEachAddBloc(this._stream) : super(0) {
+    on<_Subscribe>(_onSubscribe);
+    on<_DataReceived>(_onDataReceived);
+  }
+
+  final Stream<int> _stream;
+  final addErrors = <Object>[];
+
+  Future<void> _onSubscribe(_Subscribe event, Emitter<int> emit) async {
+    await emit.onEach<int>(
+      _stream,
+      onData: (value) {
+        if (!isClosed) add(_DataReceived(value));
+      },
+    );
+  }
+
+  void _onDataReceived(_DataReceived event, Emitter<int> emit) {
+    emit(event.value);
+  }
+
+  @override
+  void onError(Object error, StackTrace stackTrace) {
+    addErrors.add(error);
+    super.onError(error, stackTrace);
+  }
+}
+
+abstract class _TeardownEmitEvent {
+  const _TeardownEmitEvent();
+}
+
+class _StartLongHandler extends _TeardownEmitEvent {
+  const _StartLongHandler();
+}
+
+class _TeardownEmitBloc extends Bloc<_TeardownEmitEvent, int> {
+  _TeardownEmitBloc(this._resume) : super(0) {
+    on<_StartLongHandler>((event, emit) async {
+      await _resume.future;
+      emit(99);
+    });
+  }
+
+  final Completer<void> _resume;
 }
 
 void unawaited(Future<void> future) {}

--- a/packages/bloc/test/cubit_test.dart
+++ b/packages/bloc/test/cubit_test.dart
@@ -297,6 +297,13 @@ void main() {
         await cubit.close();
         expect(cubit.isClosed, isTrue);
       });
+
+      test('returns true synchronously when close is called', () {
+        final cubit = CounterCubit();
+        expect(cubit.isClosed, isFalse);
+        cubit.close();
+        expect(cubit.isClosed, isTrue);
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary

Fixes #4749 — `Bloc.isClosed` returned `false` for a brief window during `close()` teardown, causing `add()` calls guarded by `if (!isClosed)` to throw `Bad state: Cannot add new events after calling close`.

## Root cause

`BlocBase.isClosed` was defined as `_stateController.isClosed`, but `Bloc.close()` closes `_eventController` first and `_stateController` only at the end via `super.close()`. Between those two operations, `isClosed` returned `false` while `_eventController.add()` would already throw — violating the documented `Closable` contract: _"An object is considered closed once `close` is called."_

## Fix

Track close state with a synchronous `_closed` flag in `BlocBase`, set as the first line of both `BlocBase.close()` and `Bloc.close()`. `isClosed` now returns `_closed`, which flips synchronously when `close()` is invoked.

Internal `emit` / `onEmit` guards switched to `_stateController.isClosed` directly so in-flight event handlers can still emit final states during teardown (no behavior regression).

## Reproduction (fails before this fix, passes after)

```dart
import 'dart:async';
import 'package:bloc/bloc.dart';

abstract class MyEvent {}
class Subscribe extends MyEvent {}
class DataReceived extends MyEvent {
  DataReceived(this.value);
  final int value;
}

class MyBloc extends Bloc<MyEvent, int> {
  MyBloc(this._stream) : super(0) {
    on<Subscribe>((event, emit) async {
      await emit.onEach<int>(
        _stream,
        onData: (value) {
          if (!isClosed) add(DataReceived(value));
        },
      );
    });
    on<DataReceived>((event, emit) => emit(event.value));
  }
  final Stream<int> _stream;
}

Future<void> main() async {
  final controller = StreamController<int>.broadcast();
  final bloc = MyBloc(controller.stream);

  bloc.add(Subscribe());
  await Future<void>.delayed(Duration.zero);

  // Close while the stream subscription is active.
  final closeFuture = bloc.close();

  // Stream emits during close teardown.
  // Before the fix: isClosed returns false, add() throws StateError.
  // After the fix:  isClosed returns true,  add() is correctly skipped.
  controller.add(42);

  await closeFuture;
  await controller.close();
  print('Done. isClosed: \${bloc.isClosed}');
}
```

### Steps to reproduce in this repo

1. `git checkout master`
2. Save the snippet above as `packages/bloc/example/repro.dart`
3. `dart run packages/bloc/example/repro.dart` — observe `Bad state: Cannot add new events after calling close`
4. `git checkout fix/bloc-isclosed-sync`
5. Re-run — completes cleanly with `Done. isClosed: true`

## Test plan

- [x] All existing `bloc` tests pass (86 total, 4 new)
- [x] All `bloc_test` tests pass (119)
- [x] All `bloc_concurrency` tests pass (5)
- [x] `dart analyze` clean
- [x] New: `Bloc.isClosed` returns true synchronously when `close()` is called
- [x] New: `Cubit.isClosed` returns true synchronously when `close()` is called
- [x] New: regression test for #4749 (`emit.onEach` + `add()` during teardown)
- [x] New: in-flight event handler can still emit during close teardown (locks in the `_stateController.isClosed` choice for the internal guard, preventing future regressions)

## Notes

- `Bloc.isClosed` semantics shift: it now flips synchronously when `close()` is called, rather than after `_stateController` finishes closing. This restores the documented `Closable.isClosed` contract.
- `Closable.isClosed` dartdoc updated to specify "synchronously once `close()` has been called".
- Patch-level fix; no public API additions.

## Relationship to #4759

@ersanKolay opened #4759 with a similar fix using a `_closed || _eventController.isClosed` override on `Bloc.isClosed`. This PR uses the same `_closed` flag but also sets it at the top of `Bloc.close()`, so the flag alone is sufficient — no `Bloc.isClosed` override needed. Net diff is ~3 lines smaller and removes an implicit dependency on `StreamController.isClosed` flipping synchronously after `close()`. Either approach fixes the bug — happy to defer to whichever the maintainers prefer.

Closes #4749