### PR TITLE
docs(firebase-login): document cache usage in Flutter Firebase Login tutorial

### DIFF
--- a/docs/src/content/docs/tutorials/flutter-firebase-login.mdx
+++ b/docs/src/content/docs/tutorials/flutter-firebase-login.mdx
@@ -54,6 +54,29 @@ implementation details of how we authenticate and fetch user information. In
 this case, it will be integrating with Firebase but we can always change the
 internal implementation later on and our application will be unaffected.
 
+### Caching
+
+The example uses a small, local cache to persist the current `User` between
+app restarts and to avoid unnecessary network calls. The `AuthenticationRepository`
+accepts an optional `CacheClient` and defaults to an in-memory implementation
+(`CacheClient()`) when none is provided. The cache key used for the current
+user is `AuthenticationRepository.userCacheKey` and the repository exposes helper
+methods which write the `User` to cache on login and read the cached `User` on
+startup (defaulting to `User.empty` when no cached value exists).
+
+If you want to inspect or replace the cache implementation used in the example,
+see the cache package used by the tutorial:
+
+- [examples/flutter_firebase_login/packages/cache/lib/cache.dart](https://raw.githubusercontent.com/felangel/bloc/master/examples/flutter_firebase_login/packages/cache/lib/cache.dart)
+
+and the repository usage here:
+
+- [packages/authentication_repository/lib/src/authentication_repository.dart](https://raw.githubusercontent.com/felangel/bloc/master/examples/flutter_firebase_login/packages/authentication_repository/lib/src/authentication_repository.dart)
+
+This simple cache is intentionally lightweight for the tutorial; in a production
+app you might swap in a persistent cache (e.g., Hive, SharedPreferences or
+secure storage) depending on your security and persistence requirements.
+
 ### Setup
 
 We'll start by creating `packages/authentication_repository` and a

--- a/docs/src/content/docs/tutorials/flutter-firebase-login.mdx
+++ b/docs/src/content/docs/tutorials/flutter-firebase-login.mdx
@@ -77,6 +77,35 @@ This simple cache is intentionally lightweight for the tutorial; in a production
 app you might swap in a persistent cache (e.g., Hive, SharedPreferences or
 secure storage) depending on your security and persistence requirements.
 
+#### Example: persistent storage with SharedPreferences
+
+Below is a minimal example showing how to persist and restore the `User` using
+`SharedPreferences`. This example serializes the `User` to JSON; adapt as
+required for your app and consider encryption for sensitive data.
+
+```dart
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _kUserKey = 'cached_user';
+
+Future<void> persistUser(User user) async {
+	final prefs = await SharedPreferences.getInstance();
+	await prefs.setString(_kUserKey, jsonEncode(user.toJson()));
+}
+
+Future<User> readCachedUser() async {
+	final prefs = await SharedPreferences.getInstance();
+	final json = prefs.getString(_kUserKey);
+	if (json == null) return User.empty;
+	return User.fromJson(jsonDecode(json));
+}
+```
+
+If you prefer a fully-featured local database with typed models and better
+performance, consider `Hive` or `moor` (Drift). For sensitive user data use
+secure storage solutions such as `flutter_secure_storage`.
+
 ### Setup
 
 We'll start by creating `packages/authentication_repository` and a


### PR DESCRIPTION
This PR adds a concise 'Caching' section to the Flutter Firebase Login tutorial to explain the in-example cache used by the AuthenticationRepository, links to the cache implementation and repository usage, and provides a short persistent-storage example using SharedPreferences.\n\nChanges:\n- Add caching subsection in tutorial with links to implementation and usage.\n- Add SharedPreferences example for persisting/restoring the cached user.\n\nContext: Addresses feedback in issue #3941 requesting clearer documentation about the cache used in the tutorial.\n\nTesting: Docs-only change; no code behavior modified. Previewed locally via the docs source.\n\nIf helpful, I can expand the example to show  or a Hive-based example for production usage.