### PR TITLE
docs: clarify per-handler event transformer semantics (#3248)

### DIFF
--- a/docs/src/content/docs/bloc-concepts.mdx
+++ b/docs/src/content/docs/bloc-concepts.mdx
@@ -622,5 +622,39 @@ opinionated set of event transformers.
 
 :::
 
+#### Per-Handler Event Transformers
+
+Each event handler registered via `on<E>()` operates on its own independent
+stream pipeline. Internally, every call to `on<E>()` filters the shared event
+stream by the event type `E` and applies the specified transformer to that
+filtered sub-stream. As a result, different handlers with different transformers
+run completely independently — there is no cross-handler coordination.
+
+For example, if a single `Bloc` has two handlers — one with `sequential` and
+another with `restartable` — the two handlers will not affect each other's event
+queues or execution order:
+
+```dart
+class SearchBloc extends Bloc<SearchEvent, SearchState> {
+  SearchBloc() : super(const SearchState()) {
+    // Uses sequential transformer: events of this type are processed
+    // one at a time in FIFO order.
+    on<SearchQueryChanged>(_onQueryChanged, transformer: sequential());
+
+    // Uses restartable transformer: if a new ClearSearch event arrives
+    // before the previous one completes, the previous handler is cancelled.
+    on<ClearSearch>(_onClearSearch, transformer: restartable());
+  }
+}
+```
+
+In the example above, `SearchQueryChanged` events are guaranteed to be handled
+sequentially relative to each other, and `ClearSearch` events use restartable
+semantics — but the two handlers never block or interfere with one another.
+
+Similarly, when a transformer's documentation says "there is no event handler
+overlap" (as in `sequential`), it refers only to invocations of that specific
+handler — not to other handlers registered on the same `Bloc`.
+
 If you are unsure about which to use, start with `Cubit` and you can later
 refactor or scale-up to a `Bloc` as needed.

--- a/packages/bloc_concurrency/lib/src/concurrent.dart
+++ b/packages/bloc_concurrency/lib/src/concurrent.dart
@@ -3,10 +3,14 @@ import 'package:stream_transform/stream_transform.dart';
 
 /// Process events concurrently.
 ///
-/// **Note**: there may be event handler overlap and state changes will occur
-/// as soon as they are emitted. This means that states may be emitted in
-/// an order that does not match the order in which the corresponding events
-/// were added.
+/// **Note**: there may be overlap between invocations of the same handler
+/// and state changes will occur as soon as they are emitted. This means that
+/// states may be emitted in an order that does not match the order in which
+/// the corresponding events were added.
+///
+/// This guarantee applies only to the specific handler using this
+/// transformer. Different handlers registered on the same [Bloc] operate
+/// on independent stream pipelines and do not affect each other.
 EventTransformer<Event> concurrent<Event>() {
   return (events, mapper) => events.concurrentAsyncExpand(mapper);
 }

--- a/packages/bloc_concurrency/lib/src/droppable.dart
+++ b/packages/bloc_concurrency/lib/src/droppable.dart
@@ -6,6 +6,10 @@ import 'package:bloc/bloc.dart';
 /// until the current event is done.
 ///
 /// **Note**: dropped events never trigger the event handler.
+///
+/// This guarantee applies only to the specific handler using this
+/// transformer. Different handlers registered on the same [Bloc] operate
+/// on independent stream pipelines and do not affect each other.
 EventTransformer<Event> droppable<Event>() {
   return (events, mapper) {
     return events.transform(_ExhaustMapStreamTransformer(mapper));

--- a/packages/bloc_concurrency/lib/src/restartable.dart
+++ b/packages/bloc_concurrency/lib/src/restartable.dart
@@ -7,8 +7,13 @@ import 'package:stream_transform/stream_transform.dart';
 /// Avoid using [restartable] if you expect an event to have
 /// immediate results -- it should only be used with asynchronous APIs.
 ///
-/// **Note**: there is no event handler overlap and any currently running tasks
-/// will be aborted if a new event is added before a prior one completes.
+/// **Note**: there is no overlap between invocations of the same handler
+/// and any currently running handler will be cancelled if a new event is
+/// added before it completes.
+///
+/// This guarantee applies only to the specific handler using this
+/// transformer. Different handlers registered on the same [Bloc] operate
+/// on independent stream pipelines and do not affect each other.
 EventTransformer<Event> restartable<Event>() {
   return (events, mapper) => events.switchMap(mapper);
 }

--- a/packages/bloc_concurrency/lib/src/sequential.dart
+++ b/packages/bloc_concurrency/lib/src/sequential.dart
@@ -3,8 +3,13 @@ import 'package:bloc/bloc.dart';
 /// Process events one at a time by maintaining a queue of added events
 /// and processing the events sequentially.
 ///
-/// **Note**: there is no event handler overlap and every event is guaranteed
-/// to be handled in the order it was received.
+/// **Note**: there is no overlap between invocations of the same handler
+/// and every event of this type is guaranteed to be handled in the order
+/// it was received.
+///
+/// This guarantee applies only to the specific handler using this
+/// transformer. Different handlers registered on the same [Bloc] operate
+/// on independent stream pipelines and do not affect each other.
 EventTransformer<Event> sequential<Event>() {
   return (events, mapper) => events.asyncExpand(mapper);
 }


### PR DESCRIPTION
## Status
READY
## Breaking Changes
NO
## Description
Each registered event handler operates on its own independent stream pipeline. Different handlers with different transformers do not affect each other's execution.
### Changes
- Add `Per-Handler Event Transformers` section to `bloc-concepts.mdx` explaining each `on<E>()` call creates an independent subscription that filters the shared event stream by type and applies its own transformer, with a Dart example showing two handlers with different transformers on the same Bloc.
- Clarify doc comments in all `bloc_concurrency` transformers (`sequential`, `restartable`, `droppable`, `concurrent`) that their guarantees apply per-handler, not across handlers.
- Clarify that "no event handler overlap" refers to the specific handler using the transformer, not other handlers registered on the same Bloc.
### Related Issues
Part of #3248
## Type of Change
- [ ] ✨ New feature
- [ ] 🛠️ Bug fix
- [ ] ❌ Breaking change
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore