### PR TITLE
feat(bloc_lint): add `avoid_duplicate_event_handlers`

### DIFF
--- a/docs/src/components/lint-rules/avoid_duplicate_event_handlers/BadSnippet.mdx
+++ b/docs/src/components/lint-rules/avoid_duplicate_event_handlers/BadSnippet.mdx
@@ -1,0 +1,23 @@
+import { Code } from '@astrojs/starlight/components';
+import { transformerMetaHighlight } from '@shikijs/transformers';
+
+<Code
+	code={`
+  import 'package:bloc/bloc.dart';
+
+  sealed class CounterEvent {}
+  final class CounterIncrementPressed extends CounterEvent {}
+
+  class CounterBloc extends Bloc<CounterEvent, int> {
+    CounterBloc() : super(0) {
+      on<CounterIncrementPressed>((event, emit) => emit(state + 1));
+
+      // Avoid duplicate event handlers!
+      // A handler is already registered for [CounterIncrementPressed].
+      on<CounterIncrementPressed>((event, emit) => emit(state + 10));
+    }
+  }
+`}
+lang="dart" title="counter_bloc.dart"
+transformers={[transformerMetaHighlight()]} class='warning' meta="{12}"
+/>

--- a/docs/src/components/lint-rules/avoid_duplicate_event_handlers/GoodSnippet.astro
+++ b/docs/src/components/lint-rules/avoid_duplicate_event_handlers/GoodSnippet.astro
@@ -1,0 +1,20 @@
+---
+import { Code } from '@astrojs/starlight/components';
+
+const code = `
+import 'package:bloc/bloc.dart';
+
+sealed class CounterEvent {}
+final class CounterIncrementPressed extends CounterEvent {}
+final class CounterDecrementPressed extends CounterEvent {}
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0) {
+    on<CounterIncrementPressed>((event, emit) => emit(state + 1));
+    on<CounterDecrementPressed>((event, emit) => emit(state - 1));
+  }
+}
+`;
+---
+
+<Code code={code} lang="dart" title="counter_bloc.dart" />

--- a/docs/src/content/docs/lint-rules/avoid_duplicate_event_handlers.mdx
+++ b/docs/src/content/docs/lint-rules/avoid_duplicate_event_handlers.mdx
@@ -1,0 +1,51 @@
+---
+title: Avoid Duplicate Event Handlers
+description: The avoid_duplicate_event_handlers rule.
+---
+
+import { Badge } from '@astrojs/starlight/components';
+import EnableRuleSnippet from '~/components/lint-rules/EnableRuleSnippet.astro';
+import BadSnippet from '~/components/lint-rules/avoid_duplicate_event_handlers/BadSnippet.mdx';
+import GoodSnippet from '~/components/lint-rules/avoid_duplicate_event_handlers/GoodSnippet.astro';
+
+<div class="badges">
+	<Badge text="new" />
+	<Badge text="dart" variant="note" />
+</div>
+
+Avoid registering more than one event handler for the same event type.
+
+## Rationale
+
+A `Bloc` supports a single handler per event type. Registering a second handler
+for an event type which already has one is always a mistake — `on<E>` throws a
+`StateError` at runtime:
+
+```
+on<CounterIncrementPressed> was called multiple times. There should only be a
+single event handler per event type.
+```
+
+Because the check runs in an assert, it only surfaces in debug mode, so the
+duplicate can otherwise reach production unnoticed. Registering the handler once
+and branching inside it — or introducing a distinct event type — expresses the
+intent without the runtime failure.
+
+## Examples
+
+**Avoid** registering multiple handlers for the same event type.
+
+**BAD**:
+
+<BadSnippet />
+
+**GOOD**:
+
+<GoodSnippet />
+
+## Enable
+
+To enable the `avoid_duplicate_event_handlers` rule, add it to your
+`analysis_options.yaml` under `bloc` > `rules`:
+
+<EnableRuleSnippet name="avoid_duplicate_event_handlers" />

--- a/packages/bloc_lint/README.md
+++ b/packages/bloc_lint/README.md
@@ -97,6 +97,7 @@ For more information, check out the [official documentation](https://bloclibrary
 ## All Lint Rules
 
 - [avoid_build_context_extensions](https://bloclibrary.dev/lint-rules/avoid_build_context_extensions)
+- [avoid_duplicate_event_handlers](https://bloclibrary.dev/lint-rules/avoid_duplicate_event_handlers)
 - [avoid_flutter_imports](https://bloclibrary.dev/lint-rules/avoid_flutter_imports)
 - [avoid_public_bloc_methods](https://bloclibrary.dev/lint-rules/avoid_public_bloc_methods)
 - [avoid_public_fields](https://bloclibrary.dev/lint-rules/avoid_public_fields)

--- a/packages/bloc_lint/lib/all.yaml
+++ b/packages/bloc_lint/lib/all.yaml
@@ -1,6 +1,7 @@
 bloc:
   rules:
     - avoid_build_context_extensions
+    - avoid_duplicate_event_handlers
     - avoid_flutter_imports
     - avoid_public_bloc_methods
     - avoid_public_fields

--- a/packages/bloc_lint/lib/bloc_lint.dart
+++ b/packages/bloc_lint/lib/bloc_lint.dart
@@ -9,6 +9,7 @@ export 'src/linter.dart' show LintContext, Linter;
 export 'src/rules/rules.dart'
     show
         AvoidBuildContextExtensions,
+        AvoidDuplicateEventHandlers,
         AvoidFlutterImports,
         AvoidPublicBlocMethods,
         AvoidPublicFields,

--- a/packages/bloc_lint/lib/src/linter.dart
+++ b/packages/bloc_lint/lib/src/linter.dart
@@ -22,6 +22,7 @@ import 'package:path/path.dart' as p;
 /// All supported lint rules.
 final allRules = <String, LintRuleBuilder>{
   AvoidBuildContextExtensions.rule: AvoidBuildContextExtensions.new,
+  AvoidDuplicateEventHandlers.rule: AvoidDuplicateEventHandlers.new,
   AvoidFlutterImports.rule: AvoidFlutterImports.new,
   AvoidPublicBlocMethods.rule: AvoidPublicBlocMethods.new,
   AvoidPublicFields.rule: AvoidPublicFields.new,

--- a/packages/bloc_lint/lib/src/rules/avoid_duplicate_event_handlers.dart
+++ b/packages/bloc_lint/lib/src/rules/avoid_duplicate_event_handlers.dart
@@ -1,0 +1,105 @@
+import 'package:bloc_lint/bloc_lint.dart';
+
+/// {@template avoid_duplicate_event_handlers}
+/// The avoid_duplicate_event_handlers lint rule.
+/// {@endtemplate}
+class AvoidDuplicateEventHandlers extends LintRule {
+  /// {@macro avoid_duplicate_event_handlers}
+  AvoidDuplicateEventHandlers([Severity? severity])
+    : super(name: rule, severity: severity ?? Severity.warning);
+
+  /// The name of the lint rule.
+  static const rule = 'avoid_duplicate_event_handlers';
+
+  @override
+  Listener? create(LintContext context) => _Listener(context);
+}
+
+class _Listener extends Listener {
+  _Listener(this.context);
+
+  final LintContext context;
+
+  /// Whether the enclosing class is a bloc.
+  bool _isBlocClass = false;
+
+  /// The event types which already have a registered handler
+  /// within the enclosing bloc.
+  final _registeredEventTypes = <String>{};
+
+  @override
+  void beginClassDeclaration(
+    Token begin,
+    Token? abstractToken,
+    Token? sealedToken,
+    Token? baseToken,
+    Token? interfaceToken,
+    Token? finalToken,
+    Token? augmentToken,
+    Token? mixinToken,
+    Token name,
+  ) {
+    _reset();
+  }
+
+  @override
+  void handleClassExtends(Token? extendsKeyword, int typeCount) {
+    final superclass = extendsKeyword?.next;
+    if (superclass == null) return;
+    _isBlocClass = superclass.lexeme.endsWith('Bloc');
+  }
+
+  @override
+  void endClassDeclaration(Token beginToken, Token endToken) {
+    _reset();
+  }
+
+  @override
+  void endTypeArguments(int count, Token beginToken, Token endToken) {
+    if (!_isBlocClass) return;
+
+    // `on` is always invoked with exactly one type argument.
+    // e.g. `on<CounterIncrementPressed>(...)`
+    if (count != 1) return;
+
+    final onToken = beginToken.previous;
+    if (onToken == null || onToken.lexeme != 'on') return;
+
+    // Ignore handlers registered on another object.
+    // e.g. `bloc.on<CounterIncrementPressed>(...)`
+    if (onToken.previous?.type == TokenType.PERIOD) return;
+
+    // The type arguments must be followed by an argument list.
+    if (endToken.next?.type != TokenType.OPEN_PAREN) return;
+
+    final eventType = _eventType(beginToken, endToken);
+    if (_registeredEventTypes.add(eventType)) return;
+
+    context.reportTokenRange(
+      beginToken: onToken,
+      endToken: endToken,
+      message: 'Avoid duplicate event handlers.',
+      hint: 'A handler is already registered for `$eventType`.',
+    );
+  }
+
+  void _reset() {
+    _isBlocClass = false;
+    _registeredEventTypes.clear();
+  }
+}
+
+/// Returns the event type declared between [beginToken] (`<`)
+/// and [endToken] (`>`) with all whitespace removed.
+String _eventType(Token beginToken, Token endToken) {
+  final buffer = StringBuffer();
+  var token = beginToken.next;
+  while (token != null &&
+      token != endToken &&
+      token.type != TokenType.EOF &&
+      token.offset < endToken.offset) {
+    buffer.write(token.lexeme);
+    token = token.next;
+  }
+  return buffer.toString();
+}

--- a/packages/bloc_lint/lib/src/rules/rules.dart
+++ b/packages/bloc_lint/lib/src/rules/rules.dart
@@ -1,4 +1,5 @@
 export 'avoid_build_context_extensions.dart';
+export 'avoid_duplicate_event_handlers.dart';
 export 'avoid_flutter_imports.dart';
 export 'avoid_public_bloc_methods.dart';
 export 'avoid_public_fields.dart';

--- a/packages/bloc_lint/test/src/rules/avoid_duplicate_event_handlers_test.dart
+++ b/packages/bloc_lint/test/src/rules/avoid_duplicate_event_handlers_test.dart
@@ -1,0 +1,292 @@
+import 'package:bloc_lint/src/rules/rules.dart';
+import 'package:test/test.dart';
+
+import '../lint_test_helper.dart';
+
+void main() {
+  group(AvoidDuplicateEventHandlers, () {
+    lintTest(
+      'lints when the same event handler is registered twice',
+      rule: AvoidDuplicateEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+enum CounterEvent { increment, decrement }
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0) {
+    on<CounterEvent>((event, emit) => emit(state + 1));
+    on<CounterEvent>((event, emit) => emit(state - 1));
+    ^^^^^^^^^^^^^^^^
+  }
+}
+''',
+    );
+
+    lintTest(
+      'lints every duplicate when the same event handler '
+      'is registered more than twice',
+      rule: AvoidDuplicateEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+enum CounterEvent { increment, decrement }
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0) {
+    on<CounterEvent>((event, emit) => emit(state + 1));
+    on<CounterEvent>((event, emit) => emit(state - 1));
+    ^^^^^^^^^^^^^^^^
+    on<CounterEvent>((event, emit) => emit(state));
+    ^^^^^^^^^^^^^^^^
+  }
+}
+''',
+    );
+
+    lintTest(
+      'lints when event handlers are registered outside of the constructor',
+      rule: AvoidDuplicateEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+enum CounterEvent { increment, decrement }
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0) {
+    on<CounterEvent>((event, emit) => emit(state + 1));
+    _registerHandlers();
+  }
+
+  void _registerHandlers() {
+    on<CounterEvent>((event, emit) => emit(state - 1));
+    ^^^^^^^^^^^^^^^^
+  }
+}
+''',
+    );
+
+    lintTest(
+      'lints when the duplicate event handler is registered '
+      'with a different transformer',
+      rule: AvoidDuplicateEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+import 'package:bloc_concurrency/bloc_concurrency.dart';
+
+enum CounterEvent { increment, decrement }
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0) {
+    on<CounterEvent>((event, emit) => emit(state + 1));
+    on<CounterEvent>(
+    ^^^^^^^^^^^^^^^^
+      (event, emit) => emit(state - 1),
+      transformer: droppable(),
+    );
+  }
+}
+''',
+    );
+
+    lintTest(
+      'lints when the duplicate event type is generic',
+      rule: AvoidDuplicateEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+class CounterEvent<T> {}
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0) {
+    on<CounterEvent<String>>((event, emit) => emit(state + 1));
+    on<CounterEvent<String>>((event, emit) => emit(state - 1));
+    ^^^^^^^^^^^^^^^^^^^^^^^^
+  }
+}
+''',
+    );
+
+    lintTest(
+      'lints when the bloc extends HydratedBloc',
+      rule: AvoidDuplicateEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+
+enum CounterEvent { increment, decrement }
+class CounterBloc extends HydratedBloc<CounterEvent, int> {
+  CounterBloc() : super(0) {
+    on<CounterEvent>((event, emit) => emit(state + 1));
+    on<CounterEvent>((event, emit) => emit(state - 1));
+    ^^^^^^^^^^^^^^^^
+  }
+}
+''',
+    );
+
+    lintTest(
+      'lints only within the bloc which registers the duplicate handler',
+      rule: AvoidDuplicateEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+enum CounterEvent { increment, decrement }
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0) {
+    on<CounterEvent>((event, emit) => emit(state + 1));
+  }
+}
+
+class OtherCounterBloc extends Bloc<CounterEvent, int> {
+  OtherCounterBloc() : super(0) {
+    on<CounterEvent>((event, emit) => emit(state + 1));
+    on<CounterEvent>((event, emit) => emit(state - 1));
+    ^^^^^^^^^^^^^^^^
+  }
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when all event handlers are unique',
+      rule: AvoidDuplicateEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+sealed class CounterEvent {}
+final class CounterIncrementPressed extends CounterEvent {}
+final class CounterDecrementPressed extends CounterEvent {}
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0) {
+    on<CounterIncrementPressed>((event, emit) => emit(state + 1));
+    on<CounterDecrementPressed>((event, emit) => emit(state - 1));
+  }
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when generic event types differ by type argument',
+      rule: AvoidDuplicateEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+class CounterEvent<T> {}
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0) {
+    on<CounterEvent<String>>((event, emit) => emit(state + 1));
+    on<CounterEvent<int>>((event, emit) => emit(state - 1));
+  }
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when the same event is registered on separate blocs',
+      rule: AvoidDuplicateEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+enum CounterEvent { increment, decrement }
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0) {
+    on<CounterEvent>((event, emit) => emit(state + 1));
+  }
+}
+
+class OtherCounterBloc extends Bloc<CounterEvent, int> {
+  OtherCounterBloc() : super(0) {
+    on<CounterEvent>((event, emit) => emit(state + 1));
+  }
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when the enclosing class is not a bloc',
+      rule: AvoidDuplicateEventHandlers.new,
+      path: 'counter.dart',
+      content: '''
+class EventRegistry {
+  EventRegistry() {
+    on<String>((value) {});
+    on<String>((value) {});
+  }
+
+  void on<T>(void Function(T) callback) {}
+}
+''',
+    );
+
+    lintTest(
+      'does not lint handlers registered on another object',
+      rule: AvoidDuplicateEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+enum CounterEvent { increment, decrement }
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc(EventRegistry registry) : super(0) {
+    registry.on<CounterEvent>((event) {});
+    registry.on<CounterEvent>((event) {});
+  }
+}
+
+class EventRegistry {
+  void on<T>(void Function(T) callback) {}
+}
+''',
+    );
+
+    lintTest(
+      'does not lint on clauses in try/catch blocks',
+      rule: AvoidDuplicateEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+enum CounterEvent { increment, decrement }
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0) {
+    on<CounterEvent>((event, emit) {
+      try {
+        emit(state + 1);
+      } on FormatException {
+        addError(Exception('oops'));
+      } on Exception {
+        addError(Exception('oops'));
+      }
+    });
+  }
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when the duplicate handler is ignored',
+      rule: AvoidDuplicateEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+enum CounterEvent { increment, decrement }
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0) {
+    on<CounterEvent>((event, emit) => emit(state + 1));
+    // ignore: avoid_duplicate_event_handlers
+    on<CounterEvent>((event, emit) => emit(state - 1));
+  }
+}
+''',
+    );
+  });
+}


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

Adds the `avoid_duplicate_event_handlers` lint rule, which warns when a bloc registers more than one event handler for the same event type.

A `Bloc` supports a single handler per event type — `on<E>` throws a `StateError` when called twice for the same `E`. Because that check lives inside an `assert`, it only surfaces in debug mode, so a duplicate registration can otherwise reach production unnoticed.

```dart
class CounterBloc extends Bloc<CounterEvent, int> {
  CounterBloc() : super(0) {
    on<CounterIncrementPressed>((event, emit) => emit(state + 1));
    on<CounterIncrementPressed>((event, emit) => emit(state + 10)); // LINT
  }
}
```

### Implementation notes

- Hooks `endTypeArguments` so the parser resolves the balanced type argument group. Nested generics such as `on<MyEvent<String>>` work without hand-rolled `>>` splitting, and `MyEvent<String>` / `MyEvent<int>` are correctly treated as distinct event types.
- Scoped via `handleClassExtends` to classes whose superclass ends in `Bloc`, which covers `Bloc`, `HydratedBloc` and `ReplayBloc` and avoids class-level type parameters confusing the extends lookup.
- Skips member access (`registry.on<T>(...)`) and `on` clauses in `try`/`catch`.
- Detection is per-class and also catches handlers registered outside the constructor.

Known limitation: handlers registered in mutually exclusive branches (`if (x) on<E>(a); else on<E>(b);`) are flagged. `// ignore: avoid_duplicate_event_handlers` covers that case.

### Two decisions I would like your call on

1. **Severity is `warning`**, matching the other `avoid_*` rules. `error` may be more appropriate given this is a guaranteed runtime failure rather than a style preference — happy to change it.
2. **Not added to `recommended.yaml`**, following the precedent in #4665. It may be a reasonable recommended candidate since it catches code that is certain to throw.

Verified locally against the CI gates: `dart format`, `dart analyze --fatal-warnings lib test`, full suite (165 tests, 14 new) and 100% coverage.

Closes #4460

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
