### PR TITLE
docs: pt-br translations for testing, migration, and FAQs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -63,6 +63,7 @@ export default defineConfig({
 						ru: 'Введение',
 						tr: 'Giriş',
 						uk: 'Вступ',
+						'pt-BR': 'Introdução',
 					},
 					items: [
 						{
@@ -77,6 +78,7 @@ export default defineConfig({
 								ru: 'Начало работы',
 								tr: 'Başlarken',
 								uk: 'Початок роботи',
+								'pt-BR': 'Começando',
 							},
 						},
 						{
@@ -91,6 +93,7 @@ export default defineConfig({
 								ru: 'Почему Bloc?',
 								tr: 'Neden Bloc?',
 								uk: 'Чому Bloc?',
+								'pt-BR': 'Por que Bloc?',
 							},
 						},
 						{
@@ -105,6 +108,7 @@ export default defineConfig({
 								ru: 'Концепции Bloc',
 								tr: 'Bloc Kavramları',
 								uk: 'Концепції Bloc',
+								'pt-BR': 'Conceitos do Bloc',
 							},
 						},
 						{
@@ -119,6 +123,7 @@ export default defineConfig({
 								ru: 'Концепции Flutter Bloc',
 								tr: 'Flutter Bloc Kavramları',
 								uk: 'Концепції Flutter Bloc',
+								'pt-BR': 'Conceitos do Flutter Bloc',
 							},
 						},
 						{
@@ -132,6 +137,7 @@ export default defineConfig({
 								ru: 'Архитектура',
 								tr: 'Mimari',
 								uk: 'Архітектура',
+								'pt-BR': 'Arquitetura',
 							},
 						},
 						{
@@ -145,6 +151,7 @@ export default defineConfig({
 								ru: 'Моделирование состояния',
 								tr: 'Durum Modelleme',
 								uk: 'Моделювання стану',
+								'pt-BR': 'Modelagem de Estado',
 							},
 						},
 						{
@@ -158,6 +165,7 @@ export default defineConfig({
 								ru: 'Тестирование',
 								tr: 'Test Etme',
 								uk: 'Тестування',
+								'pt-BR': 'Testes',
 							},
 						},
 						{
@@ -171,6 +179,7 @@ export default defineConfig({
 								ru: 'Соглашения об именовании',
 								tr: 'Adlandırma Kuralları',
 								uk: 'Угоди про іменування',
+								'pt-BR': 'Convenções de Nomenclatura',
 							},
 						},
 						{
@@ -184,6 +193,7 @@ export default defineConfig({
 								ru: 'Руководство по миграции',
 								tr: 'Geçiş Rehberi',
 								uk: 'Посібник з міграції',
+								'pt-BR': 'Guia de Migração',
 							},
 						},
 						{
@@ -197,6 +207,7 @@ export default defineConfig({
 								ru: 'Часто задаваемые вопросы',
 								tr: 'SSS',
 								uk: 'Часті запитання',
+								'pt-BR': 'FAQs',
 							},
 						},
 					],
@@ -204,7 +215,7 @@ export default defineConfig({
 				{
 					label: 'Linter',
 					badge: { text: 'new' },
-					translations: { ar: 'المدقق', tr: 'Linter', uk: 'Лінтер' },
+					translations: { ar: 'المدقق', tr: 'Linter', uk: 'Лінтер', 'pt-BR': 'Linter' },
 					items: [
 						{
 							label: 'Overview ',
@@ -215,6 +226,7 @@ export default defineConfig({
 								ru: 'Обзор',
 								tr: 'Genel Bakış',
 								uk: 'Огляд',
+								'pt-BR': 'Visão Geral',
 							},
 						},
 						{
@@ -226,6 +238,7 @@ export default defineConfig({
 								ru: 'Установка',
 								tr: 'Kurulum',
 								uk: 'Встановлення',
+								'pt-BR': 'Instalação',
 							},
 						},
 						{
@@ -237,6 +250,7 @@ export default defineConfig({
 								ru: 'Конфигурация',
 								tr: 'Yapılandırma',
 								uk: 'Конфігурація',
+								'pt-BR': 'Configuração',
 							},
 						},
 						{
@@ -248,6 +262,7 @@ export default defineConfig({
 								ru: 'Настройка правил',
 								tr: 'Kuralları Özelleştirme',
 								uk: 'Налаштування правил',
+								'pt-BR': 'Personalizando Regras',
 							},
 						},
 						{
@@ -259,6 +274,7 @@ export default defineConfig({
 								ru: 'Правила',
 								tr: 'Kurallar',
 								uk: 'Правила',
+								'pt-BR': 'Regras',
 							},
 						},
 					],
@@ -273,6 +289,7 @@ export default defineConfig({
 						ru: 'Руководства',
 						tr: 'Eğitimler',
 						uk: 'Посібники',
+						'pt-BR': 'Tutoriais',
 					},
 					autogenerate: { directory: 'tutorials' },
 				},
@@ -286,6 +303,7 @@ export default defineConfig({
 						ru: 'Инструменты',
 						tr: 'Araçlar',
 						uk: 'Інструменти',
+						'pt-BR': 'Ferramentas',
 					},
 					items: [
 						{
@@ -298,6 +316,7 @@ export default defineConfig({
 								ru: 'Плагин IntelliJ',
 								tr: 'IntelliJ Eklentisi',
 								uk: 'Плагін IntelliJ',
+								'pt-BR': 'Plugin do IntelliJ',
 							},
 						},
 						{
@@ -310,6 +329,7 @@ export default defineConfig({
 								ru: 'Расширение VSCode',
 								tr: 'VSCode Eklentisi',
 								uk: 'Розширення VSCode',
+								'pt-BR': 'Extensão do VSCode',
 							},
 						},
 					],
@@ -324,6 +344,7 @@ export default defineConfig({
 						ru: 'Справочник',
 						tr: 'Referans',
 						uk: 'Довідник',
+						'pt-BR': 'Referência',
 					},
 					items: [
 						{

--- a/docs/src/content/docs/pt-br/faqs.mdx
+++ b/docs/src/content/docs/pt-br/faqs.mdx
@@ -1,0 +1,251 @@
+---
+title: FAQs
+description: Respostas a perguntas frequentes sobre a biblioteca bloc.
+---
+
+import StateNotUpdatingGood1Snippet from '~/components/faqs/StateNotUpdatingGood1Snippet.astro';
+import StateNotUpdatingGood2Snippet from '~/components/faqs/StateNotUpdatingGood2Snippet.astro';
+import StateNotUpdatingGood3Snippet from '~/components/faqs/StateNotUpdatingGood3Snippet.astro';
+import StateNotUpdatingBad1Snippet from '~/components/faqs/StateNotUpdatingBad1Snippet.astro';
+import StateNotUpdatingBad2Snippet from '~/components/faqs/StateNotUpdatingBad2Snippet.astro';
+import StateNotUpdatingBad3Snippet from '~/components/faqs/StateNotUpdatingBad3Snippet.astro';
+import EquatableEmitSnippet from '~/components/faqs/EquatableEmitSnippet.astro';
+import EquatableBlocTestSnippet from '~/components/faqs/EquatableBlocTestSnippet.astro';
+import NoEquatableBlocTestSnippet from '~/components/faqs/NoEquatableBlocTestSnippet.astro';
+import SingleStateSnippet from '~/components/faqs/SingleStateSnippet.astro';
+import SingleStateUsageSnippet from '~/components/faqs/SingleStateUsageSnippet.astro';
+import BlocProviderGood1Snippet from '~/components/faqs/BlocProviderGood1Snippet.astro';
+import BlocProviderGood2Snippet from '~/components/faqs/BlocProviderGood2Snippet.astro';
+import BlocProviderBad1Snippet from '~/components/faqs/BlocProviderBad1Snippet.astro';
+import BlocInternalAddEventSnippet from '~/components/faqs/BlocInternalAddEventSnippet.astro';
+import BlocInternalEventSnippet from '~/components/faqs/BlocInternalEventSnippet.astro';
+import BlocExternalForEachSnippet from '~/components/faqs/BlocExternalForEachSnippet.astro';
+
+## O Estado Não Está Atualizando
+
+❔ **Pergunta**: Estou emitindo um estado no meu bloc, mas a UI não está
+atualizando. O que estou fazendo de errado?
+
+💡 **Resposta**: Se você estiver usando Equatable, certifique-se de passar todas
+as propriedades para o getter `props`.
+
+✅ **BOM**
+
+<StateNotUpdatingGood1Snippet />
+
+❌ **RUIM**
+
+<StateNotUpdatingBad1Snippet />
+
+<StateNotUpdatingBad2Snippet />
+
+Além disso, certifique-se de que você está emitindo uma nova instância do estado
+em seu bloc.
+
+✅ **BOM**
+
+<StateNotUpdatingGood2Snippet />
+
+<StateNotUpdatingGood3Snippet />
+
+❌ **RUIM**
+
+<StateNotUpdatingBad3Snippet />
+
+:::caution
+
+As propriedades de um `Equatable` devem sempre ser copiadas em vez de
+modificadas. Se uma classe `Equatable` contém uma `List` ou `Map` como
+propriedades, certifique-se de usar `List.of` ou `Map.of` respectivamente para
+garantir que a igualdade seja avaliada com base nos valores das propriedades e
+não na referência.
+
+:::
+
+## Quando usar o Equatable
+
+❔**Pergunta**: Quando devo usar o Equatable?
+
+💡**Resposta**:
+
+<EquatableEmitSnippet />
+
+No cenário acima, se `StateA` estender `Equatable`, apenas uma mudança de estado
+ocorrerá (a segunda emissão será ignorada). Em geral, você deve usar `Equatable`
+se quiser otimizar seu código para reduzir o número de reconstruções. Você não
+deve usar `Equatable` se quiser que o mesmo estado emitido consecutivamente
+acione múltiplas transições.
+
+Além disso, usar `Equatable` torna muito mais fácil testar blocs, pois podemos
+esperar instâncias específicas de estados de bloc em vez de usar `Matchers` ou
+`Predicates`.
+
+<EquatableBlocTestSnippet />
+
+Sem `Equatable`, o teste acima falharia e precisaria ser reescrito assim:
+
+<NoEquatableBlocTestSnippet />
+
+## Tratamento de Erros
+
+❔ **Pergunta**: Como posso lidar com um erro enquanto ainda mostro os dados
+anteriores?
+
+💡 **Resposta**:
+
+Isso depende muito de como o estado do bloc foi modelado. Em casos onde os dados
+ainda devem ser mantidos mesmo na presença de um erro, considere usar uma única
+classe de estado.
+
+<SingleStateSnippet />
+
+Isso permitirá que os widgets tenham acesso às propriedades `data` e `error`
+simultaneamente, e o bloc pode usar `state.copyWith` para reter os dados antigos
+mesmo quando um erro ocorrer.
+
+<SingleStateUsageSnippet />
+
+## Bloc vs. Redux
+
+❔ **Pergunta**: Qual é a diferença entre Bloc e Redux?
+
+💡 **Resposta**:
+
+BLoC é um padrão de arquitetura definido pelas seguintes regras:
+
+1. As entradas e saídas do BLoC são streams e sinks simples.
+2. As dependências devem ser injetáveis e independentes de plataforma.
+3. Não é permitida ramificação (branching) específica de plataforma.
+4. A implementação pode ser o que você quiser, desde que siga as regras acima.
+
+As diretrizes de UI são:
+
+1. Cada componente "suficientemente complexo" possui um BLoC correspondente.
+2. Os componentes devem enviar as entradas "como estão".
+3. Os componentes devem mostrar as saídas o mais próximo possível de "como
+   estão".
+4. Toda a ramificação de fluxo deve ser baseada em saídas booleanas simples do
+   BLoC.
+
+A Biblioteca Bloc implementa o Padrão de Arquitetura BLoC e visa abstrair o
+RxDart a fim de simplificar a experiência do desenvolvedor.
+
+Os três princípios do Redux são:
+
+1. Única fonte de verdade (Single source of truth)
+2. O estado é somente leitura (State is read-only)
+3. As alterações são feitas com funções puras (Changes are made with pure
+   functions)
+
+A biblioteca bloc viola o primeiro princípio; com o bloc, o estado é distribuído
+entre múltiplos blocs. Além disso, não há o conceito de middleware no bloc, e o
+bloc foi projetado para tornar alterações assíncronas de estado muito fáceis,
+permitindo que você emita múltiplos estados para um único evento.
+
+## Bloc vs. Provider
+
+❔ **Pergunta**: Qual é a diferença entre Bloc e Provider?
+
+💡 **Resposta**: O `provider` é projetado para injeção de dependência (ele
+encapsula o `InheritedWidget`). Você ainda precisa definir como gerenciar seu
+estado (via `ChangeNotifier`, `Bloc`, `Mobx`, etc.). A Biblioteca Bloc usa o
+`provider` internamente para facilitar o fornecimento e o acesso a blocs ao
+longo da árvore de widgets.
+
+## BlocProvider.of() Falha ao Encontrar o Bloc
+
+❔ **Pergunta**: Ao usar `BlocProvider.of(context)` o bloc não é encontrado.
+Como posso corrigir isso?
+
+💡 **Resposta**: Você não pode acessar um bloc a partir do mesmo contexto em que
+ele foi fornecido, portanto, certifique-se de que o `BlocProvider.of()` seja
+chamado dentro de um `BuildContext` filho.
+
+✅ **BOM**
+
+<BlocProviderGood1Snippet />
+
+<BlocProviderGood2Snippet />
+
+❌ **RUIM**
+
+<BlocProviderBad1Snippet />
+
+## Estrutura do Projeto
+
+❔ **Pergunta**: Como devo estruturar meu projeto?
+
+💡 **Resposta**: Embora não exista realmente uma resposta certa ou errada para
+essa pergunta, algumas referências recomendadas são:
+
+- [I/O Photobooth](https://github.com/flutter/photobooth)
+- [I/O Pinball](https://github.com/flutter/pinball)
+- [Flutter News Toolkit](https://github.com/flutter/news_toolkit)
+
+O mais importante é ter uma estrutura de projeto **consistente** e
+**intencional**.
+
+## Adicionando Eventos dentro de um Bloc
+
+❔ **Pergunta**: É correto adicionar eventos dentro de um bloc?
+
+💡 **Resposta**: Na maioria dos casos, os eventos devem ser adicionados
+externamente, mas em alguns casos específicos pode fazer sentido adicionar
+eventos internamente.
+
+A situação mais comum em que eventos internos são usados é quando as mudanças de
+estado devem ocorrer em resposta a atualizações em tempo real de um repositório.
+Nessas situações, o repositório é o estímulo para a mudança de estado, em vez de
+um evento externo, como o toque em um botão.
+
+No exemplo a seguir, o estado de `MyBloc` é dependente do usuário atual, que é
+exposto através de um `Stream<User>` do `UserRepository`. O `MyBloc` escuta as
+mudanças no usuário atual e adiciona um evento interno `_UserChanged` sempre que
+um usuário é emitido a partir do stream de usuários.
+
+<BlocInternalAddEventSnippet />
+
+Ao adicionar um evento interno, também podemos especificar um `transformer`
+personalizado para o evento a fim de determinar como múltiplos eventos
+`_UserChanged` serão processados — por padrão, eles serão processados
+concorrentemente.
+
+É altamente recomendável que eventos internos sejam privados. Essa é uma maneira
+explícita de sinalizar que um evento específico é usado apenas dentro do próprio
+bloc e impede que componentes externos saibam sobre o evento.
+
+<BlocInternalEventSnippet />
+
+Como alternativa, podemos definir um evento externo `Started` e usar a API
+`emit.forEach` para lidar com a reação a atualizações de usuários em tempo real:
+
+<BlocExternalForEachSnippet />
+
+Os benefícios da abordagem acima são:
+
+- Não precisamos de um evento interno `_UserChanged`
+- Não precisamos gerenciar o `StreamSubscription` manualmente
+- Temos controle total sobre quando o bloc se inscreve no stream de atualizações
+  de usuários
+
+As desvantagens da abordagem acima são:
+
+- Não podemos pausar (`pause`) ou resumir (`resume`) facilmente a inscrição
+- Precisamos expor um evento público `Started` que deve ser adicionado
+  externamente
+- Não podemos usar um `transformer` personalizado para ajustar como reagimos às
+  atualizações de usuários
+
+## Expondo Métodos Públicos
+
+❔ **Pergunta**: É correto expor métodos públicos em minhas instâncias de bloc e
+cubit?
+
+💡 **Resposta**:
+
+Ao criar um cubit, é recomendado expor apenas métodos públicos para fins de
+acionamento de mudanças de estado. Como resultado, geralmente todos os métodos
+públicos em uma instância de cubit devem retornar `void` ou `Future<void>`.
+
+Ao criar um bloc, é recomendado evitar expor quaisquer métodos públicos
+personalizados e, em vez disso, notificar o bloc sobre eventos chamando `add`.

--- a/docs/src/content/docs/pt-br/getting-started.mdx
+++ b/docs/src/content/docs/pt-br/getting-started.mdx
@@ -10,17 +10,17 @@ import ImportTabs from '~/components/getting-started/ImportTabs.astro';
 
 O ecossistema do bloc consiste nos vários pacotes listados abaixo:
 
-| Pacote                                                                                     | Descrição                    | Link                                                                                                           |
-| ------------------------------------------------------------------------------------------ | ---------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| [angular_bloc](https://github.com/felangel/bloc/tree/master/packages/angular_bloc)         | Componentes AngularDart      | [![pub package](https://img.shields.io/pub/v/angular_bloc.svg)](https://pub.dev/packages/angular_bloc)         |
-| [bloc](https://github.com/felangel/bloc/tree/master/packages/bloc)                         | APIs Centrais do Dart        | [![pub package](https://img.shields.io/pub/v/bloc.svg)](https://pub.dev/packages/bloc)                         |
-| [bloc_concurrency](https://github.com/felangel/bloc/tree/master/packages/bloc_concurrency) | Transformadores de Eventos   | [![pub package](https://img.shields.io/pub/v/bloc_concurrency.svg)](https://pub.dev/packages/bloc_concurrency) |
-| [bloc_lint](https://github.com/felangel/bloc/tree/master/packages/bloc_lint)               | Custom Linter                | [![pub package](https://img.shields.io/pub/v/bloc_lint.svg)](https://pub.dev/packages/bloc_lint)               |
-| [bloc_test](https://github.com/felangel/bloc/tree/master/packages/bloc_test)               | APIs de Teste                | [![pub package](https://img.shields.io/pub/v/bloc_test.svg)](https://pub.dev/packages/bloc_test)               |
-| [bloc_tools](https://github.com/felangel/bloc/tree/master/packages/bloc_tools)             | Command-line Tools           | [![pub package](https://img.shields.io/pub/v/bloc_tools.svg)](https://pub.dev/packages/bloc_tools)             |
-| [flutter_bloc](https://github.com/felangel/bloc/tree/master/packages/flutter_bloc)         | Widgets do Flutter           | [![pub package](https://img.shields.io/pub/v/flutter_bloc.svg)](https://pub.dev/packages/flutter_bloc)         |
-| [hydrated_bloc](https://github.com/felangel/bloc/tree/master/packages/hydrated_bloc)       | Suporte a Cache/Persistência | [![pub package](https://img.shields.io/pub/v/hydrated_bloc.svg)](https://pub.dev/packages/hydrated_bloc)       |
-| [replay_bloc](https://github.com/felangel/bloc/tree/master/packages/replay_bloc)           | Suporte a Desfazer/Refazer   | [![pub package](https://img.shields.io/pub/v/replay_bloc.svg)](https://pub.dev/packages/replay_bloc)           |
+| Pacote                                                                                     | Descrição                       | Link                                                                                                           |
+| ------------------------------------------------------------------------------------------ | ------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| [angular_bloc](https://github.com/felangel/bloc/tree/master/packages/angular_bloc)         | Componentes AngularDart         | [![pub package](https://img.shields.io/pub/v/angular_bloc.svg)](https://pub.dev/packages/angular_bloc)         |
+| [bloc](https://github.com/felangel/bloc/tree/master/packages/bloc)                         | APIs Centrais do Dart           | [![pub package](https://img.shields.io/pub/v/bloc.svg)](https://pub.dev/packages/bloc)                         |
+| [bloc_concurrency](https://github.com/felangel/bloc/tree/master/packages/bloc_concurrency) | Transformadores de Eventos      | [![pub package](https://img.shields.io/pub/v/bloc_concurrency.svg)](https://pub.dev/packages/bloc_concurrency) |
+| [bloc_lint](https://github.com/felangel/bloc/tree/master/packages/bloc_lint)               | Custom Linter                   | [![pub package](https://img.shields.io/pub/v/bloc_lint.svg)](https://pub.dev/packages/bloc_lint)               |
+| [bloc_test](https://github.com/felangel/bloc/tree/master/packages/bloc_test)               | APIs de Teste                   | [![pub package](https://img.shields.io/pub/v/bloc_test.svg)](https://pub.dev/packages/bloc_test)               |
+| [bloc_tools](https://github.com/felangel/bloc/tree/master/packages/bloc_tools)             | Ferramentas de Linha de Comando | [![pub package](https://img.shields.io/pub/v/bloc_tools.svg)](https://pub.dev/packages/bloc_tools)             |
+| [flutter_bloc](https://github.com/felangel/bloc/tree/master/packages/flutter_bloc)         | Widgets do Flutter              | [![pub package](https://img.shields.io/pub/v/flutter_bloc.svg)](https://pub.dev/packages/flutter_bloc)         |
+| [hydrated_bloc](https://github.com/felangel/bloc/tree/master/packages/hydrated_bloc)       | Suporte a Cache/Persistência    | [![pub package](https://img.shields.io/pub/v/hydrated_bloc.svg)](https://pub.dev/packages/hydrated_bloc)       |
+| [replay_bloc](https://github.com/felangel/bloc/tree/master/packages/replay_bloc)           | Suporte a Desfazer/Refazer      | [![pub package](https://img.shields.io/pub/v/replay_bloc.svg)](https://pub.dev/packages/replay_bloc)           |
 
 ## Instalação
 
@@ -33,7 +33,7 @@ Para começar a usar o bloc, é necessário ter o
 
 :::
 
-## Importes
+## Importações
 
 Agora que instalamos o bloc com sucesso, podemos criar nosso `main.dart` e
 importar o respectivo pacote `bloc`.

--- a/docs/src/content/docs/pt-br/index.mdx
+++ b/docs/src/content/docs/pt-br/index.mdx
@@ -11,7 +11,7 @@ banner:
 editUrl: false
 lastUpdated: false
 hero:
-  title: Bloc <sup><span style="font-size:0.4em">v8.1.3</span></sup>
+  title: Bloc <sup><span style="font-size:0.4em">v9.2.1</span></sup>
   tagline: Uma biblioteca de gerenciamento de estado previsível para Dart.
   image:
     alt: Bloc logo

--- a/docs/src/content/docs/pt-br/migration.mdx
+++ b/docs/src/content/docs/pt-br/migration.mdx
@@ -1,0 +1,1913 @@
+---
+title: Guia de Migração
+description: Migre para a versão estável mais recente do Bloc.
+---
+
+import { Code, Tabs, TabItem } from '@astrojs/starlight/components';
+
+:::tip
+
+Consulte o
+[registro de lançamentos (release log)](https://github.com/felangel/bloc/releases)
+para obter mais informações sobre o que mudou em cada versão.
+
+:::
+
+## v11.0.0
+
+### `package:hydrated_bloc`
+
+#### ❗🧹 Altere a sobreposição de `storage` para um parâmetro nomeado no `HydratedCubit`
+
+:::note[O que mudou?]
+
+No hydrated_bloc v11.0.0, a sobreposição opcional de `storage` no
+`HydratedCubit` foi refatorada para um parâmetro nomeado em vez de um parâmetro
+posicional.
+
+:::
+
+##### Justificativa
+
+Isso acabou passando despercebido durante a implementação inicial e a mudança
+disruptiva (breaking change) acima ajusta a API para ser consistente entre o
+`HydratedBloc` e o `HydratedCubit`. Consulte
+[#4537](https://github.com/felangel/bloc/pull/4537) para mais informações.
+
+**v10.x.x**
+
+```dart
+class CounterCubit extends HydratedCubit<int> {
+  CounterCubit(Storage storage) : super(0, storage);
+}
+```
+
+**v11.x.x**
+
+```dart
+class CounterCubit extends HydratedCubit<int> {
+  CounterCubit(Storage storage) : super(0, storage: storage);
+}
+```
+
+## v10.0.0
+
+### `package:bloc_test`
+
+#### ❗✨ Desacoplar `blocTest` do `BlocBase`
+
+:::note[O que mudou?]
+
+No bloc_test v10.0.0, a API `blocTest` não está mais rigidamente acoplada ao
+`BlocBase`.
+
+:::
+
+##### Justificativa
+
+O `blocTest` deve usar as interfaces principais do bloc quando possível para
+maior flexibilidade e reusabilidade. Anteriormente, isso não era possível porque
+o `BlocBase` implementava `StateStreamableSource`, o que não era suficiente para
+o `blocTest` devido à dependência interna da API `emit`.
+
+### `package:hydrated_bloc`
+
+#### ❗✨ Suporte ao WebAssembly
+
+:::note[O que mudou?]
+
+No hydrated_bloc v10.0.0, foi adicionado suporte para compilação em WebAssembly
+(wasm).
+
+:::
+
+##### Justificativa
+
+Anteriormente não era possível compilar aplicativos para wasm ao usar
+`hydrated_bloc`. Na v10.0.0, o pacote foi refatorado para permitir a compilação
+para wasm.
+
+**v9.x.x**
+
+```dart
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  HydratedBloc.storage = await HydratedStorage.build(
+    storageDirectory: kIsWeb
+        ? HydratedStorage.webStorageDirectory
+        : await getTemporaryDirectory(),
+  );
+  runApp(App());
+}
+```
+
+**v10.x.x**
+
+```dart
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  HydratedBloc.storage = await HydratedStorage.build(
+    storageDirectory: kIsWeb
+        ? HydratedStorageDirectory.web
+        : HydratedStorageDirectory((await getTemporaryDirectory()).path),
+  );
+  runApp(const App());
+}
+```
+
+## v9.0.0
+
+### `package:bloc`
+
+#### ❗🧹 Remover APIs Depreciadas
+
+:::note[O que mudou?]
+
+No bloc v9.0.0, todas as APIs anteriormente depreciadas foram removidas.
+
+:::
+
+##### Resumo
+
+- `BlocOverrides` removido em favor de `Bloc.observer` e `Bloc.transformer`
+
+#### ❗✨ Introduzir a nova Interface `EmittableStateStreamableSource`
+
+:::note[O que mudou?]
+
+No bloc v9.0.0, uma nova interface central `EmittableStateStreamableSource` foi
+introduzida.
+
+:::
+
+##### Justificativa
+
+O `package:bloc_test` era anteriormente muito acoplado ao `BlocBase`. A
+interface `EmittableStateStreamableSource` foi introduzida para permitir que o
+`blocTest` seja desacoplado da implementação concreta do `BlocBase`.
+
+### `package:hydrated_bloc`
+
+#### ✨ Reintroduzir a API `HydratedBloc.storage`
+
+:::note[O que mudou?]
+
+No hydrated_bloc v9.0.0, `HydratedBlocOverrides` foi removido em favor da API
+`HydratedBloc.storage`.
+
+:::
+
+##### Justificativa
+
+Consulte a
+[justificativa para a reintrodução das APIs de sobreposição Bloc.observer e Bloc.transformer](/pt-br/migration#-reintroduzir-as-apis-blocobserver-e-bloctransformer).
+
+**v8.x.x**
+
+```dart
+Future<void> main() async {
+  final storage = await HydratedStorage.build(
+    storageDirectory: kIsWeb
+        ? HydratedStorage.webStorageDirectory
+        : await getTemporaryDirectory(),
+  );
+  HydratedBlocOverrides.runZoned(
+    () => runApp(App()),
+    storage: storage,
+  );
+}
+```
+
+**v9.0.0**
+
+```dart
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  HydratedBloc.storage = await HydratedStorage.build(
+    storageDirectory: kIsWeb
+        ? HydratedStorage.webStorageDirectory
+        : await getTemporaryDirectory(),
+  );
+  runApp(App());
+}
+```
+
+## v8.1.0
+
+### `package:bloc`
+
+#### ✨ Reintroduzir as APIs `Bloc.observer` e `Bloc.transformer`
+
+:::note[O que mudou?]
+
+No bloc v8.1.0, `BlocOverrides` foi depreciado em favor das APIs `Bloc.observer`
+e `Bloc.transformer`.
+
+:::
+
+##### Justificativa
+
+A API `BlocOverrides` foi introduzida na v8.0.0 na tentativa de dar suporte ao
+escopo de configurações específicas do bloc, como `BlocObserver`,
+`EventTransformer` e `HydratedStorage`. Em aplicações Dart puras, as alterações
+funcionavam bem; no entanto, em aplicações Flutter, a nova API causou mais
+problemas do que resolveu.
+
+A API `BlocOverrides` foi inspirada em APIs semelhantes do Flutter/Dart:
+
+- [HttpOverrides](https://api.flutter.dev/flutter/dart-io/HttpOverrides-class.html)
+- [IOOverrides](https://api.flutter.dev/flutter/dart-io/IOOverrides-class.html)
+
+**Problemas**
+
+Embora não tenha sido o motivo principal dessas alterações, a API
+`BlocOverrides` introduziu complexidade adicional para os desenvolvedores. Além
+de aumentar a quantidade de aninhamento e linhas de código necessárias para
+obter o mesmo efeito, a API `BlocOverrides` exigia que os desenvolvedores
+tivessem uma compreensão sólida de `Zones` no Dart. `Zones` não são um conceito
+amigável para iniciantes e a falha em entender como as Zones funcionam poderia
+levar à introdução de bugs (como observadores, transformadores e instâncias de
+armazenamento não inicializados).
+
+Por exemplo, muitos desenvolvedores tinham algo como:
+
+```dart
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  BlocOverrides.runZoned(...);
+}
+```
+
+O código acima, embora pareça inofensivo, pode na verdade levar a muitos bugs
+difíceis de rastrear. Qualquer zone de onde
+`WidgetsFlutterBinding.ensureInitialized` é inicialmente chamada será a zone na
+qual os eventos de gestos são manipulados (por exemplo, os callbacks `onTap` e
+`onPressed`) devido ao `GestureBinding.initInstances`. Este é apenas um dos
+muitos problemas causados pelo uso de `zoneValues`.
+
+Além disso, o Flutter faz muitas coisas nos bastidores que envolvem
+bifurcar/manipular Zones (especialmente ao executar testes) o que pode levar a
+comportamentos inesperados (e em muitos casos comportamentos fora do controle do
+desenvolvedor — veja os problemas abaixo).
+
+Devido ao uso do
+[runZoned](https://api.flutter.dev/flutter/dart-async/runZoned.html), a
+transição para a API `BlocOverrides` levou à descoberta de vários
+bugs/limitações no Flutter (especificamente em testes de Widgets e Integração):
+
+- https://github.com/flutter/flutter/issues/96939
+- https://github.com/flutter/flutter/issues/94123
+- https://github.com/flutter/flutter/issues/93676
+
+o que afetou muitos desenvolvedores usando a biblioteca bloc:
+
+- https://github.com/felangel/bloc/issues/3394
+- https://github.com/felangel/bloc/issues/3350
+- https://github.com/felangel/bloc/issues/3319
+
+**v8.0.x**
+
+```dart
+void main() {
+  BlocOverrides.runZoned(
+    () {
+      // ...
+    },
+    blocObserver: CustomBlocObserver(),
+    eventTransformer: customEventTransformer(),
+  );
+}
+```
+
+**v8.1.0**
+
+```dart
+void main() {
+  Bloc.observer = CustomBlocObserver();
+  Bloc.transformer = customEventTransformer();
+
+  // ...
+}
+```
+
+## v8.0.0
+
+### `package:bloc`
+
+#### ❗✨ Introduzir a nova API `BlocOverrides`
+
+:::note[O que mudou?]
+
+No bloc v8.0.0, `Bloc.observer` e `Bloc.transformer` foram removidos em favor da
+API `BlocOverrides`.
+
+:::
+
+##### Justificativa
+
+A API anterior usada para substituir o `BlocObserver` e o `EventTransformer`
+padrão dependia de um singleton global para ambos.
+
+Como resultado, não era possível:
+
+- Ter múltiplas implementações de `BlocObserver` ou `EventTransformer` com
+  escopo em diferentes partes da aplicação
+- Ter substituições de `BlocObserver` ou `EventTransformer` com escopo em um
+  pacote
+  - Se um pacote dependesse de `package:bloc` e registrasse seu próprio
+    `BlocObserver`, qualquer consumidor do pacote teria que sobrescrever o
+    `BlocObserver` do pacote ou relatar para o `BlocObserver` do pacote.
+
+Também era mais difícil de testar devido ao estado global compartilhado entre os
+testes.
+
+O Bloc v8.0.0 introduz uma classe `BlocOverrides` que permite aos
+desenvolvedores substituir o `BlocObserver` e/ou o `EventTransformer` para uma
+`Zone` específica, em vez de depender de um singleton global mutável.
+
+**v7.x.x**
+
+```dart
+void main() {
+  Bloc.observer = CustomBlocObserver();
+  Bloc.transformer = customEventTransformer();
+
+  // ...
+}
+```
+
+**v8.0.0**
+
+```dart
+void main() {
+  BlocOverrides.runZoned(
+    () {
+      // ...
+    },
+    blocObserver: CustomBlocObserver(),
+    eventTransformer: customEventTransformer(),
+  );
+}
+```
+
+As instâncias de `Bloc` usarão o `BlocObserver` e/ou o `EventTransformer` da
+`Zone` atual via `BlocOverrides.current`. Se não houver `BlocOverrides` para a
+zone, elas usarão os padrões internos existentes (sem alteração no
+comportamento/funcionalidade).
+
+Isso permite que cada `Zone` funcione de maneira independente com seus próprios
+`BlocOverrides`.
+
+```dart
+BlocOverrides.runZoned(
+  () {
+    // BlocObserverA e eventTransformerA
+    final overrides = BlocOverrides.current;
+
+    // Blocs nesta zone reportam para o BlocObserverA
+    // e usam eventTransformerA como o transformador padrão.
+    // ...
+
+    // Mais tarde...
+    BlocOverrides.runZoned(
+      () {
+        // BlocObserverB e eventTransformerB
+        final overrides = BlocOverrides.current;
+
+        // Blocs nesta zone reportam para o BlocObserverB
+        // e usam eventTransformerB como o transformador padrão.
+        // ...
+      },
+      blocObserver: BlocObserverB(),
+      eventTransformer: eventTransformerB(),
+    );
+  },
+  blocObserver: BlocObserverA(),
+  eventTransformer: eventTransformerA(),
+);
+```
+
+#### ❗✨ Melhorar o Tratamento e Relato de Erros
+
+:::note[O que mudou?]
+
+No bloc v8.0.0, `BlocUnhandledErrorException` foi removido. Além disso,
+quaisquer exceções não capturadas são sempre relatadas ao `onError` e relançadas
+(independentemente do modo de depuração ou de produção). A API `addError` relata
+erros ao `onError`, mas não trata os erros relatados como exceções não
+capturadas.
+
+:::
+
+##### Justificativa
+
+O objetivo dessas alterações é:
+
+- tornar as exceções não tratadas internas extremamente óbvias enquanto ainda se
+  preserva a funcionalidade do bloc
+- dar suporte ao `addError` sem interromper o fluxo de controle
+
+Anteriormente, o tratamento e o relato de erros variavam dependendo se a
+aplicação estava sendo executada em modo de depuração (debug) ou de produção
+(release). Além disso, os erros relatados via `addError` eram tratados como
+exceções não capturadas no modo de depuração, o que levava a uma experiência de
+desenvolvimento ruim ao usar a API `addError` (especificamente ao escrever
+testes unitários).
+
+Na v8.0.0, `addError` pode ser usado com segurança para relatar erros e o
+`blocTest` pode ser usado para verificar se os erros são relatados. Todos os
+erros ainda são relatados ao `onError`, no entanto, apenas exceções não
+capturadas são relançadas (independentemente do modo debug ou release).
+
+#### ❗🧹 Tornar o `BlocObserver` abstrato
+
+:::note[O que mudou?]
+
+No bloc v8.0.0, `BlocObserver` foi convertido em uma classe `abstract`, o que
+significa que uma instância de `BlocObserver` não pode ser instanciada
+diretamente.
+
+:::
+
+##### Justificativa
+
+O `BlocObserver` foi planejado para ser uma interface. Como a implementação
+padrão da API consiste em operações vazias (no-ops), o `BlocObserver` agora é
+uma classe `abstract` para comunicar claramente que a classe foi feita para ser
+estendida e não diretamente instanciada.
+
+**v7.x.x**
+
+```dart
+void main() {
+  // Era possível criar uma instância da classe base.
+  final observer = BlocObserver();
+}
+```
+
+**v8.0.0**
+
+```dart
+class MyBlocObserver extends BlocObserver {...}
+
+void main() {
+  // Não é possível instanciar a classe base.
+  final observer = BlocObserver(); // ERRO
+
+  // Estenda `BlocObserver` no lugar.
+  final observer = MyBlocObserver(); // OK
+}
+```
+
+#### ❗✨ `add` lança `StateError` se o Bloc estiver fechado
+
+:::note[O que mudou?]
+
+No bloc v8.0.0, chamar `add` em um bloc fechado resultará em um `StateError`.
+
+:::
+
+##### Justificativa
+
+Anteriormente, era possível chamar `add` em um bloc fechado e o erro interno era
+engolido, tornando difícil depurar o motivo pelo qual o evento adicionado não
+estava sendo processado. Para tornar esse cenário mais visível, na v8.0.0,
+chamar `add` em um bloc fechado lançará um `StateError` que será relatado como
+uma exceção não capturada e propagado ao `onError`.
+
+#### ❗✨ `emit` lança `StateError` se o Bloc estiver fechado
+
+:::note[O que mudou?]
+
+No bloc v8.0.0, chamar `emit` dentro de um bloc fechado resultará em um
+`StateError`.
+
+:::
+
+##### Justificativa
+
+Anteriormente, era possível chamar `emit` dentro de um bloc fechado e nenhuma
+alteração de estado ocorreria, mas também não haveria indicação do que deu
+errado, tornando a depuração difícil. Para tornar esse cenário mais visível, na
+v8.0.0, chamar `emit` dentro de um bloc fechado lançará um `StateError` que será
+relatado como uma exceção não capturada e propagado ao `onError`.
+
+#### ❗🧹 Remover APIs Depreciadas
+
+:::note[O que mudou?]
+
+No bloc v8.0.0, todas as APIs anteriormente depreciadas foram removidas.
+
+:::
+
+##### Resumo
+
+- `mapEventToState` removido em favor de `on<Event>`
+- `transformEvents` removido em favor da API `EventTransformer`
+- O typedef `TransitionFunction` foi removido em favor da API `EventTransformer`
+- `listen` removido em favor de `stream.listen`
+
+### `package:bloc_test`
+
+#### ✨ `MockBloc` e `MockCubit` não requerem mais `registerFallbackValue`
+
+:::note[O que mudou?]
+
+No bloc_test v9.0.0, os desenvolvedores não precisam mais chamar explicitamente
+`registerFallbackValue` ao usar `MockBloc` ou `MockCubit`.
+
+:::
+
+##### Resumo
+
+`registerFallbackValue` só é necessário ao usar o matcher `any()` do
+`package:mocktail` para um tipo personalizado. Anteriormente, o
+`registerFallbackValue` era necessário para cada `Event` e `State` ao usar
+`MockBloc` ou `MockCubit`.
+
+**v8.x.x**
+
+```dart
+class FakeMyEvent extends Fake implements MyEvent {}
+class FakeMyState extends Fake implements MyState {}
+class MyMockBloc extends MockBloc<MyEvent, MyState> implements MyBloc {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeMyEvent());
+    registerFallbackValue(FakeMyState());
+  });
+
+  // Testes...
+}
+```
+
+**v9.0.0**
+
+```dart
+class MyMockBloc extends MockBloc<MyEvent, MyState> implements MyBloc {}
+
+void main() {
+  // Testes...
+}
+```
+
+### `package:hydrated_bloc`
+
+#### ❗✨ Introduzir a nova API `HydratedBlocOverrides`
+
+:::note[O que mudou?]
+
+No hydrated_bloc v8.0.0, `HydratedBloc.storage` foi removido em favor da API
+`HydratedBlocOverrides`.
+
+:::
+
+##### Justificativa
+
+Anteriormente, um singleton global era usado para substituir a implementação de
+`Storage`.
+
+Como resultado, não era possível ter múltiplas implementações de `Storage` com
+escopo em partes diferentes da aplicação. Também era mais difícil de testar
+devido ao estado global compartilhado entre os testes.
+
+O `HydratedBloc` v8.0.0 introduz uma classe `HydratedBlocOverrides` que permite
+aos desenvolvedores substituir o `Storage` para uma `Zone` específica, em vez de
+depender de um singleton global mutável.
+
+**v7.x.x**
+
+```dart
+void main() async {
+  HydratedBloc.storage = await HydratedStorage.build(
+    storageDirectory: await getApplicationSupportDirectory(),
+  );
+
+  // ...
+}
+```
+
+**v8.0.0**
+
+```dart
+void main() {
+  final storage = await HydratedStorage.build(
+    storageDirectory: await getApplicationSupportDirectory(),
+  );
+
+  HydratedBlocOverrides.runZoned(
+    () {
+      // ...
+    },
+    storage: storage,
+  );
+}
+```
+
+As instâncias de `HydratedBloc` usarão o `Storage` da `Zone` atual via
+`HydratedBlocOverrides.current`.
+
+Isso permite que cada `Zone` funcione de maneira independente com seus próprios
+`BlocOverrides`.
+
+## v7.2.0
+
+### `package:bloc`
+
+#### ✨ Introduzir a nova API `on<Event>`
+
+:::note[O que mudou?]
+
+No bloc v7.2.0, `mapEventToState` foi depreciado em favor de `on<Event>`.
+`mapEventToState` será removido no bloc v8.0.0.
+
+:::
+
+##### Justificativa
+
+A API `on<Event>` foi introduzida como parte da proposta
+[[Proposta] Substituir mapEventToState por on\<Event\> no Bloc](https://github.com/felangel/bloc/issues/2526).
+Devido a [um problema no Dart](https://github.com/dart-lang/sdk/issues/44616),
+nem sempre é óbvio qual será o valor do `state` ao lidar com geradores
+assíncronos aninhados (`async*`). Embora existam maneiras de contornar o
+problema, um dos princípios fundamentais da biblioteca bloc é ser previsível. A
+API `on<Event>` foi criada para tornar a biblioteca o mais segura possível de
+usar e eliminar qualquer incerteza quando se trata de mudanças de estado.
+
+:::tip
+
+Para mais informações,
+[leia a proposta completa](https://github.com/felangel/bloc/issues/2526).
+
+:::
+
+**Resumo**
+
+`on<E>` permite registrar um manipulador de eventos para todos os eventos do
+tipo `E`. Por padrão, os eventos serão processados concorrentemente ao usar
+`on<E>`, ao contrário do `mapEventToState` que processa eventos de forma
+sequencial (`sequentially`).
+
+**v7.1.0**
+
+```dart
+abstract class CounterEvent {}
+class Increment extends CounterEvent {}
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0);
+
+  @override
+  Stream<int> mapEventToState(CounterEvent event) async* {
+    if (event is Increment) {
+      yield state + 1;
+    }
+  }
+}
+```
+
+**v7.2.0**
+
+```dart
+abstract class CounterEvent {}
+class Increment extends CounterEvent {}
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0) {
+    on<Increment>((event, emit) => emit(state + 1));
+  }
+}
+```
+
+:::note
+
+Cada `EventHandler` registrado funciona de maneira independente, por isso é
+importante registrar manipuladores de eventos com base no tipo de transformador
+que você gostaria de aplicar.
+
+:::
+
+Se você quiser manter exatamente o mesmo comportamento da v7.1.0, pode registrar
+um único manipulador de eventos para todos os eventos e aplicar um transformador
+sequencial (`sequential`):
+
+```dart
+import 'package:bloc/bloc.dart';
+import 'package:bloc_concurrency/bloc_concurrency.dart';
+
+class MyBloc extends Bloc<MyEvent, MyState> {
+  MyBloc() : super(MyState()) {
+    on<MyEvent>(_onEvent, transformer: sequential())
+  }
+
+  FutureOr<void> _onEvent(MyEvent event, Emitter<MyState> emit) async {
+    // TODO: lógica vai aqui...
+  }
+}
+```
+
+Você também pode substituir o `EventTransformer` padrão para todos os blocs da
+sua aplicação:
+
+```dart
+import 'package:bloc/bloc.dart';
+import 'package:bloc_concurrency/bloc_concurrency.dart';
+
+void main() {
+  Bloc.transformer = sequential<dynamic>();
+  ...
+}
+```
+
+#### ✨ Introduzir a nova API `EventTransformer`
+
+:::note[O que mudou?]
+
+No bloc v7.2.0, `transformEvents` foi depreciado em favor da API
+`EventTransformer`. `transformEvents` será removido no bloc v8.0.0.
+
+:::
+
+##### Justificativa
+
+A API `on<Event>` abriu as portas para fornecer um transformador de eventos
+personalizado por manipulador de eventos. Um novo typedef `EventTransformer` foi
+introduzido, permitindo aos desenvolvedores transformar o fluxo de eventos de
+entrada para cada manipulador de eventos individualmente, em vez de ter que
+especificar um único transformador para todos os eventos.
+
+**Resumo**
+
+Um `EventTransformer` é responsável por pegar o stream de eventos recebido
+juntamente com um `EventMapper` (seu manipulador de eventos) e retornar um novo
+stream de eventos.
+
+```dart
+typedef EventTransformer<Event> = Stream<Event> Function(Stream<Event> events, EventMapper<Event> mapper)
+```
+
+O `EventTransformer` padrão processa todos os eventos concorrentemente e se
+parece com algo assim:
+
+```dart
+EventTransformer<E> concurrent<E>() {
+  return (events, mapper) => events.flatMap(mapper);
+}
+```
+
+:::tip
+
+Confira [package:bloc_concurrency](https://pub.dev/packages/bloc_concurrency)
+para um conjunto opinativo de transformadores de eventos personalizados.
+
+:::
+
+**v7.1.0**
+
+```dart
+@override
+Stream<Transition<MyEvent, MyState>> transformEvents(events, transitionFn) {
+  return events
+    .debounceTime(const Duration(milliseconds: 300))
+    .flatMap(transitionFn);
+}
+```
+
+**v7.2.0**
+
+```dart
+/// Define um `EventTransformer` personalizado
+EventTransformer<MyEvent> debounce<MyEvent>(Duration duration) {
+  return (events, mapper) => events.debounceTime(duration).flatMap(mapper);
+}
+
+MyBloc() : super(MyState()) {
+  /// Aplica o `EventTransformer` personalizado ao `EventHandler`
+  on<MyEvent>(_onEvent, transformer: debounce(const Duration(milliseconds: 300)))
+}
+```
+
+#### ⚠️ Depreciar a API `transformTransitions`
+
+:::note[O que mudou?]
+
+No bloc v7.2.0, `transformTransitions` foi depreciado em favor da sobreposição
+da API `stream`. `transformTransitions` será removido no bloc v8.0.0.
+
+:::
+
+##### Justificativa
+
+O getter `stream` no `Bloc` facilita a sobreposição do fluxo de saída de
+estados, de modo que não é mais vantajoso manter uma API `transformTransitions`
+separada.
+
+**Resumo**
+
+**v7.1.0**
+
+```dart
+@override
+Stream<Transition<Event, State>> transformTransitions(
+  Stream<Transition<Event, State>> transitions,
+) {
+  return transitions.debounceTime(const Duration(milliseconds: 42));
+}
+```
+
+**v7.2.0**
+
+```dart
+@override
+Stream<State> get stream => super.stream.debounceTime(const Duration(milliseconds: 42));
+```
+
+## v7.0.0
+
+### `package:bloc`
+
+#### ❗ Bloc e Cubit estendem `BlocBase`
+
+##### Justificativa
+
+Como desenvolvedor, a relação entre blocs e cubits era um pouco desconfortável.
+Quando o cubit foi introduzido pela primeira vez, ele começou como a classe base
+para blocs, o que fazia sentido porque tinha um subconjunto de funcionalidades e
+os blocs simplesmente estendiam o Cubit e definiam APIs adicionais. Isso trouxe
+algumas desvantagens:
+
+- Todas as APIs teriam que ser renomeadas para aceitar um cubit para fins de
+  precisão ou teriam que ser mantidas como bloc para fins de consistência,
+  embora hierarquicamente isso seja incorreto
+  ([#1708](https://github.com/felangel/bloc/issues/1708),
+  [#1560](https://github.com/felangel/bloc/issues/1560)).
+
+- O Cubit precisaria estender o Stream e implementar o EventSink para ter uma
+  base comum contra a qual widgets como BlocBuilder, BlocListener, etc. pudessem
+  ser implementados ([#1429](https://github.com/felangel/bloc/issues/1429)).
+
+Mais tarde, experimentamos inverter o relacionamento e tornar o bloc a classe
+base, o que resolveu parcialmente o primeiro ponto acima, mas introduziu outros
+problemas:
+
+- A API do cubit ficou inchada devido às APIs subjacentes do bloc, como
+  mapEventToState, add, etc.
+  ([#2228](https://github.com/felangel/bloc/issues/2228))
+  - Desenvolvedores podiam invocar essas APIs tecnicamente e quebrar coisas
+- Ainda tínhamos o mesmo problema do cubit expor toda a API de stream como antes
+  ([#1429](https://github.com/felangel/bloc/issues/1429))
+
+Para resolver esses problemas, introduzimos uma classe base para ambos `Bloc` e
+`Cubit` chamada `BlocBase`, de modo que os componentes upstream ainda possam
+interoperar com as instâncias de bloc e cubit, mas sem expor as APIs de `Stream`
+e `EventSink` diretamente.
+
+**Resumo**
+
+**BlocObserver**
+
+**v6.1.x**
+
+```dart
+class SimpleBlocObserver extends BlocObserver {
+  @override
+  void onCreate(Cubit cubit) {...}
+
+  @override
+  void onEvent(Bloc bloc, Object event) {...}
+
+  @override
+  void onChange(Cubit cubit, Object event) {...}
+
+  @override
+  void onTransition(Bloc bloc, Transition transition) {...}
+
+  @override
+  void onError(Cubit cubit, Object error, StackTrace stackTrace) {...}
+
+  @override
+  void onClose(Cubit cubit) {...}
+}
+```
+
+**v7.0.0**
+
+```dart
+class SimpleBlocObserver extends BlocObserver {
+  @override
+  void onCreate(BlocBase bloc) {...}
+
+  @override
+  void onEvent(Bloc bloc, Object event) {...}
+
+  @override
+  void onChange(BlocBase bloc, Object? event) {...}
+
+  @override
+  void onTransition(Bloc bloc, Transition transition) {...}
+
+  @override
+  void onError(BlocBase bloc, Object error, StackTrace stackTrace) {...}
+
+  @override
+  void onClose(BlocBase bloc) {...}
+}
+```
+
+**Bloc/Cubit**
+
+**v6.1.x**
+
+```dart
+final bloc = MyBloc();
+bloc.listen((state) {...});
+
+final cubit = MyCubit();
+cubit.listen((state) {...});
+```
+
+**v7.0.0**
+
+```dart
+final bloc = MyBloc();
+bloc.stream.listen((state) {...});
+
+final cubit = MyCubit();
+cubit.stream.listen((state) {...});
+```
+
+### `package:bloc_test`
+
+#### ❗ `seed` retorna uma função para dar suporte a valores dinâmicos
+
+##### Justificativa
+
+Para dar suporte a ter um valor de semente (seed) mutável que pode ser
+atualizado dinamicamente no `setUp`, o `seed` agora retorna uma função.
+
+**Resumo**
+
+**v7.x.x**
+
+```dart
+blocTest(
+  '...',
+  seed: MyState(),
+  ...
+);
+```
+
+**v8.0.0**
+
+```dart
+blocTest(
+  '...',
+  seed: () => MyState(),
+  ...
+);
+```
+
+#### ❗ `expect` retorna uma função para dar suporte a valores dinâmicos e inclui suporte a matchers
+
+##### Justificativa
+
+Para dar suporte a ter uma expectativa mutável que pode ser atualizada
+dinamicamente no `setUp`, `expect` retorna uma função. O `expect` também dá
+suporte a `Matchers`.
+
+**Resumo**
+
+**v7.x.x**
+
+```dart
+blocTest(
+  '...',
+  expect: [MyStateA(), MyStateB()],
+  ...
+);
+```
+
+**v8.0.0**
+
+```dart
+blocTest(
+  '...',
+  expect: () => [MyStateA(), MyStateB()],
+  ...
+);
+
+// Também pode ser um `Matcher`
+blocTest(
+  '...',
+  expect: () => contains(MyStateA()),
+  ...
+);
+```
+
+#### ❗ `errors` retorna uma função para dar suporte a valores dinâmicos e inclui suporte a matchers
+
+##### Justificativa
+
+Para dar suporte a ter erros mutáveis que podem ser atualizados dinamicamente no
+`setUp`, `errors` retorna uma função. O `errors` também dá suporte a `Matchers`.
+
+**Resumo**
+
+**v7.x.x**
+
+```dart
+blocTest(
+  '...',
+  errors: [MyError()],
+  ...
+);
+```
+
+**v8.0.0**
+
+```dart
+blocTest(
+  '...',
+  errors: () => [MyError()],
+  ...
+);
+
+// Também pode ser um `Matcher`
+blocTest(
+  '...',
+  errors: () => contains(MyError()),
+  ...
+);
+```
+
+#### ❗ MockBloc e MockCubit
+
+##### Justificativa
+
+Para dar suporte a stubbing de várias APIs centrais, `MockBloc` e `MockCubit`
+são exportados como parte do pacote `bloc_test`. Anteriormente, `MockBloc` tinha
+que ser usado tanto para instâncias de `Bloc` quanto de `Cubit`, o que não era
+intuitivo.
+
+**Resumo**
+
+**v7.x.x**
+
+```dart
+class MockMyBloc extends MockBloc<MyState> implements MyBloc {}
+class MockMyCubit extends MockBloc<MyState> implements MyBloc {}
+```
+
+**v8.0.0**
+
+```dart
+class MockMyBloc extends MockBloc<MyEvent, MyState> implements MyBloc {}
+class MockMyCubit extends MockCubit<MyState> implements MyCubit {}
+```
+
+#### ❗ Integração com Mocktail
+
+##### Justificativa
+
+Devido a várias limitações do pacote null-safe `mockito` descritas
+[aqui](https://github.com/dart-lang/mockito/blob/master/NULL_SAFETY_README.md#problems-with-typical-mocking-and-stubbing),
+o pacote `mocktail` é usado pelo `MockBloc` e `MockCubit`. Isso permite que os
+desenvolvedores continuem usando uma API de simulação (mocking) familiar sem a
+necessidade de escrever stubs manualmente ou depender de geração de código.
+
+**Resumo**
+
+**v7.x.x**
+
+```dart
+import 'package:mockito/mockito.dart';
+
+...
+
+when(bloc.state).thenReturn(MyState());
+verify(bloc.add(any)).called(1);
+```
+
+**v8.0.0**
+
+```dart
+import 'package:mocktail/mocktail.dart';
+
+...
+
+when(() => bloc.state).thenReturn(MyState());
+verify(() => bloc.add(any())).called(1);
+```
+
+> Consulte [#347](https://github.com/dart-lang/mockito/issues/347) bem como a
+> [documentação do mocktail](https://github.com/felangel/mocktail/tree/main/packages/mocktail)
+> para mais informações.
+
+### `package:flutter_bloc`
+
+#### ❗ renomear o parâmetro `cubit` para `bloc`
+
+##### Justificativa
+
+Como resultado da refatoração no `package:bloc` para introduzir o `BlocBase`, o
+qual `Bloc` e `Cubit` estendem, os parâmetros de `BlocBuilder`, `BlocConsumer` e
+`BlocListener` foram renomeados de `cubit` para `bloc` porque os widgets operam
+no tipo `BlocBase`. Isso também alinha ainda mais com o nome da biblioteca e
+melhora a legibilidade.
+
+**Resumo**
+
+**v6.1.x**
+
+```dart
+BlocBuilder(
+  cubit: myBloc,
+  ...
+)
+
+BlocListener(
+  cubit: myBloc,
+  ...
+)
+
+BlocConsumer(
+  cubit: myBloc,
+  ...
+)
+```
+
+**v7.0.0**
+
+```dart
+BlocBuilder(
+  bloc: myBloc,
+  ...
+)
+
+BlocListener(
+  bloc: myBloc,
+  ...
+)
+
+BlocConsumer(
+  bloc: myBloc,
+  ...
+)
+```
+
+### `package:hydrated_bloc`
+
+#### ❗ `storageDirectory` é obrigatório ao chamar `HydratedStorage.build`
+
+##### Justificativa
+
+A fim de tornar o `package:hydrated_bloc` un pacote Dart puro, a dependência do
+[package:path_provider](https://pub.dev/packages/path_provider) foi removida e o
+parâmetro `storageDirectory` ao chamar `HydratedStorage.build` é obrigatório e
+não assume mais o padrão `getTemporaryDirectory`.
+
+**Resumo**
+
+**v6.x.x**
+
+```dart
+HydratedBloc.storage = await HydratedStorage.build();
+```
+
+**v7.0.0**
+
+```dart
+import 'package:path_provider/path_provider.dart';
+
+...
+
+HydratedBloc.storage = await HydratedStorage.build(
+  storageDirectory: await getTemporaryDirectory(),
+);
+```
+
+## v6.1.0
+
+### `package:flutter_bloc`
+
+#### ❗ `context.bloc` e `context.repository` foram depreciados em favor de `context.read` e `context.watch`
+
+##### Justificativa
+
+`context.read`, `context.watch` e `context.select` foram adicionados para se
+alinharem com a API existente do [provider](https://pub.dev/packages/provider),
+com a qual muitos desenvolvedores já estão familiarizados, e para resolver
+problemas que foram levantados pela comunidade. Para melhorar a segurança do
+código e manter a consistência, `context.bloc` foi depreciado porque pode ser
+substituído por `context.read` ou `context.watch`, dependendo se é usado
+diretamente dentro do método `build`.
+
+**context.watch**
+
+`context.watch` atende ao pedido de ter um
+[MultiBlocBuilder](https://github.com/felangel/bloc/issues/538) porque podemos
+observar vários blocs dentro de um único `Builder` a fim de renderizar a UI com
+base em múltiplos estados:
+
+```dart
+Builder(
+  builder: (context) {
+    final stateA = context.watch<BlocA>().state;
+    final stateB = context.watch<BlocB>().state;
+    final stateC = context.watch<BlocC>().state;
+
+    // retorna um Widget que depende do estado do BlocA, BlocB e BlocC
+  }
+);
+```
+
+**context.select**
+
+`context.select` permite aos desenvolvedores renderizar/atualizar a UI com base
+em uma parte do estado de um bloc e atende ao pedido de ter um
+[buildWhen mais simples](https://github.com/felangel/bloc/issues/1521).
+
+```dart
+final name = context.select((UserBloc bloc) => bloc.state.user.name);
+```
+
+O snippet acima nos permite acessar e reconstruir o widget somente quando o nome
+do usuário atual for alterado.
+
+**context.read**
+
+Embora pareça que o `context.read` é idêntico ao `context.bloc`, existem algumas
+diferenças sutis, mas significativas. Ambos permitem acessar um bloc com um
+`BuildContext` e não resultam em reconstruções; no entanto, o `context.read` não
+pode ser chamado diretamente dentro de um método `build`. Existem duas razões
+principais pelas quais as pessoas usavam `context.bloc` dentro do `build`:
+
+1. **Para acessar o estado do bloc**
+
+```dart
+@override
+Widget build(BuildContext context) {
+  final state = context.bloc<MyBloc>().state;
+  return Text('$state');
+}
+```
+
+O uso acima é propenso a erros porque o widget `Text` não será reconstruído se o
+estado do bloc mudar. Neste cenário, deve-se usar um `BlocBuilder` ou
+`context.watch`.
+
+```dart
+@override
+Widget build(BuildContext context) {
+  final state = context.watch<MyBloc>().state;
+  return Text('$state');
+}
+```
+
+ou
+
+```dart
+@override
+Widget build(BuildContext context) {
+  return BlocBuilder<MyBloc, MyState>(
+    builder: (context, state) => Text('$state'),
+  );
+}
+```
+
+:::note
+
+Usar `context.watch` na raiz do método `build` fará com que todo o widget seja
+reconstruído quando o estado do bloc mudar. Se nem todo o widget precisar ser
+reconstruído, use o `BlocBuilder` para envolver as partes que devem reconstruir,
+use um `Builder` com `context.watch` para limitar o escopo das reconstruções ou
+decomponha o widget em widgets menores.
+
+:::
+
+2. **Para acessar o bloc a fim de adicionar um evento**
+
+```dart
+@override
+Widget build(BuildContext context) {
+  final bloc = context.bloc<MyBloc>();
+  return ElevatedButton(
+    onPressed: () => bloc.add(MyEvent()),
+    ...
+  )
+}
+```
+
+O uso acima é ineficiente porque resulta em uma busca de bloc a cada
+reconstrução, quando o bloc só é necessário quando o usuário toca no
+`ElevatedButton`. Neste cenário, prefira usar `context.read` para acessar o bloc
+diretamente onde ele é necessário (neste caso, no callback `onPressed`).
+
+```dart
+@override
+Widget build(BuildContext context) {
+  return ElevatedButton(
+    onPressed: () => context.read<MyBloc>().add(MyEvent()),
+    ...
+  )
+}
+```
+
+?> Ao acessar um bloc para adicionar um evento, realize o acesso usando
+`context.read` no callback onde for necessário.
+
+**v6.0.x**
+
+```dart
+@override
+Widget build(BuildContext context) {
+  final state = context.bloc<MyBloc>().state;
+  return Text('$state');
+}
+```
+
+**v6.1.x**
+
+```dart
+@override
+Widget build(BuildContext context) {
+  final state = context.watch<MyBloc>().state;
+  return Text('$state');
+}
+```
+
+?> Use `context.watch` ao acessar o estado do bloc a fim de garantir que o
+widget seja reconstruído quando o estado mudar.
+
+## v6.0.0
+
+### `package:bloc`
+
+#### ❗ `BlocObserver` `onError` recebe `Cubit`
+
+##### Justificativa
+
+Devido à integração do `Cubit`, o `onError` agora é compartilhado entre as
+instâncias de `Bloc` e `Cubit`. Como `Cubit` é a base, o `BlocObserver` aceitará
+um tipo `Cubit` em vez de um tipo `Bloc` na sobreposição de `onError`.
+
+**v5.x.x**
+
+```dart
+class MyBlocObserver extends BlocObserver {
+  @override
+  void onError(Bloc bloc, Object error, StackTrace stackTrace) {
+    super.onError(bloc, error, stackTrace);
+  }
+}
+```
+
+**v6.0.0**
+
+```dart
+class MyBlocObserver extends BlocObserver {
+  @override
+  void onError(Cubit cubit, Object error, StackTrace stackTrace) {
+    super.onError(cubit, error, stackTrace);
+  }
+}
+```
+
+#### ❗ Bloc não emite o último estado na inscrição
+
+##### Justificativa
+
+Essa mudança foi feita para alinhar o `Bloc` e o `Cubit` com o comportamento
+padrão de `Stream` no `Dart`. Além disso, manter o comportamento antigo no
+contexto do `Cubit` levou a muitos efeitos colaterais indesejados e complicou
+desnecessariamente as implementações internas de outros pacotes como
+`flutter_bloc` e `bloc_test` (exigindo `skip(1)`, etc.).
+
+**v5.x.x**
+
+```dart
+final bloc = MyBloc();
+bloc.listen(print);
+```
+
+Anteriormente, o trecho acima produziria o estado inicial do bloc seguido pelas
+mudanças de estado subsequentes.
+
+**v6.x.x**
+
+Na v6.0.0, o trecho acima não gera o estado inicial e gera apenas as mudanças de
+estado subsequentes. O comportamento anterior pode ser alcançado com o seguinte:
+
+```dart
+final bloc = MyBloc();
+print(bloc.state);
+bloc.listen(print);
+```
+
+?> **Nota**: Essa alteração afetará apenas o código que depende de inscrições
+diretas em blocs. Ao usar `BlocBuilder`, `BlocListener` ou `BlocConsumer`, não
+haverá alteração perceptível no comportamento.
+
+### `package:bloc_test`
+
+#### ❗ `MockBloc` requer apenas o tipo de `State`
+
+##### Justificativa
+
+Não é necessário e elimina código extra, além de tornar o `MockBloc` compatível
+com o `Cubit`.
+
+**v5.x.x**
+
+```dart
+class MockCounterBloc extends MockBloc<CounterEvent, int> implements CounterBloc {}
+```
+
+**v6.0.0**
+
+```dart
+class MockCounterBloc extends MockBloc<int> implements CounterBloc {}
+```
+
+#### ❗ `whenListen` requer apenas o tipo de `State`
+
+##### Justificativa
+
+Não é necessário e elimina código extra, além de tornar o `whenListen`
+compatível com o `Cubit`.
+
+**v5.x.x**
+
+```dart
+whenListen<CounterEvent, int>(bloc, Stream.fromIterable([0, 1, 2, 3]));
+```
+
+**v6.0.0**
+
+```dart
+whenListen<int>(bloc, Stream.fromIterable([0, 1, 2, 3]));
+```
+
+#### ❗ `blocTest` não requer o tipo de `Event`
+
+##### Justificativa
+
+Não é necessário e elimina código extra, além de tornar o `blocTest` compatível
+com o `Cubit`.
+
+**v5.x.x**
+
+```dart
+blocTest<CounterBloc, CounterEvent, int>(
+  'emite [1] quando increment é chamado',
+  build: () async => CounterBloc(),
+  act: (bloc) => bloc.add(CounterEvent.increment),
+  expect: const <int>[1],
+);
+```
+
+**v6.0.0**
+
+```dart
+blocTest<CounterBloc, int>(
+  'emite [1] quando increment é chamado',
+  build: () => CounterBloc(),
+  act: (bloc) => bloc.add(CounterEvent.increment),
+  expect: const <int>[1],
+);
+```
+
+#### ❗ o `skip` do `blocTest` assume o padrão 0
+
+##### Justificativa
+
+Como as instâncias de `bloc` e `cubit` não emitirão mais o último estado para
+novas inscrições, não era mais necessário definir o padrão de `skip` como `1`.
+
+**v5.x.x**
+
+```dart
+blocTest<CounterBloc, CounterEvent, int>(
+  'emite [0] quando skip é 0',
+  build: () async => CounterBloc(),
+  skip: 0,
+  expect: const <int>[0],
+);
+```
+
+**v6.0.0**
+
+```dart
+blocTest<CounterBloc, int>(
+  'emite [] quando skip é 0',
+  build: () => CounterBloc(),
+  skip: 0,
+  expect: const <int>[],
+);
+```
+
+O estado inicial de um bloc ou cubit pode ser testado da seguinte forma:
+
+```dart
+test('o estado inicial está correto', () {
+  expect(MyBloc().state, InitialState());
+});
+```
+
+#### ❗ tornar o `build` do `blocTest` síncrono
+
+##### Justificativa
+
+Anteriormente, o `build` era feito de forma assíncrona (`async`) para que várias
+preparações pudessem ser feitas para colocar o bloc sob teste em um estado
+específico. Isso não é mais necessário e também resolve vários problemas devido
+à latência adicionada entre o build e a inscrição internamente. Em vez de fazer
+uma preparação assíncrona para obter um bloc no estado desejado, agora podemos
+definir o estado do bloc encadeando `emit` com o estado desejado.
+
+**v5.x.x**
+
+```dart
+blocTest<CounterBloc, CounterEvent, int>(
+  'emite [2] quando increment é adicionado',
+  build: () async {
+    final bloc = CounterBloc();
+    bloc.add(CounterEvent.increment);
+    await bloc.take(2);
+    return bloc;
+  }
+  act: (bloc) => bloc.add(CounterEvent.increment),
+  expect: const <int>[2],
+);
+```
+
+**v6.0.0**
+
+```dart
+blocTest<CounterBloc, int>(
+  'emite [2] quando increment é adicionado',
+  build: () => CounterBloc()..emit(1),
+  act: (bloc) => bloc.add(CounterEvent.increment),
+  expect: const <int>[2],
+);
+```
+
+:::note
+
+O método `emit` é visível apenas para testes e nunca deve ser usado fora deles.
+
+:::
+
+### `package:flutter_bloc`
+
+#### ❗ parâmetro `bloc` do `BlocBuilder` renomeado para `cubit`
+
+##### Justificativa
+
+A fim de fazer o `BlocBuilder` interoperar com instâncias de `bloc` e `cubit`, o
+parâmetro `bloc` foi renomeado para `cubit` (uma vez que `Cubit` é a classe
+base).
+
+**v5.x.x**
+
+```dart
+BlocBuilder(
+  bloc: myBloc,
+  builder: (context, state) {...}
+)
+```
+
+**v6.0.0**
+
+```dart
+BlocBuilder(
+  cubit: myBloc,
+  builder: (context, state) {...}
+)
+```
+
+#### ❗ parâmetro `bloc` do `BlocListener` renomeado para `cubit`
+
+##### Justificativa
+
+A fim de fazer o `BlocListener` interoperar com instâncias de `bloc` e `cubit`,
+o parâmetro `bloc` foi renomeado para `cubit` (uma vez que `Cubit` é a classe
+base).
+
+**v5.x.x**
+
+```dart
+BlocListener(
+  bloc: myBloc,
+  listener: (context, state) {...}
+)
+```
+
+**v6.0.0**
+
+```dart
+BlocListener(
+  cubit: myBloc,
+  listener: (context, state) {...}
+)
+```
+
+#### ❗ parâmetro `bloc` do `BlocConsumer` renomeado para `cubit`
+
+##### Justificativa
+
+A fim de fazer o `BlocConsumer` interoperar com instâncias de `bloc` e `cubit`,
+o parâmetro `bloc` foi renomeado para `cubit` (uma vez que `Cubit` é a classe
+base).
+
+**v5.x.x**
+
+```dart
+BlocConsumer(
+  bloc: myBloc,
+  listener: (context, state) {...},
+  builder: (context, state) {...}
+)
+```
+
+**v6.0.0**
+
+```dart
+BlocConsumer(
+  cubit: myBloc,
+  listener: (context, state) {...},
+  builder: (context, state) {...}
+)
+```
+
+---
+
+## v5.0.0
+
+### `package:bloc`
+
+#### ❗ `initialState` foi removido
+
+##### Justificativa
+
+Como desenvolvedor, ter que substituir `initialState` ao criar um bloc apresenta
+dois problemas principais:
+
+- O `initialState` do bloc pode ser dinâmico e também pode ser referenciado em
+  um ponto posterior no tempo (mesmo fora do próprio bloc). De certa forma, isso
+  pode ser visto como vazamento de informações internas do bloc para a camada de
+  UI.
+- É verboso.
+
+**v4.x.x**
+
+```dart
+class CounterBloc extends Bloc<CounterEvent, int> {
+  @override
+  int get initialState => 0;
+
+  ...
+}
+```
+
+**v5.0.0**
+
+```dart
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0);
+
+  ...
+}
+```
+
+?> Para mais informações consulte
+[#1304](https://github.com/felangel/bloc/issues/1304)
+
+#### ❗ `BlocDelegate` renomeado para `BlocObserver`
+
+##### Justificativa
+
+O nome `BlocDelegate` não era uma descrição precisa do papel desempenhado pela
+classe. `BlocDelegate` sugere que a classe desempenha um papel ativo, enquanto
+na realidade o papel pretendido do `BlocDelegate` era ser um componente passivo
+que simplesmente observa todos os blocs em uma aplicação.
+
+:::note
+
+Idealmente, não deve haver funcionalidades ou recursos voltados ao usuário
+manipulados no `BlocObserver`.
+
+:::
+
+**v4.x.x**
+
+```dart
+class MyBlocDelegate extends BlocDelegate {
+  ...
+}
+```
+
+**v5.0.0**
+
+```dart
+class MyBlocObserver extends BlocObserver {
+  ...
+}
+```
+
+#### ❗ `BlocSupervisor` foi removido
+
+##### Justificativa
+
+O `BlocSupervisor` era mais um componente que os desenvolvedores precisavam
+conhecer e interagir com o único propósito de especificar um `BlocDelegate`
+personalizado. Com a mudança para `BlocObserver`, sentimos que melhorou a
+experiência do desenvolvedor definir o observador diretamente no próprio bloc.
+
+?> Essa alteração também nos permitiu desacoplar outros add-ons do bloc, como o
+`HydratedStorage`, do `BlocObserver`.
+
+**v4.x.x**
+
+```dart
+BlocSupervisor.delegate = MyBlocDelegate();
+```
+
+**v5.0.0**
+
+```dart
+Bloc.observer = MyBlocObserver();
+```
+
+### `package:flutter_bloc`
+
+#### ❗ condição (condition) do `BlocBuilder` renomeada para `buildWhen`
+
+##### Justificativa
+
+Quando usávamos o `BlocBuilder`, anteriormente podíamos especificar uma
+`condition` para determinar se o `builder` deveria reconstruir.
+
+```dart
+BlocBuilder<MyBloc, MyState>(
+  condition: (previous, current) {
+    // retorna true/false para determinar se deve chamar o builder
+  },
+  builder: (context, state) {...}
+)
+```
+
+O nome `condition` não é muito autoexplicativo ou óbvio e, mais importante, ao
+interagir com um `BlocConsumer`, a API tornou-se inconsistente porque os
+desenvolvedores podem fornecer duas condições (uma para o `builder` e outra para
+o `listener`). Como resultado, a API do `BlocConsumer` expôs um `buildWhen` e um
+`listenWhen`.
+
+```dart
+BlocConsumer<MyBloc, MyState>(
+  listenWhen: (previous, current) {
+    // retorna true/false para determinar se deve chamar o listener
+  },
+  listener: (context, state) {...},
+  buildWhen: (previous, current) {
+    // retorna true/false para determinar se deve chamar o builder
+  },
+  builder: (context, state) {...},
+)
+```
+
+A fim de alinhar a API e fornecer uma experiência de desenvolvimento mais
+consistente, `condition` foi renomeada para `buildWhen`.
+
+**v4.x.x**
+
+```dart
+BlocBuilder<MyBloc, MyState>(
+  condition: (previous, current) {
+    // retorna true/false para determinar se deve chamar o builder
+  },
+  builder: (context, state) {...}
+)
+```
+
+**v5.0.0**
+
+```dart
+BlocBuilder<MyBloc, MyState>(
+  buildWhen: (previous, current) {
+    // retorna true/false para determinar se deve chamar o builder
+  },
+  builder: (context, state) {...}
+)
+```
+
+#### ❗ condição (condition) do `BlocListener` renomeada para `listenWhen`
+
+##### Justificativa
+
+Pelos mesmos motivos descritos acima, a `condition` do `BlocListener` também foi
+renomeada.
+
+**v4.x.x**
+
+```dart
+BlocListener<MyBloc, MyState>(
+  condition: (previous, current) {
+    // retorna true/false para determinar se deve chamar o listener
+  },
+  listener: (context, state) {...}
+)
+```
+
+**v5.0.0**
+
+```dart
+BlocListener<MyBloc, MyState>(
+  listenWhen: (previous, current) {
+    // retorna true/false para determinar se deve chamar o listener
+  },
+  listener: (context, state) {...}
+)
+```
+
+### `package:hydrated_bloc`
+
+#### ❗ `HydratedStorage` e `HydratedBlocStorage` renomeados
+
+##### Justificativa
+
+A fim de melhorar a reutilização de código entre `hydrated_bloc` e
+`hydrated_cubit`, a implementação concreta do armazenamento padrão foi renomeada
+de `HydratedBlocStorage` para `HydratedStorage`. Além disso, a interface
+`HydratedStorage` foi renomeada de `HydratedStorage` para `Storage`.
+
+**v4.0.0**
+
+```dart
+class MyHydratedStorage implements HydratedStorage {
+  ...
+}
+```
+
+**v5.0.0**
+
+```dart
+class MyHydratedStorage implements Storage {
+  ...
+}
+```
+
+#### ❗ `HydratedStorage` desacoplado do `BlocDelegate`
+
+##### Justificativa
+
+Como mencionado anteriormente, o `BlocDelegate` foi renomeado para
+`BlocObserver` e foi definido diretamente como parte do `bloc`.
+
+A alteração a seguir foi feita para:
+
+- Manter a consistência com a nova API do bloc observer
+- Manter o armazenamento escopado apenas para o `HydratedBloc`
+- Desacoplar o `BlocObserver` do `Storage`
+
+**v4.0.0**
+
+```dart
+BlocSupervisor.delegate = await HydratedBlocDelegate.build();
+```
+
+**v5.0.0**
+
+```dart
+HydratedBloc.storage = await HydratedStorage.build();
+```
+
+#### ❗ Inicialização Simplificada
+
+##### Justificativa
+
+Anteriormente, os desenvolvedores precisavam chamar manualmente
+`super.initialState ?? DefaultInitialState()` para configurar suas instâncias de
+`HydratedBloc`. Isso é deselegante e verboso, além de ser incompatível com as
+mudanças disruptivas do `initialState` no `bloc`. Como resultado, na v5.0.0 a
+inicialização do `HydratedBloc` é idêntica à inicialização de um `Bloc` normal.
+
+**v4.0.0**
+
+```dart
+class CounterBloc extends HydratedBloc<CounterEvent, int> {
+  @override
+  int get initialState => super.initialState ?? 0;
+}
+```
+
+**v5.0.0**
+
+```dart
+class CounterBloc extends HydratedBloc<CounterEvent, int> {
+  CounterBloc() : super(0);
+
+  ...
+}
+```

--- a/docs/src/content/docs/pt-br/naming-conventions.mdx
+++ b/docs/src/content/docs/pt-br/naming-conventions.mdx
@@ -1,0 +1,100 @@
+---
+title: Convenções de Nomenclatura
+description:
+  Visão geral das convenções de nomenclatura recomendadas ao usar o bloc.
+---
+
+import EventExamplesGood1 from '~/components/naming-conventions/EventExamplesGood1Snippet.astro';
+import EventExamplesBad1 from '~/components/naming-conventions/EventExamplesBad1Snippet.astro';
+import StateExamplesGood1Snippet from '~/components/naming-conventions/StateExamplesGood1Snippet.astro';
+import SingleStateExamplesGood1Snippet from '~/components/naming-conventions/SingleStateExamplesGood1Snippet.astro';
+import StateExamplesBad1Snippet from '~/components/naming-conventions/StateExamplesBad1Snippet.astro';
+
+As seguintes convenções de nomenclatura são simplesmente recomendações e são
+completamente opcionais. Sinta-se à vontade para usar as convenções de
+nomenclatura que preferir. Você poderá notar que alguns dos
+exemplos/documentação não seguem estas convenções de nomenclatura principalmente
+por simplicidade/concisão. Essas convenções são fortemente recomendadas para
+grandes projetos com múltiplos desenvolvedores.
+
+## Convenções de Eventos
+
+Os eventos devem ser nomeados no **passado** (em inglês, no past tense) porque
+os eventos são coisas que já ocorreram a partir da perspectiva do bloc.
+
+### Anatomia
+
+`BlocSubject` + `Substantivo (opcional)` + `Verbo (evento)`
+
+Os eventos de carregamento inicial devem seguir a convenção: `BlocSubject` +
+`Started`
+
+:::note
+
+A classe base de evento deve ser nomeada: `BlocSubject` + `Event`.
+
+:::
+
+### Exemplos
+
+✅ **Bom**
+
+<EventExamplesGood1 />
+
+❌ **Ruim**
+
+<EventExamplesBad1 />
+
+## Convenções de Estado
+
+Os estados devem ser substantivos porque um estado é apenas um snapshot em um
+momento específico no tempo. Existem duas maneiras comuns de representar o
+estado: usando subclasses ou usando uma única classe.
+
+### Anatomia
+
+#### Subclasses
+
+`BlocSubject` + `Verbo (ação)` + `State`
+
+Ao representar o estado como múltiplas subclasses, o `State` deve ser um dos
+seguintes:
+
+`Initial` | `Success` | `Failure` | `InProgress`
+
+:::note
+
+Os estados iniciais devem seguir a convenção: `BlocSubject` + `Initial`.
+
+:::
+
+#### Classe Única
+
+`BlocSubject` + `State`
+
+Ao representar o estado como uma única classe base, um enum nomeado
+`BlocSubject` + `Status` deve ser usado para representar o status do estado:
+
+`initial` | `success` | `failure` | `loading`.
+
+:::note
+
+A classe base de estado deve ser sempre nomeada: `BlocSubject` + `State`.
+
+:::
+
+### Exemplos
+
+✅ **Bom**
+
+##### Subclasses
+
+<StateExamplesGood1Snippet />
+
+##### Classe Única
+
+<SingleStateExamplesGood1Snippet />
+
+❌ **Ruim**
+
+<StateExamplesBad1Snippet />

--- a/docs/src/content/docs/pt-br/testing.mdx
+++ b/docs/src/content/docs/pt-br/testing.mdx
@@ -1,0 +1,81 @@
+---
+title: Testes
+description: O básico de como escrever testes para seus blocs.
+---
+
+import CounterBlocSnippet from '~/components/testing/CounterBlocSnippet.astro';
+import AddDevDependenciesSnippet from '~/components/testing/AddDevDependenciesSnippet.astro';
+import CounterBlocTestImportsSnippet from '~/components/testing/CounterBlocTestImportsSnippet.astro';
+import CounterBlocTestMainSnippet from '~/components/testing/CounterBlocTestMainSnippet.astro';
+import CounterBlocTestSetupSnippet from '~/components/testing/CounterBlocTestSetupSnippet.astro';
+import CounterBlocTestInitialStateSnippet from '~/components/testing/CounterBlocTestInitialStateSnippet.astro';
+import CounterBlocTestBlocTestSnippet from '~/components/testing/CounterBlocTestBlocTestSnippet.astro';
+
+O Bloc foi projetado para ser extremamente fácil de testar. Nesta seção,
+passaremos por como realizar testes unitários em um bloc.
+
+Por simplicidade, vamos escrever testes para o `CounterBloc` que criamos em
+[Conceitos do Bloc](/pt-br/bloc-concepts).
+
+Recapitulando, a implementação do `CounterBloc` se parece com isso:
+
+<CounterBlocSnippet />
+
+## Configuração
+
+Antes de começarmos a escrever nossos testes, precisaremos adicionar um
+framework de testes às nossas dependências.
+
+Precisamos adicionar [test](https://pub.dev/packages/test) e
+[bloc_test](https://pub.dev/packages/bloc_test) ao nosso projeto.
+
+<AddDevDependenciesSnippet />
+
+## Testando
+
+Vamos começar criando o arquivo para os testes do `CounterBloc`,
+`counter_bloc_test.dart`, e importando o pacote de testes.
+
+<CounterBlocTestImportsSnippet />
+
+Em seguida, precisamos criar nossa função `main` bem como nosso grupo de testes.
+
+<CounterBlocTestMainSnippet />
+
+:::note
+
+Os grupos servem para organizar testes individuais, bem como para criar um
+contexto no qual você pode compartilhar funções comuns de `setUp` e `tearDown`
+em todos os testes individuais.
+
+:::
+
+Vamos começar criando uma instância do nosso `CounterBloc` que será utilizada em
+todos os nossos testes.
+
+<CounterBlocTestSetupSnippet />
+
+Agora podemos começar a escrever nossos testes individuais.
+
+<CounterBlocTestInitialStateSnippet />
+
+:::note
+
+Podemos executar todos os nossos testes com o comando `dart test`.
+
+:::
+
+Neste ponto, devemos ter nosso primeiro teste passando! Agora vamos escrever um
+teste mais complexo usando o pacote
+[bloc_test](https://pub.dev/packages/bloc_test).
+
+<CounterBlocTestBlocTestSnippet />
+
+Devemos ser capazes de executar os testes e ver que todos estão passando.
+
+Isso é tudo o que há para fazer, testar deve ser moleza e devemos nos sentir
+confiantes ao fazer alterações e refatorar nosso código.
+
+Você pode consultar o
+[Weather App](https://github.com/felangel/bloc/tree/master/examples/flutter_weather)
+para obter um exemplo de uma aplicação totalmente testada.


### PR DESCRIPTION
Hi there, I noticed that some pages in pt-br were not translated or were outdated. Since it's my native language, I decided to contribute by translating and synchronizing them.

## Status

**READY**

## Breaking Changes

NO

## Description

This PR synchronizes and translates various missing/outdated documentation pages for Portuguese (pt-BR):

- **Sidebar Config (`astro.config.mjs`)**: Configured the translation keys for the entire Portuguese sidebar navigation.
- **Landing Page (`index.mdx`)**: Updated the landing page to reference package version `v9.2.1` in pt-BR.
- **Migration Guide (`migration.mdx`)**: Fully translated the comprehensive guide for migrating between major versions (v5.0.0 to v11.0.0) with MDX-compliant escapes.
- **Testing Guide (`testing.mdx`)**: Created the page detailing how to test Blocs/Cubits using `bloc_test`.
- **Naming Conventions (`naming-conventions.mdx`)**: Localized the official rules for naming Blocs, Cubits, Events, and States.
- **FAQs (`faqs.mdx`)**: Localized the frequently asked questions regarding architecture, async states, and other developer concerns.

All files are structured identically to their English counterparts and the documentation build was verified successfully (`npm run build`) with zero diagnostic errors and fully validated internal links.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
