### PR TITLE
fix: make Freezed templates compatible with Freezed 3

### DIFF
--- a/bricks/bloc/__brick__/{{~ freezed_event }}
+++ b/bricks/bloc/__brick__/{{~ freezed_event }}
@@ -1,6 +1,6 @@
 part of '{{name.snakeCase()}}_bloc.dart';
 
 @freezed
-class {{name.pascalCase()}}Event with _${{name.pascalCase()}}Event {
+abstract class {{name.pascalCase()}}Event with _${{name.pascalCase()}}Event {
   const factory {{name.pascalCase()}}Event.started() = _Started;
 }

--- a/bricks/bloc/__brick__/{{~ freezed_state }}
+++ b/bricks/bloc/__brick__/{{~ freezed_state }}
@@ -1,6 +1,6 @@
 part of '{{name.snakeCase()}}_bloc.dart';
 
 @freezed
-class {{name.pascalCase()}}State with _${{name.pascalCase()}}State {
+abstract class {{name.pascalCase()}}State with _${{name.pascalCase()}}State {
   const factory {{name.pascalCase()}}State.initial() = _Initial;
 }

--- a/bricks/cubit/__brick__/{{~ freezed_state }}
+++ b/bricks/cubit/__brick__/{{~ freezed_state }}
@@ -1,6 +1,6 @@
 part of '{{name.snakeCase()}}_cubit.dart';
 
 @freezed
-class {{name.pascalCase()}}State with _${{name.pascalCase()}}State {
+abstract class {{name.pascalCase()}}State with _${{name.pascalCase()}}State {
   const factory {{name.pascalCase()}}State.initial() = _Initial;
 }

--- a/bricks/hydrated_bloc/__brick__/{{~ freezed_event }}
+++ b/bricks/hydrated_bloc/__brick__/{{~ freezed_event }}
@@ -1,6 +1,6 @@
 part of '{{name.snakeCase()}}_bloc.dart';
 
 @freezed
-class {{name.pascalCase()}}Event with _${{name.pascalCase()}}Event {
+abstract class {{name.pascalCase()}}Event with _${{name.pascalCase()}}Event {
   const factory {{name.pascalCase()}}Event.started() = _Started;
 }

--- a/bricks/hydrated_bloc/__brick__/{{~ freezed_state }}
+++ b/bricks/hydrated_bloc/__brick__/{{~ freezed_state }}
@@ -1,6 +1,6 @@
 part of '{{name.snakeCase()}}_bloc.dart';
 
 @freezed
-class {{name.pascalCase()}}State with _${{name.pascalCase()}}State {
+abstract class {{name.pascalCase()}}State with _${{name.pascalCase()}}State {
   const factory {{name.pascalCase()}}State.initial() = _Initial;
 }

--- a/bricks/hydrated_cubit/__brick__/{{~ freezed_state }}
+++ b/bricks/hydrated_cubit/__brick__/{{~ freezed_state }}
@@ -1,6 +1,6 @@
 part of '{{name.snakeCase()}}_cubit.dart';
 
 @freezed
-class {{name.pascalCase()}}State with _${{name.pascalCase()}}State {
+abstract class {{name.pascalCase()}}State with _${{name.pascalCase()}}State {
   const factory {{name.pascalCase()}}State.initial() = _Initial;
 }

--- a/bricks/replay_bloc/__brick__/{{~ freezed_event }}
+++ b/bricks/replay_bloc/__brick__/{{~ freezed_event }}
@@ -1,6 +1,6 @@
 part of '{{name.snakeCase()}}_bloc.dart';
 
 @freezed
-class {{name.pascalCase()}}Event extends ReplayEvent with _${{name.pascalCase()}}Event {
+abstract class {{name.pascalCase()}}Event extends ReplayEvent with _${{name.pascalCase()}}Event {
   const factory {{name.pascalCase()}}Event.started() = _Started;
 }

--- a/bricks/replay_bloc/__brick__/{{~ freezed_state }}
+++ b/bricks/replay_bloc/__brick__/{{~ freezed_state }}
@@ -1,6 +1,6 @@
 part of '{{name.snakeCase()}}_bloc.dart';
 
 @freezed
-class {{name.pascalCase()}}State with _${{name.pascalCase()}}State {
+abstract class {{name.pascalCase()}}State with _${{name.pascalCase()}}State {
   const factory {{name.pascalCase()}}State.initial() = _Initial;
 }

--- a/bricks/replay_cubit/__brick__/{{~ freezed_state }}
+++ b/bricks/replay_cubit/__brick__/{{~ freezed_state }}
@@ -1,6 +1,6 @@
 part of '{{name.snakeCase()}}_cubit.dart';
 
 @freezed
-class {{name.pascalCase()}}State with _${{name.pascalCase()}}State {
+abstract class {{name.pascalCase()}}State with _${{name.pascalCase()}}State {
   const factory {{name.pascalCase()}}State.initial() = _Initial;
 }

--- a/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/bloc_freezed/bloc_event.dart.template
+++ b/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/bloc_freezed/bloc_event.dart.template
@@ -1,6 +1,6 @@
 part of '{{bloc_snake_case}}_bloc.dart';
 
 @freezed
-class {{bloc_pascal_case}}Event with _${{bloc_pascal_case}}Event {
+abstract class {{bloc_pascal_case}}Event with _${{bloc_pascal_case}}Event {
   const factory {{bloc_pascal_case}}Event.started() = _Started;
 }

--- a/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/bloc_freezed/bloc_state.dart.template
+++ b/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/bloc_freezed/bloc_state.dart.template
@@ -1,6 +1,6 @@
 part of '{{bloc_snake_case}}_bloc.dart';
 
 @freezed
-class {{bloc_pascal_case}}State with _${{bloc_pascal_case}}State {
+abstract class {{bloc_pascal_case}}State with _${{bloc_pascal_case}}State {
   const factory {{bloc_pascal_case}}State.initial() = _Initial;
 }

--- a/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/cubit_freezed/cubit_state.dart.template
+++ b/extensions/intellij/intellij_generator_plugin/src/main/resources/templates/cubit_freezed/cubit_state.dart.template
@@ -1,6 +1,6 @@
 part of '{{cubit_snake_case}}_cubit.dart';
 
 @freezed
-class {{cubit_pascal_case}}State with _${{cubit_pascal_case}}State {
+abstract class {{cubit_pascal_case}}State with _${{cubit_pascal_case}}State {
   const factory {{cubit_pascal_case}}State.initial() = _Initial;
 }

--- a/extensions/vscode/src/templates/bloc-event.template.ts
+++ b/extensions/vscode/src/templates/bloc-event.template.ts
@@ -54,7 +54,7 @@ function getFreezedBlocEvent(blocName: string): string {
   return `part of '${snakeCaseBlocName}_bloc.dart';
 
 @freezed
-class ${pascalCaseBlocName} with _\$${pascalCaseBlocName} {
+abstract class ${pascalCaseBlocName} with _\$${pascalCaseBlocName} {
   const factory ${pascalCaseBlocName}.started() = _Started;
 }`;
 }

--- a/extensions/vscode/src/templates/bloc-state.template.ts
+++ b/extensions/vscode/src/templates/bloc-state.template.ts
@@ -60,7 +60,7 @@ function getFreezedBlocStateTemplate(blocName: string): string {
   return `part of '${snakeCaseBlocName}_bloc.dart';
 
 @freezed
-class ${pascalCaseBlocName} with _\$${pascalCaseBlocName} {
+abstract class ${pascalCaseBlocName} with _\$${pascalCaseBlocName} {
   const factory ${pascalCaseBlocName}.initial() = _Initial;
 }
 `;

--- a/extensions/vscode/src/templates/cubit-state.template.ts
+++ b/extensions/vscode/src/templates/cubit-state.template.ts
@@ -60,7 +60,7 @@ function getFreezedCubitStateTemplate(cubitName: string): string {
   return `part of '${snakeCaseCubitName}_cubit.dart';
 
 @freezed
-class ${pascalCaseCubitName}State with _\$${pascalCaseCubitName}State {
+abstract class ${pascalCaseCubitName}State with _\$${pascalCaseCubitName}State {
   const factory ${pascalCaseCubitName}State.initial() = _Initial;
 }
 `;

--- a/packages/bloc_tools/lib/src/commands/new/bundles/bloc_bundle.dart
+++ b/packages/bloc_tools/lib/src/commands/new/bundles/bloc_bundle.dart
@@ -68,13 +68,13 @@ final blocBundle = MasonBundle.fromJson(<String, dynamic>{
     {
       "path": "{{~ freezed_event }}",
       "data":
-          "cGFydCBvZiAne3tuYW1lLnNuYWtlQ2FzZSgpfX1fYmxvYy5kYXJ0JzsKCkBmcmVlemVkCmNsYXNzIHt7bmFtZS5wYXNjYWxDYXNlKCl9fUV2ZW50IHdpdGggXyR7e25hbWUucGFzY2FsQ2FzZSgpfX1FdmVudCB7CiAgY29uc3QgZmFjdG9yeSB7e25hbWUucGFzY2FsQ2FzZSgpfX1FdmVudC5zdGFydGVkKCkgPSBfU3RhcnRlZDsKfQo=",
+          "cGFydCBvZiAne3tuYW1lLnNuYWtlQ2FzZSgpfX1fYmxvYy5kYXJ0JzsKCkBmcmVlemVkCmFic3RyYWN0IGNsYXNzIHt7bmFtZS5wYXNjYWxDYXNlKCl9fUV2ZW50IHdpdGggXyR7e25hbWUucGFzY2FsQ2FzZSgpfX1FdmVudCB7CiAgY29uc3QgZmFjdG9yeSB7e25hbWUucGFzY2FsQ2FzZSgpfX1FdmVudC5zdGFydGVkKCkgPSBfU3RhcnRlZDsKfQo=",
       "type": "text",
     },
     {
       "path": "{{~ freezed_state }}",
       "data":
-          "cGFydCBvZiAne3tuYW1lLnNuYWtlQ2FzZSgpfX1fYmxvYy5kYXJ0JzsKCkBmcmVlemVkCmNsYXNzIHt7bmFtZS5wYXNjYWxDYXNlKCl9fVN0YXRlIHdpdGggXyR7e25hbWUucGFzY2FsQ2FzZSgpfX1TdGF0ZSB7CiAgY29uc3QgZmFjdG9yeSB7e25hbWUucGFzY2FsQ2FzZSgpfX1TdGF0ZS5pbml0aWFsKCkgPSBfSW5pdGlhbDsKfQo=",
+          "cGFydCBvZiAne3tuYW1lLnNuYWtlQ2FzZSgpfX1fYmxvYy5kYXJ0JzsKCkBmcmVlemVkCmFic3RyYWN0IGNsYXNzIHt7bmFtZS5wYXNjYWxDYXNlKCl9fVN0YXRlIHdpdGggXyR7e25hbWUucGFzY2FsQ2FzZSgpfX1TdGF0ZSB7CiAgY29uc3QgZmFjdG9yeSB7e25hbWUucGFzY2FsQ2FzZSgpfX1TdGF0ZS5pbml0aWFsKCkgPSBfSW5pdGlhbDsKfQo=",
       "type": "text",
     },
   ],

--- a/packages/bloc_tools/lib/src/commands/new/bundles/cubit_bundle.dart
+++ b/packages/bloc_tools/lib/src/commands/new/bundles/cubit_bundle.dart
@@ -50,7 +50,7 @@ final cubitBundle = MasonBundle.fromJson(<String, dynamic>{
     {
       "path": "{{~ freezed_state }}",
       "data":
-          "cGFydCBvZiAne3tuYW1lLnNuYWtlQ2FzZSgpfX1fY3ViaXQuZGFydCc7CgpAZnJlZXplZApjbGFzcyB7e25hbWUucGFzY2FsQ2FzZSgpfX1TdGF0ZSB3aXRoIF8ke3tuYW1lLnBhc2NhbENhc2UoKX19U3RhdGUgewogIGNvbnN0IGZhY3Rvcnkge3tuYW1lLnBhc2NhbENhc2UoKX19U3RhdGUuaW5pdGlhbCgpID0gX0luaXRpYWw7Cn0K",
+          "cGFydCBvZiAne3tuYW1lLnNuYWtlQ2FzZSgpfX1fY3ViaXQuZGFydCc7CgpAZnJlZXplZAphYnN0cmFjdCBjbGFzcyB7e25hbWUucGFzY2FsQ2FzZSgpfX1TdGF0ZSB3aXRoIF8ke3tuYW1lLnBhc2NhbENhc2UoKX19U3RhdGUgewogIGNvbnN0IGZhY3Rvcnkge3tuYW1lLnBhc2NhbENhc2UoKX19U3RhdGUuaW5pdGlhbCgpID0gX0luaXRpYWw7Cn0K",
       "type": "text",
     },
   ],

--- a/packages/bloc_tools/lib/src/commands/new/bundles/hydrated_bloc_bundle.dart
+++ b/packages/bloc_tools/lib/src/commands/new/bundles/hydrated_bloc_bundle.dart
@@ -68,13 +68,13 @@ final hydratedBlocBundle = MasonBundle.fromJson(<String, dynamic>{
     {
       "path": "{{~ freezed_event }}",
       "data":
-          "cGFydCBvZiAne3tuYW1lLnNuYWtlQ2FzZSgpfX1fYmxvYy5kYXJ0JzsKCkBmcmVlemVkCmNsYXNzIHt7bmFtZS5wYXNjYWxDYXNlKCl9fUV2ZW50IHdpdGggXyR7e25hbWUucGFzY2FsQ2FzZSgpfX1FdmVudCB7CiAgY29uc3QgZmFjdG9yeSB7e25hbWUucGFzY2FsQ2FzZSgpfX1FdmVudC5zdGFydGVkKCkgPSBfU3RhcnRlZDsKfQo=",
+          "cGFydCBvZiAne3tuYW1lLnNuYWtlQ2FzZSgpfX1fYmxvYy5kYXJ0JzsKCkBmcmVlemVkCmFic3RyYWN0IGNsYXNzIHt7bmFtZS5wYXNjYWxDYXNlKCl9fUV2ZW50IHdpdGggXyR7e25hbWUucGFzY2FsQ2FzZSgpfX1FdmVudCB7CiAgY29uc3QgZmFjdG9yeSB7e25hbWUucGFzY2FsQ2FzZSgpfX1FdmVudC5zdGFydGVkKCkgPSBfU3RhcnRlZDsKfQo=",
       "type": "text",
     },
     {
       "path": "{{~ freezed_state }}",
       "data":
-          "cGFydCBvZiAne3tuYW1lLnNuYWtlQ2FzZSgpfX1fYmxvYy5kYXJ0JzsKCkBmcmVlemVkCmNsYXNzIHt7bmFtZS5wYXNjYWxDYXNlKCl9fVN0YXRlIHdpdGggXyR7e25hbWUucGFzY2FsQ2FzZSgpfX1TdGF0ZSB7CiAgY29uc3QgZmFjdG9yeSB7e25hbWUucGFzY2FsQ2FzZSgpfX1TdGF0ZS5pbml0aWFsKCkgPSBfSW5pdGlhbDsKfQo=",
+          "cGFydCBvZiAne3tuYW1lLnNuYWtlQ2FzZSgpfX1fYmxvYy5kYXJ0JzsKCkBmcmVlemVkCmFic3RyYWN0IGNsYXNzIHt7bmFtZS5wYXNjYWxDYXNlKCl9fVN0YXRlIHdpdGggXyR7e25hbWUucGFzY2FsQ2FzZSgpfX1TdGF0ZSB7CiAgY29uc3QgZmFjdG9yeSB7e25hbWUucGFzY2FsQ2FzZSgpfX1TdGF0ZS5pbml0aWFsKCkgPSBfSW5pdGlhbDsKfQo=",
       "type": "text",
     },
   ],

--- a/packages/bloc_tools/lib/src/commands/new/bundles/hydrated_cubit_bundle.dart
+++ b/packages/bloc_tools/lib/src/commands/new/bundles/hydrated_cubit_bundle.dart
@@ -50,7 +50,7 @@ final hydratedCubitBundle = MasonBundle.fromJson(<String, dynamic>{
     {
       "path": "{{~ freezed_state }}",
       "data":
-          "cGFydCBvZiAne3tuYW1lLnNuYWtlQ2FzZSgpfX1fY3ViaXQuZGFydCc7CgpAZnJlZXplZApjbGFzcyB7e25hbWUucGFzY2FsQ2FzZSgpfX1TdGF0ZSB3aXRoIF8ke3tuYW1lLnBhc2NhbENhc2UoKX19U3RhdGUgewogIGNvbnN0IGZhY3Rvcnkge3tuYW1lLnBhc2NhbENhc2UoKX19U3RhdGUuaW5pdGlhbCgpID0gX0luaXRpYWw7Cn0K",
+          "cGFydCBvZiAne3tuYW1lLnNuYWtlQ2FzZSgpfX1fY3ViaXQuZGFydCc7CgpAZnJlZXplZAphYnN0cmFjdCBjbGFzcyB7e25hbWUucGFzY2FsQ2FzZSgpfX1TdGF0ZSB3aXRoIF8ke3tuYW1lLnBhc2NhbENhc2UoKX19U3RhdGUgewogIGNvbnN0IGZhY3Rvcnkge3tuYW1lLnBhc2NhbENhc2UoKX19U3RhdGUuaW5pdGlhbCgpID0gX0luaXRpYWw7Cn0K",
       "type": "text",
     },
   ],

--- a/packages/bloc_tools/lib/src/commands/new/bundles/replay_bloc_bundle.dart
+++ b/packages/bloc_tools/lib/src/commands/new/bundles/replay_bloc_bundle.dart
@@ -68,13 +68,13 @@ final replayBlocBundle = MasonBundle.fromJson(<String, dynamic>{
     {
       "path": "{{~ freezed_event }}",
       "data":
-          "cGFydCBvZiAne3tuYW1lLnNuYWtlQ2FzZSgpfX1fYmxvYy5kYXJ0JzsKCkBmcmVlemVkCmNsYXNzIHt7bmFtZS5wYXNjYWxDYXNlKCl9fUV2ZW50IGV4dGVuZHMgUmVwbGF5RXZlbnQgd2l0aCBfJHt7bmFtZS5wYXNjYWxDYXNlKCl9fUV2ZW50IHsKICBjb25zdCBmYWN0b3J5IHt7bmFtZS5wYXNjYWxDYXNlKCl9fUV2ZW50LnN0YXJ0ZWQoKSA9IF9TdGFydGVkOwp9Cg==",
+          "cGFydCBvZiAne3tuYW1lLnNuYWtlQ2FzZSgpfX1fYmxvYy5kYXJ0JzsKCkBmcmVlemVkCmFic3RyYWN0IGNsYXNzIHt7bmFtZS5wYXNjYWxDYXNlKCl9fUV2ZW50IGV4dGVuZHMgUmVwbGF5RXZlbnQgd2l0aCBfJHt7bmFtZS5wYXNjYWxDYXNlKCl9fUV2ZW50IHsKICBjb25zdCBmYWN0b3J5IHt7bmFtZS5wYXNjYWxDYXNlKCl9fUV2ZW50LnN0YXJ0ZWQoKSA9IF9TdGFydGVkOwp9Cg==",
       "type": "text",
     },
     {
       "path": "{{~ freezed_state }}",
       "data":
-          "cGFydCBvZiAne3tuYW1lLnNuYWtlQ2FzZSgpfX1fYmxvYy5kYXJ0JzsKCkBmcmVlemVkCmNsYXNzIHt7bmFtZS5wYXNjYWxDYXNlKCl9fVN0YXRlIHdpdGggXyR7e25hbWUucGFzY2FsQ2FzZSgpfX1TdGF0ZSB7CiAgY29uc3QgZmFjdG9yeSB7e25hbWUucGFzY2FsQ2FzZSgpfX1TdGF0ZS5pbml0aWFsKCkgPSBfSW5pdGlhbDsKfQo=",
+          "cGFydCBvZiAne3tuYW1lLnNuYWtlQ2FzZSgpfX1fYmxvYy5kYXJ0JzsKCkBmcmVlemVkCmFic3RyYWN0IGNsYXNzIHt7bmFtZS5wYXNjYWxDYXNlKCl9fVN0YXRlIHdpdGggXyR7e25hbWUucGFzY2FsQ2FzZSgpfX1TdGF0ZSB7CiAgY29uc3QgZmFjdG9yeSB7e25hbWUucGFzY2FsQ2FzZSgpfX1TdGF0ZS5pbml0aWFsKCkgPSBfSW5pdGlhbDsKfQo=",
       "type": "text",
     },
   ],

--- a/packages/bloc_tools/lib/src/commands/new/bundles/replay_cubit_bundle.dart
+++ b/packages/bloc_tools/lib/src/commands/new/bundles/replay_cubit_bundle.dart
@@ -50,7 +50,7 @@ final replayCubitBundle = MasonBundle.fromJson(<String, dynamic>{
     {
       "path": "{{~ freezed_state }}",
       "data":
-          "cGFydCBvZiAne3tuYW1lLnNuYWtlQ2FzZSgpfX1fY3ViaXQuZGFydCc7CgpAZnJlZXplZApjbGFzcyB7e25hbWUucGFzY2FsQ2FzZSgpfX1TdGF0ZSB3aXRoIF8ke3tuYW1lLnBhc2NhbENhc2UoKX19U3RhdGUgewogIGNvbnN0IGZhY3Rvcnkge3tuYW1lLnBhc2NhbENhc2UoKX19U3RhdGUuaW5pdGlhbCgpID0gX0luaXRpYWw7Cn0K",
+          "cGFydCBvZiAne3tuYW1lLnNuYWtlQ2FzZSgpfX1fY3ViaXQuZGFydCc7CgpAZnJlZXplZAphYnN0cmFjdCBjbGFzcyB7e25hbWUucGFzY2FsQ2FzZSgpfX1TdGF0ZSB3aXRoIF8ke3tuYW1lLnBhc2NhbENhc2UoKX19U3RhdGUgewogIGNvbnN0IGZhY3Rvcnkge3tuYW1lLnBhc2NhbENhc2UoKX19U3RhdGUuaW5pdGlhbCgpID0gX0luaXRpYWw7Cn0K",
       "type": "text",
     },
   ],


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->

Fixes #4815 
- Update Freezed templates to use `abstract class`
- Apply the change across IntelliJ, VS Code, Mason bricks, and `bloc_tools` bundles

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
