### PR TITLE
fix(bloc_concurrency): close droppable stream when source ends mid-event

### DIFF
--- a/packages/bloc_concurrency/lib/src/droppable.dart
+++ b/packages/bloc_concurrency/lib/src/droppable.dart
@@ -21,6 +21,7 @@ class _ExhaustMapStreamTransformer<T> extends StreamTransformerBase<T, T> {
   Stream<T> bind(Stream<T> stream) {
     late StreamSubscription<T> subscription;
     StreamSubscription<T>? mappedSubscription;
+    var isSourceDone = false;
 
     final controller = StreamController<T>(
       onCancel: () async {
@@ -29,6 +30,12 @@ class _ExhaustMapStreamTransformer<T> extends StreamTransformerBase<T, T> {
       },
       sync: true,
     );
+
+    // Close the output stream once the source has completed and there is no
+    // event currently in flight.
+    void maybeClose() {
+      if (isSourceDone && mappedSubscription == null) controller.close();
+    }
 
     subscription = stream.listen(
       (data) {
@@ -39,11 +46,17 @@ class _ExhaustMapStreamTransformer<T> extends StreamTransformerBase<T, T> {
         mappedSubscription = mappedStream.listen(
           controller.add,
           onError: controller.addError,
-          onDone: () => mappedSubscription = null,
+          onDone: () {
+            mappedSubscription = null;
+            maybeClose();
+          },
         );
       },
       onError: controller.addError,
-      onDone: () => mappedSubscription ?? controller.close(),
+      onDone: () {
+        isSourceDone = true;
+        maybeClose();
+      },
     );
 
     return controller.stream;

--- a/packages/bloc_concurrency/test/src/droppable_test.dart
+++ b/packages/bloc_concurrency/test/src/droppable_test.dart
@@ -105,5 +105,39 @@ void main() {
 
       expect(states, isEmpty);
     });
+
+    test('closes the output stream when the source ends mid-event', () async {
+      final states = <int>[];
+      var isDone = false;
+      final controller = StreamController<int>();
+      final stream = droppable<int>()(controller.stream, (x) async* {
+        await wait();
+        yield x;
+      });
+
+      final subscription = stream.listen(
+        states.add,
+        onDone: () => isDone = true,
+      );
+
+      controller.add(0);
+
+      await tick();
+
+      // The event handler is in flight when the source stream completes.
+      await controller.close();
+
+      expect(isDone, isFalse);
+      expect(states, isEmpty);
+
+      await wait();
+      await tick();
+
+      // The in-flight event is still delivered and the output stream closes.
+      expect(states, equals([0]));
+      expect(isDone, isTrue);
+
+      await subscription.cancel();
+    });
   });
 }


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

**NO**

## Description

`droppable()` uses a hand-written `_ExhaustMapStreamTransformer` whose output `StreamController` is never closed when the source event stream completes while a mapped event handler is still in flight.

- The source `onDone` (`() => mappedSubscription ?? controller.close()`) intentionally defers closing while a mapped subscription is active, but
- the mapped subscription's `onDone` (`() => mappedSubscription = null`) only clears the reference and never re-checks whether the source has already completed.

As a result the transformed stream never emits `done`: the subscription leaks and a `Bloc`/`Cubit` that is closed while a `droppable` event is being processed never completes. The sibling transformers all propagate source completion (`sequential` → `asyncExpand`, `concurrent` → `concurrentAsyncExpand`, `restartable` → `switchMap`), so `droppable` was the only outlier.

This tracks source completion with an `isSourceDone` flag and closes the output controller once the source is done and no event is in flight (extracted into a small `maybeClose()` helper so the completion condition lives in one place):

- source completes while idle → close immediately (unchanged behavior);
- source completes while an event is in flight → close once the mapped subscription's `onDone` fires.

There is no public API change and no change to event-dropping, cancellation, or idle-completion behavior. A regression test covering the source-completes-mid-event path is included (it fails on `master` and passes with this change); the existing suite stays green at 100% coverage.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
