### PR TITLE
feat(github_search): add pagination, refresh, and race-safe concurrency

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,6 +28,7 @@ jobs:
       needs_angular_dart_example_checks: ${{ steps.needs_angular_dart_example_checks.outputs.changes }}
       needs_bloc_tools_e2e_checks: ${{ steps.needs_bloc_tools_e2e_checks.outputs.changes }}
       needs_dart_package_checks: ${{ steps.needs_dart_package_checks.outputs.changes }}
+      needs_common_github_search_checks: ${{ steps.needs_common_github_search_checks.outputs.changes }}
       needs_bloc_tools_compile_checks: ${{ steps.needs_bloc_tools_compile_checks.outputs.changes }}
       needs_flutter_package_checks: ${{ steps.needs_flutter_package_checks.outputs.changes }}
       needs_flutter_example_checks: ${{ steps.needs_flutter_example_checks.outputs.changes }}
@@ -100,6 +101,17 @@ jobs:
               - ./.github/workflows/main.yaml
               - ./.github/actions/dart_package/action.yaml
               - packages/bloc/**
+
+      - uses: dorny/paths-filter@v4
+        name: Common GitHub Search Detection
+        id: needs_common_github_search_checks
+        with:
+          filters: |
+            common_github_search:
+              - ./.github/codecov.yml
+              - ./.github/workflows/main.yaml
+              - ./.github/actions/dart_package/action.yaml
+              - examples/github_search/common_github_search/**
 
       - uses: dorny/paths-filter@v4
         name: Bloc Tools Compile Detection
@@ -280,6 +292,31 @@ jobs:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
           collect_score: ${{ matrix.package != 'angular_bloc'}}
           working_directory: packages/${{ matrix.package }}
+          min_coverage: 100
+
+  common_github_search_checks:
+    needs: changes
+    if: ${{ needs.changes.outputs.needs_common_github_search_checks != '[]' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.changes.outputs.needs_common_github_search_checks) }}
+
+    runs-on: ubuntu-latest
+
+    name: 🎯 ${{ matrix.package }}
+
+    steps:
+      - name: 📚 Git Checkout
+        uses: actions/checkout@v7
+
+      - name: 🎯 Build ${{ matrix.package }}
+        uses: ./.github/actions/dart_package
+        with:
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
+          collect_score: false
+          working_directory: examples/github_search/${{ matrix.package }}
           min_coverage: 100
 
   bloc_tools_compile_checks:

--- a/examples/github_search/angular_github_search/lib/src/search_form/search_body/search_body_component.dart
+++ b/examples/github_search/angular_github_search/lib/src/search_form/search_body/search_body_component.dart
@@ -14,6 +14,9 @@ class SearchBodyComponent {
   @Input()
   late GithubSearchState state;
 
+  @Input()
+  late GithubSearchBloc githubSearchBloc;
+
   bool get isEmpty => state is SearchStateEmpty;
   bool get isLoading => state is SearchStateLoading;
   bool get isSuccess => state is SearchStateSuccess;
@@ -22,5 +25,12 @@ class SearchBodyComponent {
   List<SearchResultItem> get items =>
       isSuccess ? (state as SearchStateSuccess).items : [];
 
+  bool get hasReachedMax =>
+      isSuccess && (state as SearchStateSuccess).hasReachedMax;
+
   String get error => isError ? (state as SearchStateError).error : '';
+
+  void loadMore() => githubSearchBloc.add(const NextPageRequested());
+
+  void refresh() => githubSearchBloc.add(const Refreshed());
 }

--- a/examples/github_search/angular_github_search/lib/src/search_form/search_body/search_body_component.html
+++ b/examples/github_search/angular_github_search/lib/src/search_form/search_body/search_body_component.html
@@ -23,5 +23,7 @@
       <p>No Results</p>
     </div>
     <search-results [items]="items"></search-results>
+    <button *ngIf="!hasReachedMax" (click)="loadMore()">Load More</button>
+    <button (click)="refresh()">Refresh</button>
   </div>
 </div>

--- a/examples/github_search/angular_github_search/lib/src/search_form/search_form_component.html
+++ b/examples/github_search/angular_github_search/lib/src/search_form/search_form_component.html
@@ -1,5 +1,8 @@
 <div>
   <h1>GitHub Search</h1>
   <search-bar [githubSearchBloc]="githubSearchBloc"></search-bar>
-  <search-body [state]="$pipe.bloc(githubSearchBloc)"></search-body>
+  <search-body
+    [state]="$pipe.bloc(githubSearchBloc)"
+    [githubSearchBloc]="githubSearchBloc"
+  ></search-body>
 </div>

--- a/examples/github_search/common_github_search/lib/src/github_cache.dart
+++ b/examples/github_search/common_github_search/lib/src/github_cache.dart
@@ -1,6 +1,8 @@
 import 'package:common_github_search/common_github_search.dart';
 
 class GithubCache {
+  // ponytail: key is a composite 'term::page' string built by the repository;
+  // the cache stays a plain String-keyed map (no per-page class needed).
   final _cache = <String, SearchResult>{};
 
   SearchResult? get(String term) => _cache[term];

--- a/examples/github_search/common_github_search/lib/src/github_client.dart
+++ b/examples/github_search/common_github_search/lib/src/github_client.dart
@@ -13,8 +13,16 @@ class GithubClient {
   final String baseUrl;
   final http.Client _httpClient;
 
-  Future<SearchResult> search(String term) async {
-    final response = await _httpClient.get(Uri.parse('$baseUrl$term'));
+  Future<SearchResult> search(
+    String term, {
+    int page = 1,
+    int perPage = 30,
+  }) async {
+    // ponytail: encode the term so an embedded `&` can't inject query params.
+    final query = Uri.encodeQueryComponent(term);
+    final response = await _httpClient.get(
+      Uri.parse('$baseUrl$query&page=$page&per_page=$perPage'),
+    );
     final results = json.decode(response.body) as Map<String, dynamic>;
 
     if (response.statusCode == 200) {

--- a/examples/github_search/common_github_search/lib/src/github_repository.dart
+++ b/examples/github_search/common_github_search/lib/src/github_repository.dart
@@ -10,13 +10,23 @@ class GithubRepository {
   final GithubCache _cache;
   final GithubClient _client;
 
-  Future<SearchResult> search(String term) async {
-    final cachedResult = _cache.get(term);
-    if (cachedResult != null) {
-      return cachedResult;
+  Future<SearchResult> search(
+    String term, {
+    int page = 1,
+    int perPage = 30,
+    bool forceRefresh = false,
+  }) async {
+    // ponytail: composite term+page cache key so pages cache independently.
+    final cacheKey = '$term::$page';
+    if (!forceRefresh) {
+      final cachedResult = _cache.get(cacheKey);
+      if (cachedResult != null) {
+        return cachedResult;
+      }
     }
-    final result = await _client.search(term);
-    _cache.set(term, result);
+    final result = await _client.search(term, page: page, perPage: perPage);
+    // Overwrite so a forced refresh never leaves stale cached data behind.
+    _cache.set(cacheKey, result);
     return result;
   }
 

--- a/examples/github_search/common_github_search/lib/src/github_search_bloc/github_search_bloc.dart
+++ b/examples/github_search/common_github_search/lib/src/github_search_bloc/github_search_bloc.dart
@@ -1,4 +1,7 @@
+import 'dart:developer' as developer;
+
 import 'package:bloc/bloc.dart';
+import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:common_github_search/common_github_search.dart';
 import 'package:stream_transform/stream_transform.dart';
 
@@ -12,9 +15,26 @@ class GithubSearchBloc extends Bloc<GithubSearchEvent, GithubSearchState> {
   GithubSearchBloc({required this._githubRepository})
     : super(SearchStateEmpty()) {
     on<TextChanged>(_onTextChanged, transformer: debounce(_duration));
+    // droppable: ignore new page requests while one is already in flight.
+    on<NextPageRequested>(_onNextPage, transformer: droppable());
+    // restartable: newest refresh wins; resets to page 1.
+    on<Refreshed>(_onRefreshed, transformer: restartable());
   }
 
   final GithubRepository _githubRepository;
+
+  // ponytail: observability for the concurrency behavior — shows in the browser
+  // console under `[GithubSearchBloc]`. Uses dart:developer.log (avoid_print).
+  void _log(String message) => developer.log(message, name: 'GithubSearchBloc');
+
+  // ponytail: monotonic race-guard stamp. Per-handler transformers are
+  // INDEPENDENT — restartable() on Refreshed cancels only the Refreshed
+  // handler's own future, NOT a droppable _onNextPage already awaiting. So a
+  // slow next page can resolve after a refresh/new search and clobber results.
+  // Every fresh search bumps this; _onNextPage drops its result if the stamp
+  // moved while it awaited. Also catches a same-term refresh, which a
+  // searchTerm-only guard would miss.
+  var _generation = 0;
 
   Future<void> _onTextChanged(
     TextChanged event,
@@ -24,17 +44,111 @@ class GithubSearchBloc extends Bloc<GithubSearchEvent, GithubSearchState> {
 
     if (searchTerm.isEmpty) return emit(SearchStateEmpty());
 
+    final generation = ++_generation;
+    _log('search "$searchTerm" g$generation (debounce) p1');
     emit(SearchStateLoading());
 
     try {
-      final results = await _githubRepository.search(searchTerm);
-      emit(SearchStateSuccess(results.items));
-    } catch (error) {
+      final result = await _githubRepository.search(searchTerm);
+      _log('search "$searchTerm" g$generation: ${result.items.length} items');
       emit(
-        error is SearchResultError
-            ? SearchStateError(error.message)
-            : const SearchStateError('something went wrong'),
+        SearchStateSuccess(
+          items: result.items,
+          searchTerm: searchTerm,
+          page: 1,
+          hasReachedMax: _reachedMax(result.items.length, result),
+          generation: generation,
+        ),
       );
+    } catch (error) {
+      emit(_errorState(error));
     }
   }
+
+  Future<void> _onRefreshed(
+    Refreshed event,
+    Emitter<GithubSearchState> emit,
+  ) async {
+    final currentState = state;
+    if (currentState is! SearchStateSuccess) {
+      _log('Refreshed ignored — no active search');
+      return;
+    }
+    final searchTerm = currentState.searchTerm;
+    final generation = ++_generation;
+    _log('refresh "$searchTerm" g$generation (restartable) p1');
+
+    // ponytail: no full-screen SearchStateLoading — RefreshIndicator shows its
+    // own spinner; just emit the new Success (or an error) when data arrives.
+    try {
+      final result = await _githubRepository.search(
+        searchTerm,
+        forceRefresh: true,
+      );
+      emit(
+        SearchStateSuccess(
+          items: result.items,
+          searchTerm: searchTerm,
+          page: 1,
+          hasReachedMax: _reachedMax(result.items.length, result),
+          generation: generation,
+        ),
+      );
+    } catch (error) {
+      emit(_errorState(error));
+    }
+  }
+
+  Future<void> _onNextPage(
+    NextPageRequested event,
+    Emitter<GithubSearchState> emit,
+  ) async {
+    final currentState = state;
+    if (currentState is! SearchStateSuccess || currentState.hasReachedMax) {
+      _log('NextPageRequested ignored — no results or hasReachedMax');
+      return;
+    }
+    final searchTerm = currentState.searchTerm;
+    final generation = currentState.generation; // capture BEFORE await
+    final nextPage = currentState.page + 1;
+    _log('nextPage "$searchTerm" g$generation → p$nextPage (droppable)');
+
+    try {
+      final result = await _githubRepository.search(searchTerm, page: nextPage);
+      // ponytail: droppable only serialises NextPage against itself. A
+      // Refreshed/TextChanged (restartable/debounce) can replace state while
+      // this page is in flight and resolve first. Drop the stale page unless
+      // the same generation is still current.
+      final latest = state;
+      if (latest is! SearchStateSuccess || latest.generation != generation) {
+        final currentGen = latest is SearchStateSuccess
+            ? '${latest.generation}'
+            : 'n/a';
+        _log('DROPPED stale p$nextPage g$generation ≠ current g$currentGen');
+        return;
+      }
+      final merged = [...latest.items, ...result.items];
+      _log('p$nextPage merged → ${merged.length} items g$generation');
+      emit(
+        SearchStateSuccess(
+          items: merged,
+          searchTerm: searchTerm,
+          page: nextPage,
+          hasReachedMax: _reachedMax(merged.length, result),
+          generation: generation,
+        ),
+      );
+    } catch (error) {
+      emit(_errorState(error));
+    }
+  }
+
+  bool _reachedMax(int accumulatedCount, SearchResult result) =>
+      result.items.isEmpty || accumulatedCount >= result.totalCount;
+  // ponytail: GitHub caps search results at 1000; totalCount can exceed that.
+  // Fine for an example.
+
+  GithubSearchState _errorState(Object error) => error is SearchResultError
+      ? SearchStateError(error.message)
+      : const SearchStateError('something went wrong');
 }

--- a/examples/github_search/common_github_search/lib/src/github_search_bloc/github_search_event.dart
+++ b/examples/github_search/common_github_search/lib/src/github_search_bloc/github_search_event.dart
@@ -15,3 +15,17 @@ final class TextChanged extends GithubSearchEvent {
   @override
   String toString() => 'TextChanged { text: $text }';
 }
+
+final class NextPageRequested extends GithubSearchEvent {
+  const NextPageRequested();
+
+  @override
+  List<Object> get props => [];
+}
+
+final class Refreshed extends GithubSearchEvent {
+  const Refreshed();
+
+  @override
+  List<Object> get props => [];
+}

--- a/examples/github_search/common_github_search/lib/src/github_search_bloc/github_search_state.dart
+++ b/examples/github_search/common_github_search/lib/src/github_search_bloc/github_search_state.dart
@@ -13,15 +13,37 @@ final class SearchStateEmpty extends GithubSearchState {}
 final class SearchStateLoading extends GithubSearchState {}
 
 final class SearchStateSuccess extends GithubSearchState {
-  const SearchStateSuccess(this.items);
+  const SearchStateSuccess({
+    required this.items,
+    required this.searchTerm,
+    required this.page,
+    required this.hasReachedMax,
+    required this.generation,
+  });
 
   final List<SearchResultItem> items;
+  final String searchTerm;
+  final int page;
+  final bool hasReachedMax;
+
+  /// Race-guard stamp bumped by every fresh search (TextChanged/Refreshed);
+  /// see GithubSearchBloc — a stale in-flight next page is dropped unless the
+  /// current success state still carries the same generation.
+  final int generation;
 
   @override
-  List<Object> get props => [items];
+  List<Object> get props => [
+    items,
+    searchTerm,
+    page,
+    hasReachedMax,
+    generation,
+  ];
 
   @override
-  String toString() => 'SearchStateSuccess { items: ${items.length} }';
+  String toString() =>
+      'SearchStateSuccess { items: ${items.length}, page: $page, '
+      'hasReachedMax: $hasReachedMax, generation: $generation }';
 }
 
 final class SearchStateError extends GithubSearchState {

--- a/examples/github_search/common_github_search/lib/src/models/search_result.dart
+++ b/examples/github_search/common_github_search/lib/src/models/search_result.dart
@@ -1,7 +1,7 @@
 import 'package:common_github_search/common_github_search.dart';
 
 class SearchResult {
-  const SearchResult({required this.items});
+  const SearchResult({required this.items, required this.totalCount});
 
   factory SearchResult.fromJson(Map<String, dynamic> json) {
     final items = (json['items'] as List<dynamic>)
@@ -10,8 +10,12 @@ class SearchResult {
               SearchResultItem.fromJson(item as Map<String, dynamic>),
         )
         .toList();
-    return SearchResult(items: items);
+    return SearchResult(
+      items: items,
+      totalCount: json['total_count'] as int? ?? 0,
+    );
   }
 
   final List<SearchResultItem> items;
+  final int totalCount;
 }

--- a/examples/github_search/common_github_search/pubspec.yaml
+++ b/examples/github_search/common_github_search/pubspec.yaml
@@ -8,8 +8,12 @@ environment:
 
 dependencies:
   bloc: ^9.0.0
+  bloc_concurrency: ^0.3.0
   equatable: ^2.1.0-dev.0
   http: ^1.0.0
   stream_transform: ^2.0.0
 dev_dependencies:
   bloc_lint: ^0.3.0
+  bloc_test: ^10.0.0
+  mocktail: ^1.0.0
+  test: ^1.17.0

--- a/examples/github_search/common_github_search/pubspec_overrides.yaml
+++ b/examples/github_search/common_github_search/pubspec_overrides.yaml
@@ -1,5 +1,9 @@
 dependency_overrides:
   bloc:
     path: ../../../packages/bloc
+  bloc_concurrency:
+    path: ../../../packages/bloc_concurrency
   bloc_lint:
     path: ../../../packages/bloc_lint
+  bloc_test:
+    path: ../../../packages/bloc_test

--- a/examples/github_search/common_github_search/test/github_cache_test.dart
+++ b/examples/github_search/common_github_search/test/github_cache_test.dart
@@ -1,0 +1,43 @@
+import 'package:common_github_search/common_github_search.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GithubCache', () {
+    late GithubCache cache;
+    const result = SearchResult(items: [], totalCount: 0);
+
+    setUp(() {
+      cache = GithubCache();
+    });
+
+    test('get returns null when the key is absent', () {
+      expect(cache.get('flutter::1'), isNull);
+    });
+
+    test('set stores a result retrievable by get and reported by contains', () {
+      cache.set('flutter::1', result);
+
+      expect(cache.get('flutter::1'), same(result));
+      expect(cache.contains('flutter::1'), isTrue);
+      expect(cache.contains('flutter::2'), isFalse);
+    });
+
+    test('remove deletes a single entry', () {
+      cache
+        ..set('flutter::1', result)
+        ..remove('flutter::1');
+
+      expect(cache.contains('flutter::1'), isFalse);
+    });
+
+    test('close clears every entry', () {
+      cache
+        ..set('flutter::1', result)
+        ..set('flutter::2', result)
+        ..close();
+
+      expect(cache.contains('flutter::1'), isFalse);
+      expect(cache.contains('flutter::2'), isFalse);
+    });
+  });
+}

--- a/examples/github_search/common_github_search/test/github_client_test.dart
+++ b/examples/github_search/common_github_search/test/github_client_test.dart
@@ -1,0 +1,115 @@
+import 'dart:convert';
+
+import 'package:common_github_search/common_github_search.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class MockHttpClient extends Mock implements http.Client {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(Uri());
+  });
+
+  group('GithubClient', () {
+    late http.Client httpClient;
+    late GithubClient client;
+
+    const searchBody = '''
+{
+  "total_count": 1,
+  "items": [
+    {
+      "full_name": "a/a",
+      "html_url": "https://a",
+      "owner": { "login": "octocat", "avatar_url": "https://avatar" }
+    }
+  ]
+}
+''';
+
+    setUp(() {
+      httpClient = MockHttpClient();
+      client = GithubClient(httpClient: httpClient);
+    });
+
+    test(
+      'search builds the URL with encoded term, page and per_page',
+      () async {
+        when(
+          () => httpClient.get(any()),
+        ).thenAnswer((_) async => http.Response(searchBody, 200));
+
+        await client.search('flutter & dart', page: 3, perPage: 50);
+
+        final captured =
+            verify(() => httpClient.get(captureAny())).captured.single as Uri;
+        expect(
+          captured.toString(),
+          'https://api.github.com/search/repositories?q='
+          '${Uri.encodeQueryComponent('flutter & dart')}'
+          '&page=3&per_page=50',
+        );
+      },
+    );
+
+    test('search uses default page 1 and per_page 30', () async {
+      when(
+        () => httpClient.get(any()),
+      ).thenAnswer((_) async => http.Response(searchBody, 200));
+
+      await client.search('flutter');
+
+      final captured =
+          verify(() => httpClient.get(captureAny())).captured.single as Uri;
+      expect(captured.toString(), contains('&page=1&per_page=30'));
+    });
+
+    test('search returns a SearchResult on a 200 response', () async {
+      when(
+        () => httpClient.get(any()),
+      ).thenAnswer((_) async => http.Response(searchBody, 200));
+
+      final result = await client.search('flutter');
+
+      expect(result.totalCount, 1);
+      expect(result.items.single.fullName, 'a/a');
+      expect(result.items.single.owner.login, 'octocat');
+    });
+
+    test('search throws SearchResultError on a non-200 response', () async {
+      when(() => httpClient.get(any())).thenAnswer(
+        (_) async => http.Response(
+          json.encode({'message': 'rate limited'}),
+          403,
+        ),
+      );
+
+      expect(
+        () => client.search('flutter'),
+        throwsA(
+          isA<SearchResultError>().having(
+            (e) => e.message,
+            'message',
+            'rate limited',
+          ),
+        ),
+      );
+    });
+
+    test('close delegates to the underlying http client', () {
+      when(() => httpClient.close()).thenReturn(null);
+
+      client.close();
+
+      verify(() => httpClient.close()).called(1);
+    });
+
+    test('defaults to a real http.Client when none is provided', () {
+      // Exercises the `?? http.Client()` fallback. No request is made; the
+      // default client is created and immediately closed.
+      GithubClient().close();
+    });
+  });
+}

--- a/examples/github_search/common_github_search/test/github_repository_test.dart
+++ b/examples/github_search/common_github_search/test/github_repository_test.dart
@@ -1,0 +1,130 @@
+import 'package:common_github_search/common_github_search.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class MockGithubClient extends Mock implements GithubClient {}
+
+class MockGithubCache extends Mock implements GithubCache {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(const SearchResult(items: [], totalCount: 0));
+  });
+
+  group('GithubRepository', () {
+    late GithubClient client;
+    late GithubCache cache;
+    late GithubRepository repository;
+    const result = SearchResult(items: [], totalCount: 0);
+
+    setUp(() {
+      client = MockGithubClient();
+      cache = MockGithubCache();
+      repository = GithubRepository(cache: cache, client: client);
+    });
+
+    test('cache miss calls the client and caches the result', () async {
+      when(() => cache.get('flutter::1')).thenReturn(null);
+      when(() => cache.set(any(), any())).thenReturn(null);
+      when(
+        () => client.search(
+          any(),
+          page: any(named: 'page'),
+          perPage: any(named: 'perPage'),
+        ),
+      ).thenAnswer((_) async => result);
+
+      final actual = await repository.search('flutter');
+
+      expect(actual, same(result));
+      final captured = verify(
+        () => client.search(
+          'flutter',
+          page: captureAny(named: 'page'),
+          perPage: captureAny(named: 'perPage'),
+        ),
+      ).captured;
+      expect(captured, [1, 30]);
+      verify(() => cache.set('flutter::1', result)).called(1);
+    });
+
+    test(
+      'cache hit returns cached result without calling the client',
+      () async {
+        when(() => cache.get('flutter::1')).thenReturn(result);
+
+        final actual = await repository.search('flutter');
+
+        expect(actual, same(result));
+        verifyNever(
+          () => client.search(
+            any(),
+            page: any(named: 'page'),
+            perPage: any(named: 'perPage'),
+          ),
+        );
+        verifyNever(() => cache.set(any(), any()));
+      },
+    );
+
+    test('composite term::page key is used per page', () async {
+      when(() => cache.get('flutter::2')).thenReturn(null);
+      when(() => cache.set(any(), any())).thenReturn(null);
+      when(
+        () => client.search(
+          any(),
+          page: any(named: 'page'),
+          perPage: any(named: 'perPage'),
+        ),
+      ).thenAnswer((_) async => result);
+
+      await repository.search('flutter', page: 2);
+
+      verify(() => cache.get('flutter::2')).called(1);
+      verify(
+        () => client.search('flutter', page: 2, perPage: any(named: 'perPage')),
+      ).called(1);
+      verify(() => cache.set('flutter::2', result)).called(1);
+    });
+
+    test('forceRefresh bypasses the cache lookup and overwrites it', () async {
+      when(() => cache.set(any(), any())).thenReturn(null);
+      when(
+        () => client.search(
+          any(),
+          page: any(named: 'page'),
+          perPage: any(named: 'perPage'),
+        ),
+      ).thenAnswer((_) async => result);
+
+      final actual = await repository.search('flutter', forceRefresh: true);
+
+      expect(actual, same(result));
+      verifyNever(() => cache.get(any()));
+      verify(
+        () => client.search(
+          'flutter',
+          page: any(named: 'page'),
+          perPage: any(named: 'perPage'),
+        ),
+      ).called(1);
+      verify(() => cache.set('flutter::1', result)).called(1);
+    });
+
+    test('dispose closes both the cache and the client', () {
+      when(() => cache.close()).thenReturn(null);
+      when(() => client.close()).thenReturn(null);
+
+      repository.dispose();
+
+      verify(() => cache.close()).called(1);
+      verify(() => client.close()).called(1);
+    });
+
+    test('defaults to a real cache and client when none are provided', () {
+      // Exercises the `?? GithubCache()` / `?? GithubClient()` fallbacks. No
+      // request is made; the defaults are created and disposed immediately.
+      GithubRepository().dispose();
+    });
+  });
+}

--- a/examples/github_search/common_github_search/test/github_search_bloc_test.dart
+++ b/examples/github_search/common_github_search/test/github_search_bloc_test.dart
@@ -1,0 +1,375 @@
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:common_github_search/common_github_search.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class MockGithubRepository extends Mock implements GithubRepository {}
+
+// Shared fixture instances. SearchResultItem is not Equatable, so states
+// compare items by identity — expected states must reuse the same instances.
+const _owner = GithubUser(login: 'octocat', avatarUrl: 'https://avatar');
+const _itemA = SearchResultItem(
+  fullName: 'a/a',
+  htmlUrl: 'https://a',
+  owner: _owner,
+);
+const _itemB = SearchResultItem(
+  fullName: 'b/b',
+  htmlUrl: 'https://b',
+  owner: _owner,
+);
+const _itemC = SearchResultItem(
+  fullName: 'c/c',
+  htmlUrl: 'https://c',
+  owner: _owner,
+);
+
+void main() {
+  late GithubRepository repository;
+
+  setUp(() {
+    repository = MockGithubRepository();
+  });
+
+  group('GithubSearchBloc', () {
+    blocTest<GithubSearchBloc, GithubSearchState>(
+      'debounced TextChanged emits [Loading, Success(page 1)]',
+      setUp: () {
+        when(() => repository.search('flutter')).thenAnswer(
+          (_) async => const SearchResult(items: [_itemA], totalCount: 1),
+        );
+      },
+      build: () => GithubSearchBloc(githubRepository: repository),
+      act: (bloc) => bloc.add(const TextChanged(text: 'flutter')),
+      wait: const Duration(milliseconds: 400),
+      expect: () => <GithubSearchState>[
+        SearchStateLoading(),
+        const SearchStateSuccess(
+          items: [_itemA],
+          searchTerm: 'flutter',
+          page: 1,
+          hasReachedMax: true,
+          generation: 1,
+        ),
+      ],
+    );
+
+    blocTest<GithubSearchBloc, GithubSearchState>(
+      'NextPageRequested accumulates items and increments page',
+      setUp: () {
+        when(
+          () => repository.search('flutter', page: 2),
+        ).thenAnswer(
+          (_) async => const SearchResult(items: [_itemB], totalCount: 100),
+        );
+      },
+      build: () => GithubSearchBloc(githubRepository: repository),
+      seed: () => const SearchStateSuccess(
+        items: [_itemA],
+        searchTerm: 'flutter',
+        page: 1,
+        hasReachedMax: false,
+        generation: 5,
+      ),
+      act: (bloc) => bloc.add(const NextPageRequested()),
+      expect: () => const <GithubSearchState>[
+        SearchStateSuccess(
+          items: [_itemA, _itemB],
+          searchTerm: 'flutter',
+          page: 2,
+          hasReachedMax: false,
+          generation: 5,
+        ),
+      ],
+    );
+
+    blocTest<GithubSearchBloc, GithubSearchState>(
+      'NextPageRequested is a no-op when hasReachedMax is true',
+      build: () => GithubSearchBloc(githubRepository: repository),
+      seed: () => const SearchStateSuccess(
+        items: [_itemA],
+        searchTerm: 'flutter',
+        page: 1,
+        hasReachedMax: true,
+        generation: 1,
+      ),
+      act: (bloc) => bloc.add(const NextPageRequested()),
+      expect: () => const <GithubSearchState>[],
+      verify: (_) => verifyNever(
+        () => repository.search(any(), page: any(named: 'page')),
+      ),
+    );
+
+    blocTest<GithubSearchBloc, GithubSearchState>(
+      'droppable: a second NextPageRequested in flight is dropped',
+      setUp: () {
+        when(() => repository.search('flutter', page: 2)).thenAnswer(
+          (_) => Future.delayed(
+            const Duration(milliseconds: 100),
+            () => const SearchResult(items: [_itemB], totalCount: 100),
+          ),
+        );
+      },
+      build: () => GithubSearchBloc(githubRepository: repository),
+      seed: () => const SearchStateSuccess(
+        items: [_itemA],
+        searchTerm: 'flutter',
+        page: 1,
+        hasReachedMax: false,
+        generation: 0,
+      ),
+      act: (bloc) => bloc
+        ..add(const NextPageRequested())
+        ..add(const NextPageRequested()),
+      wait: const Duration(milliseconds: 300),
+      expect: () => const <GithubSearchState>[
+        SearchStateSuccess(
+          items: [_itemA, _itemB],
+          searchTerm: 'flutter',
+          page: 2,
+          hasReachedMax: false,
+          generation: 0,
+        ),
+      ],
+      verify: (_) =>
+          verify(() => repository.search('flutter', page: 2)).called(1),
+    );
+
+    blocTest<GithubSearchBloc, GithubSearchState>(
+      'Refreshed force-refreshes page 1 (forceRefresh: true)',
+      setUp: () {
+        when(
+          () => repository.search('flutter', forceRefresh: true),
+        ).thenAnswer(
+          (_) async => const SearchResult(items: [_itemC], totalCount: 100),
+        );
+      },
+      build: () => GithubSearchBloc(githubRepository: repository),
+      seed: () => const SearchStateSuccess(
+        items: [_itemA, _itemB],
+        searchTerm: 'flutter',
+        page: 2,
+        hasReachedMax: false,
+        generation: 0,
+      ),
+      act: (bloc) => bloc.add(const Refreshed()),
+      expect: () => const <GithubSearchState>[
+        SearchStateSuccess(
+          items: [_itemC],
+          searchTerm: 'flutter',
+          page: 1,
+          hasReachedMax: false,
+          generation: 1,
+        ),
+      ],
+      verify: (_) => verify(
+        () => repository.search('flutter', forceRefresh: true),
+      ).called(1),
+    );
+
+    blocTest<GithubSearchBloc, GithubSearchState>(
+      'Refreshed is a no-op when state is not SearchStateSuccess',
+      build: () => GithubSearchBloc(githubRepository: repository),
+      // Bloc starts in SearchStateEmpty; Refreshed must early-return safely.
+      act: (bloc) => bloc.add(const Refreshed()),
+      expect: () => const <GithubSearchState>[],
+      verify: (_) => verifyNever(
+        () => repository.search(
+          any(),
+          forceRefresh: any(named: 'forceRefresh'),
+        ),
+      ),
+    );
+
+    blocTest<GithubSearchBloc, GithubSearchState>(
+      'empty TextChanged emits [SearchStateEmpty] without hitting the repo',
+      build: () => GithubSearchBloc(githubRepository: repository),
+      act: (bloc) => bloc.add(const TextChanged(text: '')),
+      wait: const Duration(milliseconds: 400),
+      expect: () => <GithubSearchState>[SearchStateEmpty()],
+      verify: (_) => verifyNever(() => repository.search(any())),
+    );
+
+    blocTest<GithubSearchBloc, GithubSearchState>(
+      'TextChanged with empty result marks hasReachedMax true',
+      setUp: () {
+        when(() => repository.search('flutter')).thenAnswer(
+          (_) async => const SearchResult(items: [], totalCount: 0),
+        );
+      },
+      build: () => GithubSearchBloc(githubRepository: repository),
+      act: (bloc) => bloc.add(const TextChanged(text: 'flutter')),
+      wait: const Duration(milliseconds: 400),
+      expect: () => <GithubSearchState>[
+        SearchStateLoading(),
+        const SearchStateSuccess(
+          items: [],
+          searchTerm: 'flutter',
+          page: 1,
+          hasReachedMax: true,
+          generation: 1,
+        ),
+      ],
+    );
+
+    blocTest<GithubSearchBloc, GithubSearchState>(
+      'TextChanged maps SearchResultError to SearchStateError(message)',
+      setUp: () {
+        when(
+          () => repository.search('flutter'),
+        ).thenThrow(SearchResultError(message: 'rate limited'));
+      },
+      build: () => GithubSearchBloc(githubRepository: repository),
+      act: (bloc) => bloc.add(const TextChanged(text: 'flutter')),
+      wait: const Duration(milliseconds: 400),
+      expect: () => <GithubSearchState>[
+        SearchStateLoading(),
+        const SearchStateError('rate limited'),
+      ],
+    );
+
+    blocTest<GithubSearchBloc, GithubSearchState>(
+      'TextChanged maps a generic error to the fallback message',
+      setUp: () {
+        when(() => repository.search('flutter')).thenThrow(Exception('boom'));
+      },
+      build: () => GithubSearchBloc(githubRepository: repository),
+      act: (bloc) => bloc.add(const TextChanged(text: 'flutter')),
+      wait: const Duration(milliseconds: 400),
+      expect: () => <GithubSearchState>[
+        SearchStateLoading(),
+        const SearchStateError('something went wrong'),
+      ],
+    );
+
+    blocTest<GithubSearchBloc, GithubSearchState>(
+      'Refreshed emits SearchStateError when the repo throws',
+      setUp: () {
+        when(
+          () => repository.search('flutter', forceRefresh: true),
+        ).thenThrow(SearchResultError(message: 'refresh failed'));
+      },
+      build: () => GithubSearchBloc(githubRepository: repository),
+      seed: () => const SearchStateSuccess(
+        items: [_itemA],
+        searchTerm: 'flutter',
+        page: 1,
+        hasReachedMax: false,
+        generation: 0,
+      ),
+      act: (bloc) => bloc.add(const Refreshed()),
+      expect: () => const <GithubSearchState>[
+        SearchStateError('refresh failed'),
+      ],
+    );
+
+    blocTest<GithubSearchBloc, GithubSearchState>(
+      'NextPageRequested is a no-op when state is not SearchStateSuccess',
+      build: () => GithubSearchBloc(githubRepository: repository),
+      act: (bloc) => bloc.add(const NextPageRequested()),
+      expect: () => const <GithubSearchState>[],
+      verify: (_) => verifyNever(
+        () => repository.search(any(), page: any(named: 'page')),
+      ),
+    );
+
+    blocTest<GithubSearchBloc, GithubSearchState>(
+      'NextPageRequested emits SearchStateError when the repo throws',
+      setUp: () {
+        when(
+          () => repository.search('flutter', page: 2),
+        ).thenThrow(Exception('boom'));
+      },
+      build: () => GithubSearchBloc(githubRepository: repository),
+      seed: () => const SearchStateSuccess(
+        items: [_itemA],
+        searchTerm: 'flutter',
+        page: 1,
+        hasReachedMax: false,
+        generation: 0,
+      ),
+      act: (bloc) => bloc.add(const NextPageRequested()),
+      expect: () => const <GithubSearchState>[
+        SearchStateError('something went wrong'),
+      ],
+    );
+
+    blocTest<GithubSearchBloc, GithubSearchState>(
+      'NextPageRequested with empty page marks hasReachedMax true',
+      setUp: () {
+        when(() => repository.search('flutter', page: 2)).thenAnswer(
+          (_) async => const SearchResult(items: [], totalCount: 100),
+        );
+      },
+      build: () => GithubSearchBloc(githubRepository: repository),
+      seed: () => const SearchStateSuccess(
+        items: [_itemA],
+        searchTerm: 'flutter',
+        page: 1,
+        hasReachedMax: false,
+        generation: 0,
+      ),
+      act: (bloc) => bloc.add(const NextPageRequested()),
+      expect: () => const <GithubSearchState>[
+        SearchStateSuccess(
+          items: [_itemA],
+          searchTerm: 'flutter',
+          page: 2,
+          hasReachedMax: true,
+          generation: 0,
+        ),
+      ],
+    );
+
+    blocTest<GithubSearchBloc, GithubSearchState>(
+      'race guard: a slow next page resolving after a refresh is dropped',
+      setUp: () {
+        // Next page hangs until we complete it manually, AFTER the refresh.
+        final pageCompleter = Completer<SearchResult>();
+        when(
+          () => repository.search('flutter', page: 2),
+        ).thenAnswer((_) => pageCompleter.future);
+        when(
+          () => repository.search('flutter', forceRefresh: true),
+        ).thenAnswer(
+          (_) async => const SearchResult(items: [_itemC], totalCount: 100),
+        );
+        _pageCompleter = pageCompleter;
+      },
+      build: () => GithubSearchBloc(githubRepository: repository),
+      // generation 0 matches the bloc's internal counter initial value.
+      seed: () => const SearchStateSuccess(
+        items: [_itemA],
+        searchTerm: 'flutter',
+        page: 1,
+        hasReachedMax: false,
+        generation: 0,
+      ),
+      act: (bloc) async {
+        bloc.add(const NextPageRequested()); // captures generation 0, awaits
+        await Future<void>.delayed(Duration.zero);
+        bloc.add(const Refreshed()); // bumps generation to 1, emits page 1
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        _pageCompleter.complete(
+          const SearchResult(items: [_itemB], totalCount: 100),
+        ); // resolves late -> must be dropped, not merged
+      },
+      wait: const Duration(milliseconds: 100),
+      // Only the refresh survives; the stale next page (would-be
+      // [_itemA, _itemB]) is discarded because generation moved from 0 to 1.
+      expect: () => const <GithubSearchState>[
+        SearchStateSuccess(
+          items: [_itemC],
+          searchTerm: 'flutter',
+          page: 1,
+          hasReachedMax: false,
+          generation: 1,
+        ),
+      ],
+    );
+  });
+}
+
+late Completer<SearchResult> _pageCompleter;

--- a/examples/github_search/common_github_search/test/github_search_event_test.dart
+++ b/examples/github_search/common_github_search/test/github_search_event_test.dart
@@ -1,0 +1,46 @@
+import 'package:common_github_search/common_github_search.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TextChanged', () {
+    test('supports value equality via props', () {
+      expect(
+        const TextChanged(text: 'flutter'),
+        const TextChanged(text: 'flutter'),
+      );
+      expect(
+        const TextChanged(text: 'flutter'),
+        isNot(const TextChanged(text: 'bloc')),
+      );
+    });
+
+    test('toString includes the text', () {
+      expect(
+        const TextChanged(text: 'flutter').toString(),
+        'TextChanged { text: flutter }',
+      );
+    });
+  });
+
+  group('NextPageRequested', () {
+    test('supports value equality with empty props', () {
+      expect(const NextPageRequested(), const NextPageRequested());
+      expect(const NextPageRequested().props, isEmpty);
+    });
+
+    test('toString uses the default Equatable representation', () {
+      expect(const NextPageRequested().toString(), 'NextPageRequested()');
+    });
+  });
+
+  group('Refreshed', () {
+    test('supports value equality with empty props', () {
+      expect(const Refreshed(), const Refreshed());
+      expect(const Refreshed().props, isEmpty);
+    });
+
+    test('toString uses the default Equatable representation', () {
+      expect(const Refreshed().toString(), 'Refreshed()');
+    });
+  });
+}

--- a/examples/github_search/common_github_search/test/github_search_state_test.dart
+++ b/examples/github_search/common_github_search/test/github_search_state_test.dart
@@ -1,0 +1,82 @@
+import 'package:common_github_search/common_github_search.dart';
+import 'package:test/test.dart';
+
+const _owner = GithubUser(login: 'octocat', avatarUrl: 'https://avatar');
+const _item = SearchResultItem(
+  fullName: 'a/a',
+  htmlUrl: 'https://a',
+  owner: _owner,
+);
+
+void main() {
+  group('SearchStateEmpty', () {
+    test('supports value equality', () {
+      expect(SearchStateEmpty(), SearchStateEmpty());
+    });
+  });
+
+  group('SearchStateLoading', () {
+    test('supports value equality', () {
+      expect(SearchStateLoading(), SearchStateLoading());
+    });
+  });
+
+  group('SearchStateSuccess', () {
+    const state = SearchStateSuccess(
+      items: [_item],
+      searchTerm: 'flutter',
+      page: 1,
+      hasReachedMax: false,
+      generation: 1,
+    );
+
+    test('supports value equality via props', () {
+      expect(
+        state,
+        const SearchStateSuccess(
+          items: [_item],
+          searchTerm: 'flutter',
+          page: 1,
+          hasReachedMax: false,
+          generation: 1,
+        ),
+      );
+    });
+
+    test('differs when any field differs', () {
+      expect(
+        state,
+        isNot(
+          const SearchStateSuccess(
+            items: [_item],
+            searchTerm: 'flutter',
+            page: 2,
+            hasReachedMax: false,
+            generation: 1,
+          ),
+        ),
+      );
+    });
+
+    test('toString summarises item count, page, max and generation', () {
+      expect(
+        state.toString(),
+        'SearchStateSuccess { items: 1, page: 1, '
+        'hasReachedMax: false, generation: 1 }',
+      );
+    });
+  });
+
+  group('SearchStateError', () {
+    test('supports value equality via props', () {
+      expect(
+        const SearchStateError('boom'),
+        const SearchStateError('boom'),
+      );
+      expect(
+        const SearchStateError('boom'),
+        isNot(const SearchStateError('bang')),
+      );
+    });
+  });
+}

--- a/examples/github_search/common_github_search/test/models_test.dart
+++ b/examples/github_search/common_github_search/test/models_test.dart
@@ -1,0 +1,64 @@
+import 'package:common_github_search/common_github_search.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GithubUser', () {
+    test('fromJson maps login and avatar_url', () {
+      final user = GithubUser.fromJson({
+        'login': 'octocat',
+        'avatar_url': 'https://avatar',
+      });
+
+      expect(user.login, 'octocat');
+      expect(user.avatarUrl, 'https://avatar');
+    });
+  });
+
+  group('SearchResultItem', () {
+    test('fromJson maps fields and nested owner', () {
+      final item = SearchResultItem.fromJson({
+        'full_name': 'a/a',
+        'html_url': 'https://a',
+        'owner': {'login': 'octocat', 'avatar_url': 'https://avatar'},
+      });
+
+      expect(item.fullName, 'a/a');
+      expect(item.htmlUrl, 'https://a');
+      expect(item.owner.login, 'octocat');
+      expect(item.owner.avatarUrl, 'https://avatar');
+    });
+  });
+
+  group('SearchResult', () {
+    test('fromJson maps items and total_count', () {
+      final result = SearchResult.fromJson({
+        'total_count': 42,
+        'items': [
+          {
+            'full_name': 'a/a',
+            'html_url': 'https://a',
+            'owner': {'login': 'octocat', 'avatar_url': 'https://avatar'},
+          },
+        ],
+      });
+
+      expect(result.totalCount, 42);
+      expect(result.items.single.fullName, 'a/a');
+    });
+
+    test('fromJson defaults total_count to 0 when missing', () {
+      final result = SearchResult.fromJson({'items': <dynamic>[]});
+
+      expect(result.totalCount, 0);
+      expect(result.items, isEmpty);
+    });
+  });
+
+  group('SearchResultError', () {
+    test('fromJson maps message', () {
+      final error = SearchResultError.fromJson({'message': 'not found'});
+
+      expect(error.message, 'not found');
+    });
+  });
+}

--- a/examples/github_search/flutter_github_search/lib/search_form.dart
+++ b/examples/github_search/flutter_github_search/lib/search_form.dart
@@ -78,25 +78,97 @@ class _SearchBody extends StatelessWidget {
           SearchStateSuccess() =>
             state.items.isEmpty
                 ? const Text('No Results')
-                : Expanded(child: _SearchResults(items: state.items)),
+                : Expanded(child: _SearchResults(state: state)),
         };
       },
     );
   }
 }
 
-class _SearchResults extends StatelessWidget {
-  const _SearchResults({required this.items});
+class _SearchResults extends StatefulWidget {
+  const _SearchResults({required this.state});
 
-  final List<SearchResultItem> items;
+  final SearchStateSuccess state;
+
+  @override
+  State<_SearchResults> createState() => _SearchResultsState();
+}
+
+class _SearchResultsState extends State<_SearchResults> {
+  final _scrollController = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    return ListView.builder(
-      itemCount: items.length,
-      itemBuilder: (BuildContext context, int index) {
-        return _SearchResultItem(item: items[index]);
+    final items = widget.state.items;
+    final hasReachedMax = widget.state.hasReachedMax;
+    return RefreshIndicator(
+      onRefresh: () {
+        // ponytail: RefreshIndicator needs a Future to dismiss its spinner —
+        // fire Refreshed and await the next terminal (success/error) state.
+        // orElse guards a closed stream (firstWhere would throw StateError),
+        // catchError guards any other stream error, and timeout guarantees the
+        // spinner always dismisses even if no terminal state ever arrives.
+        final bloc = context.read<GithubSearchBloc>()..add(const Refreshed());
+        return bloc.stream
+            .firstWhere(
+              (s) => s is SearchStateSuccess || s is SearchStateError,
+              orElse: () => bloc.state,
+            )
+            .timeout(
+              const Duration(seconds: 10),
+              onTimeout: () => bloc.state,
+            )
+            .catchError((_) => bloc.state);
       },
+      child: ListView.builder(
+        controller: _scrollController,
+        itemCount: hasReachedMax ? items.length : items.length + 1,
+        itemBuilder: (BuildContext context, int index) {
+          return index >= items.length
+              ? const _BottomLoader()
+              : _SearchResultItem(item: items[index]);
+        },
+      ),
+    );
+  }
+
+  void _onScroll() {
+    if (_isBottom) {
+      context.read<GithubSearchBloc>().add(const NextPageRequested());
+    }
+  }
+
+  bool get _isBottom {
+    if (!_scrollController.hasClients) return false;
+    final maxScroll = _scrollController.position.maxScrollExtent;
+    final currentScroll = _scrollController.offset;
+    return currentScroll >= (maxScroll * 0.9);
+  }
+}
+
+class _BottomLoader extends StatelessWidget {
+  const _BottomLoader();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: SizedBox(
+        height: 24,
+        width: 24,
+        child: CircularProgressIndicator.adaptive(strokeWidth: 1.5),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Status

**IN DEVELOPMENT**

## Breaking Changes

**NO**

## Description

Closes #2785.

Extends the `github_search` example to demonstrate **search + pagination +
pull-to-refresh together with correct concurrency** — the combination the
issue asks for. Per @felangel's guidance on the issue, this builds on
`github_search` (which already has debounced search) rather than modifying the
`flutter_infinite_list` example, which is intentionally kept minimal.

### Approach

A single `GithubSearchBloc` with one event type per concern, each using the
`bloc_concurrency` transformer that fits it:

| Event | Transformer | Behavior |
|-------|-------------|----------|
| `TextChanged` | `debounce` | debounced search, resets to page 1 |
| `NextPageRequested` | `droppable` | ignores new page requests while one is in flight |
| `Refreshed` | `restartable` | newest refresh wins, resets to page 1 |

### The race the issue calls out

The reporter's core concern is a slow **next-page** request completing *after*
a **refresh** and corrupting pagination. Because per-handler transformers are
independent, `restartable` on `Refreshed` cancels only its own future — not a
`droppable` next-page already awaiting. A monotonic `generation` stamp on
`SearchStateSuccess` fixes this: `_onNextPage` captures the generation before
its `await` and drops the result if the generation moved while it was in
flight (covers new-search *and* same-term-refresh). Proven deterministically
by a `Completer`-driven test.

### Changes

- `common_github_search`: paged `GithubClient`/`GithubRepository`,
  accumulating `SearchStateSuccess` (`page`/`hasReachedMax`/`generation`),
  new `NextPageRequested` / `Refreshed` events, `bloc_concurrency` dependency.
- `flutter_github_search`: infinite scroll + `RefreshIndicator`.
- `angular_github_search`: parity (Load More / Refresh) so it keeps building.
- **Tests**: `common_github_search` at **100% line coverage** (mocked
  repository/client — no live network).
- **CI**: dedicated `common_github_search` job enforcing `min_coverage: 100`.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
