### PR TITLE
docs: fix class names that don't match the example code

### DIFF
--- a/docs/src/components/tutorials/flutter-todos/EditTodosPageTreeSnippet.astro
+++ b/docs/src/components/tutorials/flutter-todos/EditTodosPageTreeSnippet.astro
@@ -2,10 +2,10 @@
 import { Code } from '@astrojs/starlight/components';
 
 const code = `
-├── BlocProvider<EditTodosBloc>
-│   └── EditTodosPage
-│       └── BlocListener<EditTodosBloc>
-│           └── EditTodosView
+├── BlocProvider<EditTodoBloc>
+│   └── EditTodoPage
+│       └── BlocListener<EditTodoBloc>
+│           └── EditTodoView
 │               ├── TitleField
 │               ├── DescriptionField
 │               └── Floating Action Button

--- a/docs/src/content/docs/ar/tutorials/flutter-todos.mdx
+++ b/docs/src/content/docs/ar/tutorials/flutter-todos.mdx
@@ -771,12 +771,12 @@ repository.
 	title="lib/edit_todo/view/edit_todo_page.dart"
 />
 
-تمامًا مثل الميزات السابقة، توفر `EditTodosPage` نسخة من `EditTodosBloc` عبر
-`BlocProvider`. على عكس الميزات الأخرى، صفحة `EditTodosPage` هي مسار منفصل ولهذا
+تمامًا مثل الميزات السابقة، توفر `EditTodoPage` نسخة من `EditTodoBloc` عبر
+`BlocProvider`. على عكس الميزات الأخرى، صفحة `EditTodoPage` هي مسار منفصل ولهذا
 توفر طريقة `static` اسمها `route`. هذا يسهل دفع الصفحة على مكدس التنقل عبر
 `Navigator.of(context).push(...)`.
 
-تمثيل مبسط لشجرة Widget الخاصة بـ `EditTodosPage` هو:
+تمثيل مبسط لشجرة Widget الخاصة بـ `EditTodoPage` هو:
 
 <EditTodosPageTreeSnippet />
 

--- a/docs/src/content/docs/it/tutorials/flutter-login.mdx
+++ b/docs/src/content/docs/it/tutorials/flutter-login.mdx
@@ -325,7 +325,7 @@ analytics e crash reporting.;
 Quando lo stream `status` emette `AuthenticationStatus.unknown` o
 `unauthenticated`, viene emesso lo `AuthenticationState` corrispondente.
 
-Quando viene emesso `AuthenticationStatus.authenticated`, l'`AuthentictionBloc`
+Quando viene emesso `AuthenticationStatus.authenticated`, l'`AuthenticationBloc`
 interroga l'utente tramite il `UserRepository`.
 
 ## main.dart

--- a/docs/src/content/docs/ko/tutorials/flutter-todos.mdx
+++ b/docs/src/content/docs/ko/tutorials/flutter-todos.mdx
@@ -761,13 +761,13 @@ UI가 `EditTodoSubmitted` 이벤트를 제출하면:
 	title="lib/edit_todo/view/edit_todo_page.dart"
 />
 
-이전 기능과 마찬가지로 `EditTodosPage`는 `BlocProvider`를 통해 `EditTodosBloc`
-인스턴스를 제공합니다. 다른 기능과 달리 `EditTodosPage`는 별도의 라우트이므로
+이전 기능과 마찬가지로 `EditTodoPage`는 `BlocProvider`를 통해 `EditTodoBloc`
+인스턴스를 제공합니다. 다른 기능과 달리 `EditTodoPage`는 별도의 라우트이므로
 `static` `route` 메서드를 노출합니다. 이를 통해
-`Navigator.of(context).push(...)`를 통해 네비게이션 스택에 `EditTodosPage`를
+`Navigator.of(context).push(...)`를 통해 네비게이션 스택에 `EditTodoPage`를
 쉽게 푸시할 수 있습니다.
 
-`EditTodosPage`의 위젯 트리를 간략하게 나타내면:
+`EditTodoPage`의 위젯 트리를 간략하게 나타내면:
 
 <EditTodosPageTreeSnippet />
 

--- a/docs/src/content/docs/ru/tutorials/flutter-login.mdx
+++ b/docs/src/content/docs/ru/tutorials/flutter-login.mdx
@@ -324,7 +324,7 @@ import FlutterPubGetSnippet from '~/components/tutorials/FlutterPubGetSnippet.as
 Когда поток `status` выдает `AuthenticationStatus.unknown` или
 `unauthenticated`, выдается соответствующий `AuthenticationState`.
 
-Когда выдается `AuthenticationStatus.authenticated`, `AuthentictionBloc`
+Когда выдается `AuthenticationStatus.authenticated`, `AuthenticationBloc`
 запрашивает пользователя через `UserRepository`.
 
 ## main.dart

--- a/docs/src/content/docs/ru/tutorials/flutter-todos.mdx
+++ b/docs/src/content/docs/ru/tutorials/flutter-todos.mdx
@@ -793,13 +793,13 @@ When the UI submits a `EditTodoSubmitted` event:
 	title="lib/edit_todo/view/edit_todo_page.dart"
 />
 
-Just like with the previous features, the `EditTodosPage` provides an instance
-of the `EditTodosBloc` via `BlocProvider`. Unlike the other features, the
-`EditTodosPage` is a separate route which is why it exposes a `static` `route`
-method. This makes it easy to push the `EditTodosPage` onto the navigation stack
+Just like with the previous features, the `EditTodoPage` provides an instance
+of the `EditTodoBloc` via `BlocProvider`. Unlike the other features, the
+`EditTodoPage` is a separate route which is why it exposes a `static` `route`
+method. This makes it easy to push the `EditTodoPage` onto the navigation stack
 via `Navigator.of(context).push(...)`.
 
-A simplified representation of the widget tree for the `EditTodosPage` is:
+A simplified representation of the widget tree for the `EditTodoPage` is:
 
 <EditTodosPageTreeSnippet />
 

--- a/docs/src/content/docs/tr/tutorials/flutter-login.mdx
+++ b/docs/src/content/docs/tr/tutorials/flutter-login.mdx
@@ -328,7 +328,7 @@ loglamak için harikadır.;
 `status` stream'i `AuthenticationStatus.unknown` veya `unauthenticated`
 yaydığında, ilgili `AuthenticationState` yayılır.
 
-`AuthenticationStatus.authenticated` yayıldığında, `AuthentictionBloc`,
+`AuthenticationStatus.authenticated` yayıldığında, `AuthenticationBloc`,
 `UserRepository` aracılığıyla kullanıcıyı sorgular.
 
 ## main.dart

--- a/docs/src/content/docs/tr/tutorials/flutter-todos.mdx
+++ b/docs/src/content/docs/tr/tutorials/flutter-todos.mdx
@@ -803,13 +803,13 @@ UI bir `EditTodoSubmitted` olayı gönderdiğinde:
 	title="lib/edit_todo/view/edit_todo_page.dart"
 />
 
-Önceki özelliklerde olduğu gibi, `EditTodosPage` `BlocProvider` aracılığıyla bir
-`EditTodosBloc` örneği sağlar. Diğer özelliklerin aksine, `EditTodosPage` ayrı
+Önceki özelliklerde olduğu gibi, `EditTodoPage` `BlocProvider` aracılığıyla bir
+`EditTodoBloc` örneği sağlar. Diğer özelliklerin aksine, `EditTodoPage` ayrı
 bir route'tur, bu yüzden `static` bir `route` metodu sunar. Bu,
-`Navigator.of(context).push(...)` aracılığıyla `EditTodosPage`'i navigasyon
+`Navigator.of(context).push(...)` aracılığıyla `EditTodoPage`'i navigasyon
 yığınına eklemeyi kolaylaştırır.
 
-`EditTodosPage` için widget ağacının basitleştirilmiş bir gösterimi:
+`EditTodoPage` için widget ağacının basitleştirilmiş bir gösterimi:
 
 <EditTodosPageTreeSnippet />
 

--- a/docs/src/content/docs/tutorials/flutter-login.mdx
+++ b/docs/src/content/docs/tutorials/flutter-login.mdx
@@ -320,7 +320,7 @@ reporting.;
 When the `status` stream emits `AuthenticationStatus.unknown` or
 `unauthenticated`, the corresponding `AuthenticationState` is emitted.
 
-When `AuthenticationStatus.authenticated` is emitted, the `AuthentictionBloc`
+When `AuthenticationStatus.authenticated` is emitted, the `AuthenticationBloc`
 queries the user via the `UserRepository`.
 
 ## main.dart

--- a/docs/src/content/docs/tutorials/flutter-todos.mdx
+++ b/docs/src/content/docs/tutorials/flutter-todos.mdx
@@ -789,13 +789,13 @@ When the UI submits a `EditTodoSubmitted` event:
 	title="lib/edit_todo/view/edit_todo_page.dart"
 />
 
-Just like with the previous features, the `EditTodosPage` provides an instance
-of the `EditTodosBloc` via `BlocProvider`. Unlike the other features, the
-`EditTodosPage` is a separate route which is why it exposes a `static` `route`
-method. This makes it easy to push the `EditTodosPage` onto the navigation stack
+Just like with the previous features, the `EditTodoPage` provides an instance
+of the `EditTodoBloc` via `BlocProvider`. Unlike the other features, the
+`EditTodoPage` is a separate route which is why it exposes a `static` `route`
+method. This makes it easy to push the `EditTodoPage` onto the navigation stack
 via `Navigator.of(context).push(...)`.
 
-A simplified representation of the widget tree for the `EditTodosPage` is:
+A simplified representation of the widget tree for the `EditTodoPage` is:
 
 <EditTodosPageTreeSnippet />
 

--- a/docs/src/content/docs/uk/tutorials/flutter-todos.mdx
+++ b/docs/src/content/docs/uk/tutorials/flutter-todos.mdx
@@ -784,12 +784,12 @@ bloc через `context.read`.
 	title="lib/edit_todo/view/edit_todo_page.dart"
 />
 
-Як і з попередніми модулями, `EditTodosPage` надає екземпляр `EditTodosBloc`
-через `BlocProvider`. На відміну від інших модулів, `EditTodosPage` є окремим
+Як і з попередніми модулями, `EditTodoPage` надає екземпляр `EditTodoBloc`
+через `BlocProvider`. На відміну від інших модулів, `EditTodoPage` є окремим
 маршрутом, тому він надає `static` метод `route`. Це спрощує додавання
-`EditTodosPage` до стеку навігації через `Navigator.of(context).push(...)`.
+`EditTodoPage` до стеку навігації через `Navigator.of(context).push(...)`.
 
-Спрощене представлення дерева віджетів для `EditTodosPage`:
+Спрощене представлення дерева віджетів для `EditTodoPage`:
 
 <EditTodosPageTreeSnippet />
 


### PR DESCRIPTION
Fixes #4842

Two class names in the docs didn't match the code they describe. Both verified against `examples/flutter_todos`.

### `AuthentictionBloc` → `AuthenticationBloc`

Missing an "a" at `tutorials/flutter-login.mdx:323`. The same file spells it correctly 16 other times. Also fixed in the `it`, `ru` and `tr` copies of that page, which inherited it.

### `EditTodosPage` / `EditTodosBloc` / `EditTodosView` → singular

The example declares the singular forms:

| symbol | declared at |
|---|---|
| `EditTodoPage` | `examples/flutter_todos/lib/edit_todo/view/edit_todo_page.dart:9` |
| `EditTodoView` | same file, line 37 |
| `EditTodoBloc` | `examples/flutter_todos/lib/edit_todo/bloc/edit_todo_bloc.dart:8` |

The tutorial already used the correct singular name at line 345 and in the `#### EditTodoPage` heading, but the plural in the paragraphs below it and in the widget-tree snippet. `TodosOverviewPageTreeSnippet` and `StatsPageTreeSnippet` both match their real classes, so this snippet was the only one out of step.

I left the component's **filename** (`EditTodosPageTreeSnippet.astro`) alone and only corrected its contents, so all seven imports still resolve — renaming the file seemed like unnecessary churn, but say the word if you'd prefer it renamed for consistency.

Docs only. Identifier corrections are language-independent, which is why the translated pages are included.
