### PR TITLE
feat(bloc_lint): add `prefer_multi_bloc_listener` and `prefer_multi_repository_provider`

### DIFF
--- a/docs/src/components/lint-rules/prefer_multi_bloc_listener/BadSnippet.mdx
+++ b/docs/src/components/lint-rules/prefer_multi_bloc_listener/BadSnippet.mdx
@@ -1,0 +1,23 @@
+import { Code } from '@astrojs/starlight/components';
+import { transformerMetaHighlight } from '@shikijs/transformers';
+
+<Code
+	code={`
+  import 'package:flutter_bloc/flutter_bloc.dart';
+
+  // Avoid nesting BlocListener widgets!
+  // Prefer a single MultiBlocListener instead.
+  BlocListener<BlocA, BlocAState>(
+    listener: (context, state) {},
+    child: BlocListener<BlocB, BlocBState>(
+      listener: (context, state) {},
+      child: BlocListener<BlocC, BlocCState>(
+        listener: (context, state) {},
+        child: ChildA(),
+      ),
+    ),
+  );
+`}
+lang="dart" title="home_page.dart"
+transformers={[transformerMetaHighlight()]} class='warning' meta="{5}"
+/>

--- a/docs/src/components/lint-rules/prefer_multi_bloc_listener/GoodSnippet.astro
+++ b/docs/src/components/lint-rules/prefer_multi_bloc_listener/GoodSnippet.astro
@@ -1,0 +1,24 @@
+---
+import { Code } from '@astrojs/starlight/components';
+
+const code = `
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+MultiBlocListener(
+  listeners: [
+    BlocListener<BlocA, BlocAState>(
+      listener: (context, state) {},
+    ),
+    BlocListener<BlocB, BlocBState>(
+      listener: (context, state) {},
+    ),
+    BlocListener<BlocC, BlocCState>(
+      listener: (context, state) {},
+    ),
+  ],
+  child: ChildA(),
+);
+`;
+---
+
+<Code code={code} lang="dart" title="home_page.dart" />

--- a/docs/src/components/lint-rules/prefer_multi_repository_provider/BadSnippet.mdx
+++ b/docs/src/components/lint-rules/prefer_multi_repository_provider/BadSnippet.mdx
@@ -1,0 +1,23 @@
+import { Code } from '@astrojs/starlight/components';
+import { transformerMetaHighlight } from '@shikijs/transformers';
+
+<Code
+	code={`
+  import 'package:flutter_bloc/flutter_bloc.dart';
+
+  // Avoid nesting RepositoryProvider widgets!
+  // Prefer a single MultiRepositoryProvider instead.
+  RepositoryProvider<RepositoryA>(
+    create: (context) => RepositoryA(),
+    child: RepositoryProvider<RepositoryB>(
+      create: (context) => RepositoryB(),
+      child: RepositoryProvider<RepositoryC>(
+        create: (context) => RepositoryC(),
+        child: ChildA(),
+      ),
+    ),
+  );
+`}
+lang="dart" title="app.dart"
+transformers={[transformerMetaHighlight()]} class='warning' meta="{5}"
+/>

--- a/docs/src/components/lint-rules/prefer_multi_repository_provider/GoodSnippet.astro
+++ b/docs/src/components/lint-rules/prefer_multi_repository_provider/GoodSnippet.astro
@@ -1,0 +1,18 @@
+---
+import { Code } from '@astrojs/starlight/components';
+
+const code = `
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+MultiRepositoryProvider(
+  providers: [
+    RepositoryProvider<RepositoryA>(create: (context) => RepositoryA()),
+    RepositoryProvider<RepositoryB>(create: (context) => RepositoryB()),
+    RepositoryProvider<RepositoryC>(create: (context) => RepositoryC()),
+  ],
+  child: ChildA(),
+);
+`;
+---
+
+<Code code={code} lang="dart" title="app.dart" />

--- a/docs/src/content/docs/lint-rules/prefer_multi_bloc_listener.mdx
+++ b/docs/src/content/docs/lint-rules/prefer_multi_bloc_listener.mdx
@@ -1,0 +1,42 @@
+---
+title: Prefer MultiBlocListener
+description: The prefer_multi_bloc_listener rule.
+---
+
+import { Badge } from '@astrojs/starlight/components';
+import EnableRuleSnippet from '~/components/lint-rules/EnableRuleSnippet.astro';
+import BadSnippet from '~/components/lint-rules/prefer_multi_bloc_listener/BadSnippet.mdx';
+import GoodSnippet from '~/components/lint-rules/prefer_multi_bloc_listener/GoodSnippet.astro';
+
+<div class="badges">
+	<Badge text="new" />
+	<Badge text="dart" variant="note" />
+</div>
+
+Prefer a single `MultiBlocListener` over nested `BlocListener` widgets.
+
+## Rationale
+
+`MultiBlocListener` merges multiple `BlocListener` widgets into one widget tree.
+It converts the list of listeners back into the same tree of nested
+`BlocListener` widgets, so the two forms are equivalent at runtime — the
+advantage is improved readability and less boilerplate as the nesting grows.
+
+## Examples
+
+**Avoid** nesting `BlocListener` widgets via the `child` argument.
+
+**BAD**:
+
+<BadSnippet />
+
+**GOOD**:
+
+<GoodSnippet />
+
+## Enable
+
+To enable the `prefer_multi_bloc_listener` rule, add it to your
+`analysis_options.yaml` under `bloc` > `rules`:
+
+<EnableRuleSnippet name="prefer_multi_bloc_listener" />

--- a/docs/src/content/docs/lint-rules/prefer_multi_repository_provider.mdx
+++ b/docs/src/content/docs/lint-rules/prefer_multi_repository_provider.mdx
@@ -1,0 +1,43 @@
+---
+title: Prefer MultiRepositoryProvider
+description: The prefer_multi_repository_provider rule.
+---
+
+import { Badge } from '@astrojs/starlight/components';
+import EnableRuleSnippet from '~/components/lint-rules/EnableRuleSnippet.astro';
+import BadSnippet from '~/components/lint-rules/prefer_multi_repository_provider/BadSnippet.mdx';
+import GoodSnippet from '~/components/lint-rules/prefer_multi_repository_provider/GoodSnippet.astro';
+
+<div class="badges">
+	<Badge text="new" />
+	<Badge text="dart" variant="note" />
+</div>
+
+Prefer a single `MultiRepositoryProvider` over nested `RepositoryProvider`
+widgets.
+
+## Rationale
+
+`MultiRepositoryProvider` merges multiple `RepositoryProvider` widgets into one
+widget tree. It converts the list of providers back into the same tree of nested
+`RepositoryProvider` widgets, so the two forms are equivalent at runtime — the
+advantage is improved readability and less boilerplate as the nesting grows.
+
+## Examples
+
+**Avoid** nesting `RepositoryProvider` widgets via the `child` argument.
+
+**BAD**:
+
+<BadSnippet />
+
+**GOOD**:
+
+<GoodSnippet />
+
+## Enable
+
+To enable the `prefer_multi_repository_provider` rule, add it to your
+`analysis_options.yaml` under `bloc` > `rules`:
+
+<EnableRuleSnippet name="prefer_multi_repository_provider" />

--- a/packages/bloc_lint/README.md
+++ b/packages/bloc_lint/README.md
@@ -104,6 +104,8 @@ For more information, check out the [official documentation](https://bloclibrary
 - [prefer_build_context_extensions](https://bloclibrary.dev/lint-rules/prefer_build_context_extensions)
 - [prefer_cubit](https://bloclibrary.dev/lint-rules/prefer_cubit)
 - [prefer_file_naming_conventions](https://bloclibrary.dev/lint-rules/prefer_file_naming_conventions)
+- [prefer_multi_bloc_listener](https://bloclibrary.dev/lint-rules/prefer_multi_bloc_listener)
+- [prefer_multi_repository_provider](https://bloclibrary.dev/lint-rules/prefer_multi_repository_provider)
 - [prefer_void_public_cubit_methods](https://bloclibrary.dev/lint-rules/prefer_void_public_cubit_methods)
 
 ## Dart Versions

--- a/packages/bloc_lint/lib/all.yaml
+++ b/packages/bloc_lint/lib/all.yaml
@@ -8,4 +8,6 @@ bloc:
     - prefer_build_context_extensions
     - prefer_cubit
     - prefer_file_naming_conventions
+    - prefer_multi_bloc_listener
+    - prefer_multi_repository_provider
     - prefer_void_public_cubit_methods

--- a/packages/bloc_lint/lib/bloc_lint.dart
+++ b/packages/bloc_lint/lib/bloc_lint.dart
@@ -16,6 +16,8 @@ export 'src/rules/rules.dart'
         PreferBuildContextExtensions,
         PreferCubit,
         PreferFileNamingConventions,
+        PreferMultiBlocListener,
+        PreferMultiRepositoryProvider,
         PreferVoidPublicCubitMethods;
 export 'src/text_document.dart'
     show

--- a/packages/bloc_lint/lib/src/linter.dart
+++ b/packages/bloc_lint/lib/src/linter.dart
@@ -29,6 +29,8 @@ final allRules = <String, LintRuleBuilder>{
   PreferBuildContextExtensions.rule: PreferBuildContextExtensions.new,
   PreferCubit.rule: PreferCubit.new,
   PreferFileNamingConventions.rule: PreferFileNamingConventions.new,
+  PreferMultiBlocListener.rule: PreferMultiBlocListener.new,
+  PreferMultiRepositoryProvider.rule: PreferMultiRepositoryProvider.new,
   PreferVoidPublicCubitMethods.rule: PreferVoidPublicCubitMethods.new,
 };
 

--- a/packages/bloc_lint/lib/src/nested_widget_listener.dart
+++ b/packages/bloc_lint/lib/src/nested_widget_listener.dart
@@ -1,0 +1,116 @@
+import 'package:bloc_lint/bloc_lint.dart';
+import 'package:collection/collection.dart';
+
+/// {@template nested_widget_listener}
+/// A [Listener] which reports [widget] instances that are nested directly
+/// within the `child` of another [widget] and could instead be collapsed
+/// into a single [replacement] widget.
+///
+/// Only the outermost [widget] of a nested chain is reported.
+/// {@endtemplate}
+class NestedWidgetListener extends Listener {
+  /// {@macro nested_widget_listener}
+  NestedWidgetListener({
+    required this.context,
+    required this.widget,
+    required this.replacement,
+  });
+
+  /// The current [LintContext].
+  final LintContext context;
+
+  /// The name of the widget which should not be nested.
+  final String widget;
+
+  /// The name of the widget which should be used instead.
+  final String replacement;
+
+  /// The enclosing argument lists, outermost first.
+  final _invocations = <_Invocation>[];
+
+  /// Maps the closing `>` of a type argument list to the identifier
+  /// which owns it (e.g. `>` -> `BlocListener`).
+  final _typeArgumentOwners = <Token, Token>{};
+
+  /// The widgets which have already been reported.
+  final _reported = <Token>{};
+
+  @override
+  void endTypeArguments(int count, Token beginToken, Token endToken) {
+    final owner = beginToken.previous;
+    if (owner != null) _typeArgumentOwners[endToken] = owner;
+  }
+
+  @override
+  void beginArguments(Token token) {
+    final target = _targetOf(token);
+    final isChild = target != null && _isChildArgument(target);
+
+    if (isChild && (_invocations.lastOrNull?.target != null)) _report();
+
+    _invocations.add(_Invocation(target: target, isChild: isChild));
+  }
+
+  @override
+  void endArguments(int count, Token beginToken, Token endToken) {
+    if (_invocations.isNotEmpty) _invocations.removeLast();
+  }
+
+  /// Returns the [widget] identifier which owns the argument list beginning
+  /// at [openParen] or `null` if the invocation is not a [widget].
+  Token? _targetOf(Token openParen) {
+    var token = openParen.previous;
+    if (token == null) return null;
+
+    // Resolve named constructors. e.g. `RepositoryProvider.value(...)`
+    final period = token.previous;
+    if (period != null && period.type == TokenType.PERIOD) {
+      final receiver = period.previous;
+      if (receiver == null) return null;
+      token = receiver;
+    }
+
+    // Resolve type arguments. e.g. `BlocListener<BlocA, BlocAState>(...)`
+    final resolved = _typeArgumentOwners[token] ?? token;
+    return resolved.lexeme == widget ? resolved : null;
+  }
+
+  /// Whether [target] is the value of a `child` argument.
+  bool _isChildArgument(Token target) {
+    final colon = target.previous;
+    if (colon == null || colon.type != TokenType.COLON) return false;
+    return colon.previous?.lexeme == 'child';
+  }
+
+  void _report() {
+    final root = _outermost();
+    if (!_reported.add(root)) return;
+    context.reportToken(
+      token: root,
+      message: 'Avoid nesting $widget widgets.',
+      hint: 'Prefer using $replacement instead.',
+    );
+  }
+
+  /// Walks up the chain of `child` arguments to find the outermost [widget].
+  Token _outermost() {
+    var root = _invocations.last.target!;
+    for (var i = _invocations.length - 1; i > 0; i--) {
+      final invocation = _invocations[i];
+      final parent = _invocations[i - 1];
+      if (!invocation.isChild || parent.target == null) break;
+      root = parent.target!;
+    }
+    return root;
+  }
+}
+
+class _Invocation {
+  const _Invocation({required this.target, required this.isChild});
+
+  /// The watched widget which owns this argument list, if any.
+  final Token? target;
+
+  /// Whether this invocation is the value of a `child` argument.
+  final bool isChild;
+}

--- a/packages/bloc_lint/lib/src/rules/prefer_multi_bloc_listener.dart
+++ b/packages/bloc_lint/lib/src/rules/prefer_multi_bloc_listener.dart
@@ -1,0 +1,21 @@
+import 'package:bloc_lint/bloc_lint.dart';
+import 'package:bloc_lint/src/nested_widget_listener.dart';
+
+/// {@template prefer_multi_bloc_listener}
+/// The prefer_multi_bloc_listener lint rule.
+/// {@endtemplate}
+class PreferMultiBlocListener extends LintRule {
+  /// {@macro prefer_multi_bloc_listener}
+  PreferMultiBlocListener([Severity? severity])
+    : super(name: rule, severity: severity ?? Severity.info);
+
+  /// The name of the lint rule.
+  static const rule = 'prefer_multi_bloc_listener';
+
+  @override
+  Listener? create(LintContext context) => NestedWidgetListener(
+    context: context,
+    widget: 'BlocListener',
+    replacement: 'MultiBlocListener',
+  );
+}

--- a/packages/bloc_lint/lib/src/rules/prefer_multi_repository_provider.dart
+++ b/packages/bloc_lint/lib/src/rules/prefer_multi_repository_provider.dart
@@ -1,0 +1,21 @@
+import 'package:bloc_lint/bloc_lint.dart';
+import 'package:bloc_lint/src/nested_widget_listener.dart';
+
+/// {@template prefer_multi_repository_provider}
+/// The prefer_multi_repository_provider lint rule.
+/// {@endtemplate}
+class PreferMultiRepositoryProvider extends LintRule {
+  /// {@macro prefer_multi_repository_provider}
+  PreferMultiRepositoryProvider([Severity? severity])
+    : super(name: rule, severity: severity ?? Severity.info);
+
+  /// The name of the lint rule.
+  static const rule = 'prefer_multi_repository_provider';
+
+  @override
+  Listener? create(LintContext context) => NestedWidgetListener(
+    context: context,
+    widget: 'RepositoryProvider',
+    replacement: 'MultiRepositoryProvider',
+  );
+}

--- a/packages/bloc_lint/lib/src/rules/rules.dart
+++ b/packages/bloc_lint/lib/src/rules/rules.dart
@@ -6,4 +6,6 @@ export 'prefer_bloc.dart';
 export 'prefer_build_context_extensions.dart';
 export 'prefer_cubit.dart';
 export 'prefer_file_naming_conventions.dart';
+export 'prefer_multi_bloc_listener.dart';
+export 'prefer_multi_repository_provider.dart';
 export 'prefer_void_public_cubit_methods.dart';

--- a/packages/bloc_lint/test/src/rules/prefer_multi_bloc_listener_test.dart
+++ b/packages/bloc_lint/test/src/rules/prefer_multi_bloc_listener_test.dart
@@ -1,0 +1,267 @@
+import 'package:bloc_lint/src/rules/rules.dart';
+import 'package:test/test.dart';
+
+import '../lint_test_helper.dart';
+
+void main() {
+  group(PreferMultiBlocListener, () {
+    lintTest(
+      'lints when a BlocListener is nested in the child of a BlocListener',
+      rule: PreferMultiBlocListener.new,
+      path: 'home_page.dart',
+      content: '''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+Widget build() {
+  return BlocListener<BlocA, BlocAState>(
+         ^^^^^^^^^^^^
+    listener: (context, state) {},
+    child: BlocListener<BlocB, BlocBState>(
+      listener: (context, state) {},
+      child: const SizedBox(),
+    ),
+  );
+}
+''',
+    );
+
+    lintTest(
+      'lints only the outermost BlocListener when several are nested',
+      rule: PreferMultiBlocListener.new,
+      path: 'home_page.dart',
+      content: '''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+Widget build() {
+  return BlocListener<BlocA, BlocAState>(
+         ^^^^^^^^^^^^
+    listener: (context, state) {},
+    child: BlocListener<BlocB, BlocBState>(
+      listener: (context, state) {},
+      child: BlocListener<BlocC, BlocCState>(
+        listener: (context, state) {},
+        child: const SizedBox(),
+      ),
+    ),
+  );
+}
+''',
+    );
+
+    lintTest(
+      'lints when no type arguments are specified',
+      rule: PreferMultiBlocListener.new,
+      path: 'home_page.dart',
+      content: '''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+Widget build() {
+  return BlocListener(
+         ^^^^^^^^^^^^
+    listener: (context, state) {},
+    child: BlocListener(
+      listener: (context, state) {},
+      child: const SizedBox(),
+    ),
+  );
+}
+''',
+    );
+
+    lintTest(
+      'lints the outermost BlocListener of the nested chain '
+      'rather than an unrelated ancestor',
+      rule: PreferMultiBlocListener.new,
+      path: 'home_page.dart',
+      content: '''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+Widget build() {
+  return BlocListener<BlocA, BlocAState>(
+    listener: (context, state) => showDialog(
+      builder: (context) => BlocListener<BlocB, BlocBState>(
+                            ^^^^^^^^^^^^
+        listener: (context, state) {},
+        child: BlocListener<BlocC, BlocCState>(
+          listener: (context, state) {},
+          child: const SizedBox(),
+        ),
+      ),
+    ),
+    child: const SizedBox(),
+  );
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when nested deeper within other widgets',
+      rule: PreferMultiBlocListener.new,
+      path: 'home_page.dart',
+      content: '''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+Widget build() {
+  return BlocListener<BlocA, BlocAState>(
+    listener: (context, state) {},
+    child: Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(8),
+          child: BlocListener<BlocB, BlocBState>(
+            listener: (context, state) {},
+            child: const SizedBox(),
+          ),
+        ),
+      ],
+    ),
+  );
+}
+''',
+    );
+
+    lintTest(
+      'does not lint a single BlocListener',
+      rule: PreferMultiBlocListener.new,
+      path: 'home_page.dart',
+      content: '''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+Widget build() {
+  return BlocListener<BlocA, BlocAState>(
+    listener: (context, state) {},
+    child: const SizedBox(),
+  );
+}
+''',
+    );
+
+    lintTest(
+      'does not lint a MultiBlocListener',
+      rule: PreferMultiBlocListener.new,
+      path: 'home_page.dart',
+      content: '''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+Widget build() {
+  return MultiBlocListener(
+    listeners: [
+      BlocListener<BlocA, BlocAState>(listener: (context, state) {}),
+      BlocListener<BlocB, BlocBState>(listener: (context, state) {}),
+    ],
+    child: const SizedBox(),
+  );
+}
+''',
+    );
+
+    lintTest(
+      'does not lint sibling BlocListener widgets',
+      rule: PreferMultiBlocListener.new,
+      path: 'home_page.dart',
+      content: '''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+Widget build() {
+  return Column(
+    children: [
+      BlocListener<BlocA, BlocAState>(
+        listener: (context, state) {},
+        child: const SizedBox(),
+      ),
+      BlocListener<BlocB, BlocBState>(
+        listener: (context, state) {},
+        child: const SizedBox(),
+      ),
+    ],
+  );
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when the nested BlocListener is not a direct child',
+      rule: PreferMultiBlocListener.new,
+      path: 'home_page.dart',
+      content: '''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+Widget build() {
+  return BlocListener<BlocA, BlocAState>(
+    listener: (context, state) {},
+    child: Padding(
+      padding: const EdgeInsets.all(8),
+      child: BlocListener<BlocB, BlocBState>(
+        listener: (context, state) {},
+        child: const SizedBox(),
+      ),
+    ),
+  );
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when a different widget is nested',
+      rule: PreferMultiBlocListener.new,
+      path: 'home_page.dart',
+      content: '''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+Widget build() {
+  return BlocProvider<BlocA>(
+    create: (context) => BlocA(),
+    child: BlocListener<BlocB, BlocBState>(
+      listener: (context, state) {},
+      child: const SizedBox(),
+    ),
+  );
+}
+''',
+    );
+
+    lintTest(
+      'does not lint a BlocListener created inside a callback',
+      rule: PreferMultiBlocListener.new,
+      path: 'home_page.dart',
+      content: '''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+Widget build() {
+  return BlocListener<BlocA, BlocAState>(
+    listener: (context, state) {
+      showDialog(
+        context: context,
+        builder: (context) => BlocListener<BlocB, BlocBState>(
+          listener: (context, state) {},
+          child: const SizedBox(),
+        ),
+      );
+    },
+    child: const SizedBox(),
+  );
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when the nested BlocListener is ignored',
+      rule: PreferMultiBlocListener.new,
+      path: 'home_page.dart',
+      content: '''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+Widget build() {
+  // ignore: prefer_multi_bloc_listener
+  return BlocListener<BlocA, BlocAState>(
+    listener: (context, state) {},
+    child: BlocListener<BlocB, BlocBState>(
+      listener: (context, state) {},
+      child: const SizedBox(),
+    ),
+  );
+}
+''',
+    );
+  });
+}

--- a/packages/bloc_lint/test/src/rules/prefer_multi_repository_provider_test.dart
+++ b/packages/bloc_lint/test/src/rules/prefer_multi_repository_provider_test.dart
@@ -1,0 +1,189 @@
+import 'package:bloc_lint/src/rules/rules.dart';
+import 'package:test/test.dart';
+
+import '../lint_test_helper.dart';
+
+void main() {
+  group(PreferMultiRepositoryProvider, () {
+    lintTest(
+      'lints when a RepositoryProvider is nested '
+      'in the child of a RepositoryProvider',
+      rule: PreferMultiRepositoryProvider.new,
+      path: 'app.dart',
+      content: '''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+Widget build() {
+  return RepositoryProvider<RepositoryA>(
+         ^^^^^^^^^^^^^^^^^^
+    create: (context) => RepositoryA(),
+    child: RepositoryProvider<RepositoryB>(
+      create: (context) => RepositoryB(),
+      child: const SizedBox(),
+    ),
+  );
+}
+''',
+    );
+
+    lintTest(
+      'lints only the outermost RepositoryProvider when several are nested',
+      rule: PreferMultiRepositoryProvider.new,
+      path: 'app.dart',
+      content: '''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+Widget build() {
+  return RepositoryProvider<RepositoryA>(
+         ^^^^^^^^^^^^^^^^^^
+    create: (context) => RepositoryA(),
+    child: RepositoryProvider<RepositoryB>(
+      create: (context) => RepositoryB(),
+      child: RepositoryProvider<RepositoryC>(
+        create: (context) => RepositoryC(),
+        child: const SizedBox(),
+      ),
+    ),
+  );
+}
+''',
+    );
+
+    lintTest(
+      'lints when the value constructor is used',
+      rule: PreferMultiRepositoryProvider.new,
+      path: 'app.dart',
+      content: '''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+Widget build(RepositoryA repositoryA, RepositoryB repositoryB) {
+  return RepositoryProvider<RepositoryA>.value(
+         ^^^^^^^^^^^^^^^^^^
+    value: repositoryA,
+    child: RepositoryProvider<RepositoryB>.value(
+      value: repositoryB,
+      child: const SizedBox(),
+    ),
+  );
+}
+''',
+    );
+
+    lintTest(
+      'does not lint a single RepositoryProvider',
+      rule: PreferMultiRepositoryProvider.new,
+      path: 'app.dart',
+      content: '''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+Widget build() {
+  return RepositoryProvider<RepositoryA>(
+    create: (context) => RepositoryA(),
+    child: const SizedBox(),
+  );
+}
+''',
+    );
+
+    lintTest(
+      'does not lint a MultiRepositoryProvider',
+      rule: PreferMultiRepositoryProvider.new,
+      path: 'app.dart',
+      content: '''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+Widget build() {
+  return MultiRepositoryProvider(
+    providers: [
+      RepositoryProvider<RepositoryA>(create: (context) => RepositoryA()),
+      RepositoryProvider<RepositoryB>(create: (context) => RepositoryB()),
+    ],
+    child: const SizedBox(),
+  );
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when the nested RepositoryProvider is not a direct child',
+      rule: PreferMultiRepositoryProvider.new,
+      path: 'app.dart',
+      content: '''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+Widget build() {
+  return RepositoryProvider<RepositoryA>(
+    create: (context) => RepositoryA(),
+    child: Padding(
+      padding: const EdgeInsets.all(8),
+      child: RepositoryProvider<RepositoryB>(
+        create: (context) => RepositoryB(),
+        child: const SizedBox(),
+      ),
+    ),
+  );
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when a different widget is nested',
+      rule: PreferMultiRepositoryProvider.new,
+      path: 'app.dart',
+      content: '''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+Widget build() {
+  return RepositoryProvider<RepositoryA>(
+    create: (context) => RepositoryA(),
+    child: BlocProvider<BlocA>(
+      create: (context) => BlocA(),
+      child: const SizedBox(),
+    ),
+  );
+}
+''',
+    );
+
+    lintTest(
+      'does not lint a RepositoryProvider created inside a callback',
+      rule: PreferMultiRepositoryProvider.new,
+      path: 'app.dart',
+      content: '''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+Widget build() {
+  return RepositoryProvider<RepositoryA>(
+    create: (context) => RepositoryA(),
+    child: Builder(
+      builder: (context) => RepositoryProvider<RepositoryB>(
+        create: (context) => RepositoryB(),
+        child: const SizedBox(),
+      ),
+    ),
+  );
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when the nested RepositoryProvider is ignored',
+      rule: PreferMultiRepositoryProvider.new,
+      path: 'app.dart',
+      content: '''
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+Widget build() {
+  // ignore: prefer_multi_repository_provider
+  return RepositoryProvider<RepositoryA>(
+    create: (context) => RepositoryA(),
+    child: RepositoryProvider<RepositoryB>(
+      create: (context) => RepositoryB(),
+      child: const SizedBox(),
+    ),
+  );
+}
+''',
+    );
+  });
+}


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

Adds two lint rules which warn when `BlocListener` or `RepositoryProvider` widgets are nested through the `child` argument, where a single `MultiBlocListener` / `MultiRepositoryProvider` is equivalent and easier to read.

```dart
// BAD
BlocListener<BlocA, BlocAState>(
  listener: (context, state) {},
  child: BlocListener<BlocB, BlocBState>(
    listener: (context, state) {},
    child: ChildA(),
  ),
);

// GOOD
MultiBlocListener(
  listeners: [
    BlocListener<BlocA, BlocAState>(listener: (context, state) {}),
    BlocListener<BlocB, BlocBState>(listener: (context, state) {}),
  ],
  child: ChildA(),
);
```

### Implementation notes

Both rules are thin wrappers over a shared `NestedWidgetListener` (`lib/src/nested_widget_listener.dart`), parameterized by the widget name and its replacement.

- Maintains a stack of the enclosing argument lists, recording for each whether it belongs to the watched widget and whether it sits in a `child` slot. A report fires only when the *immediately* enclosing invocation is the same widget, so a widget that merely has a matching ancestor higher up the tree is not flagged.
- Only the outermost widget of a contiguous nested chain is reported, so a chain of three produces one diagnostic rather than two. Where the chain is broken by an unrelated callback, the innermost valid chain root is reported instead — both behaviours are covered by tests.
- Resolves type arguments via `endTypeArguments` and named constructors via the preceding `.`, so `BlocListener<A, B>(...)`, `RepositoryProvider(...)` and `RepositoryProvider<A>.value(...)` are all recognized.
- Severity is `info`, matching the other `prefer_*` rules. These are readability rules — the two forms are equivalent at runtime, as the `MultiBlocListener` docs note.

Adding `prefer_multi_bloc_provider` (#4453) on top of this is a ~20 line change, should you want it — I left it out since that issue is assigned.

Verified locally against the CI gates: `dart format`, `dart analyze --fatal-warnings lib test`, full suite (172 tests, 21 new) and 100% coverage.

Closes #4454
Closes #4455

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
