### PR TITLE
feat(bloc_lint): add avoid_missing_event_handlers

### DIFF
--- a/docs/src/components/lint-rules/avoid_missing_event_handlers/BadSnippet.mdx
+++ b/docs/src/components/lint-rules/avoid_missing_event_handlers/BadSnippet.mdx
@@ -1,0 +1,21 @@
+import { Code } from '@astrojs/starlight/components';
+import { transformerMetaHighlight } from '@shikijs/transformers';
+
+<Code
+	code={`
+  import 'package:bloc/bloc.dart';
+
+  sealed class CounterEvent {}
+  final class Increment extends CounterEvent {}
+  final class Decrement extends CounterEvent {}
+
+  class CounterBloc extends Bloc<CounterEvent, int> {
+    CounterBloc() : super(0) {
+      on<Increment>((event, emit) => emit(state + 1));
+      // Missing on<Decrement>!
+    }
+  }
+`}
+lang="dart" title="counter_bloc.dart"
+transformers={[transformerMetaHighlight()]} class='warning' meta="{7}"
+/>

--- a/docs/src/components/lint-rules/avoid_missing_event_handlers/GoodSnippet.astro
+++ b/docs/src/components/lint-rules/avoid_missing_event_handlers/GoodSnippet.astro
@@ -1,0 +1,20 @@
+---
+import { Code } from '@astrojs/starlight/components';
+
+const code = `
+import 'package:bloc/bloc.dart';
+
+sealed class CounterEvent {}
+final class Increment extends CounterEvent {}
+final class Decrement extends CounterEvent {}
+
+class CounterBloc extends Bloc<CounterEvent, int> { 
+  CounterBloc() : super(0) {
+    on<Increment>((event, emit) => emit(state + 1));
+    on<Decrement>((event, emit) => emit(state - 1));
+  }
+}
+`;
+---
+
+<Code code={code} lang="dart" title="counter_bloc.dart" />

--- a/docs/src/content/docs/lint-rules/avoid_missing_event_handlers.mdx
+++ b/docs/src/content/docs/lint-rules/avoid_missing_event_handlers.mdx
@@ -1,0 +1,47 @@
+---
+title: Avoid Missing Event Handlers
+description: The avoid_missing_event_handlers rule.
+---
+
+import { Badge } from '@astrojs/starlight/components';
+import EnableRuleSnippet from '~/components/lint-rules/EnableRuleSnippet.astro';
+import BadSnippet from '~/components/lint-rules/avoid_missing_event_handlers/BadSnippet.mdx';
+import GoodSnippet from '~/components/lint-rules/avoid_missing_event_handlers/GoodSnippet.astro';
+
+<div class="badges">
+	<Badge text="new" />
+	<Badge text="dart" variant="note" />
+	<Badge text="recommended" variant="success" />
+</div>
+
+Avoid declaring events that have no matching `on<Event>` handler.
+
+## Rationale
+
+A `Bloc` only reacts to events that were registered with `on<Event>`. If a
+subclass (or the event type itself) is never handled, `add` calls for that event
+are silently ignored.
+
+The rule reports a warning when a bloc's event type is declared in the same
+file and either the event type or one of its concrete subclasses has no
+handler. Registering `on<Event>` for the event superclass covers every
+subclass.
+
+## Examples
+
+**DO** register a handler for each event, or handle the event superclass.
+
+**BAD**:
+
+<BadSnippet />
+
+**GOOD**:
+
+<GoodSnippet />
+
+## Enable
+
+To enable the `avoid_missing_event_handlers` rule, add it to your
+`analysis_options.yaml` under `bloc` > `rules`:
+
+<EnableRuleSnippet name="avoid_missing_event_handlers" />

--- a/packages/bloc_lint/CHANGELOG.md
+++ b/packages/bloc_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.3
+
+- feat: add [avoid_missing_event_handlers](https://bloclibrary.dev/lint-rules/avoid_missing_event_handlers)
+
 # 0.4.2
 
 - deps: adjust bounds for `_fe_analyzer_shared`

--- a/packages/bloc_lint/README.md
+++ b/packages/bloc_lint/README.md
@@ -89,6 +89,7 @@ For more information, check out the [official documentation](https://bloclibrary
 ## Recommended Lint Rules
 
 - [avoid_flutter_imports](https://bloclibrary.dev/lint-rules/avoid_flutter_imports)
+- [avoid_missing_event_handlers](https://bloclibrary.dev/lint-rules/avoid_missing_event_handlers)
 - [avoid_public_bloc_methods](https://bloclibrary.dev/lint-rules/avoid_public_bloc_methods)
 - [avoid_public_fields](https://bloclibrary.dev/lint-rules/avoid_public_fields)
 - [prefer_file_naming_conventions](https://bloclibrary.dev/lint-rules/prefer_file_naming_conventions)
@@ -98,6 +99,7 @@ For more information, check out the [official documentation](https://bloclibrary
 
 - [avoid_build_context_extensions](https://bloclibrary.dev/lint-rules/avoid_build_context_extensions)
 - [avoid_flutter_imports](https://bloclibrary.dev/lint-rules/avoid_flutter_imports)
+- [avoid_missing_event_handlers](https://bloclibrary.dev/lint-rules/avoid_missing_event_handlers)
 - [avoid_public_bloc_methods](https://bloclibrary.dev/lint-rules/avoid_public_bloc_methods)
 - [avoid_public_fields](https://bloclibrary.dev/lint-rules/avoid_public_fields)
 - [prefer_bloc](https://bloclibrary.dev/lint-rules/prefer_bloc)

--- a/packages/bloc_lint/lib/all.yaml
+++ b/packages/bloc_lint/lib/all.yaml
@@ -2,6 +2,7 @@ bloc:
   rules:
     - avoid_build_context_extensions
     - avoid_flutter_imports
+    - avoid_missing_event_handlers
     - avoid_public_bloc_methods
     - avoid_public_fields
     - prefer_bloc

--- a/packages/bloc_lint/lib/bloc_lint.dart
+++ b/packages/bloc_lint/lib/bloc_lint.dart
@@ -10,6 +10,7 @@ export 'src/rules/rules.dart'
     show
         AvoidBuildContextExtensions,
         AvoidFlutterImports,
+        AvoidMissingEventHandlers,
         AvoidPublicBlocMethods,
         AvoidPublicFields,
         PreferBloc,

--- a/packages/bloc_lint/lib/recommended.yaml
+++ b/packages/bloc_lint/lib/recommended.yaml
@@ -1,6 +1,7 @@
 bloc:
   rules:
     - avoid_flutter_imports
+    - avoid_missing_event_handlers
     - avoid_public_bloc_methods
     - avoid_public_fields
     - prefer_file_naming_conventions

--- a/packages/bloc_lint/lib/src/linter.dart
+++ b/packages/bloc_lint/lib/src/linter.dart
@@ -23,6 +23,7 @@ import 'package:path/path.dart' as p;
 final allRules = <String, LintRuleBuilder>{
   AvoidBuildContextExtensions.rule: AvoidBuildContextExtensions.new,
   AvoidFlutterImports.rule: AvoidFlutterImports.new,
+  AvoidMissingEventHandlers.rule: AvoidMissingEventHandlers.new,
   AvoidPublicBlocMethods.rule: AvoidPublicBlocMethods.new,
   AvoidPublicFields.rule: AvoidPublicFields.new,
   PreferBloc.rule: PreferBloc.new,

--- a/packages/bloc_lint/lib/src/rules/avoid_missing_event_handlers.dart
+++ b/packages/bloc_lint/lib/src/rules/avoid_missing_event_handlers.dart
@@ -1,0 +1,292 @@
+import 'package:bloc_lint/bloc_lint.dart';
+
+/// {@template avoid_missing_event_handlers}
+/// The avoid_missing_event_handlers lint rule.
+/// {@endtemplate}
+class AvoidMissingEventHandlers extends LintRule {
+  /// {@macro avoid_missing_event_handlers}
+  AvoidMissingEventHandlers([Severity? severity])
+    : super(name: rule, severity: severity ?? Severity.warning);
+
+  /// The name of the lint rule.
+  static const rule = 'avoid_missing_event_handlers';
+
+  @override
+  Listener create(LintContext context) => _Listener(context);
+}
+
+class _DeclaredType {
+  _DeclaredType({
+    required this.name,
+    required this.parents,
+    required this.isAbstractOrSealed,
+    required this.isEnum,
+  });
+
+  final String name;
+  final List<String> parents;
+  final bool isAbstractOrSealed;
+  final bool isEnum;
+}
+
+class _BlocInfo {
+  _BlocInfo({
+    required this.token,
+    required this.eventType,
+    required this.isAbstract,
+  });
+
+  final Token token;
+  final String eventType;
+  final bool isAbstract;
+  final Set<String> handled = <String>{};
+}
+
+class _Listener extends Listener {
+  _Listener(this.context);
+
+  final LintContext context;
+
+  final Map<String, _DeclaredType> _types = {};
+  final List<_BlocInfo> _blocs = [];
+
+  _BlocInfo? _currentBloc;
+
+  @override
+  void beginClassDeclaration(
+    Token begin,
+    Token? abstractToken,
+    Token? sealedToken,
+    Token? baseToken,
+    Token? interfaceToken,
+    Token? finalToken,
+    Token? augmentToken,
+    Token? mixinToken,
+    Token name,
+  ) {
+    _currentBloc = null;
+
+    final isAbstractOrSealed =
+        abstractToken != null || sealedToken != null || mixinToken != null;
+    final parents = _supertypes(name);
+    _types[name.lexeme] = _DeclaredType(
+      name: name.lexeme,
+      parents: parents,
+      isAbstractOrSealed: isAbstractOrSealed,
+      isEnum: false,
+    );
+
+    final superclazz = _extendsName(name);
+    if (superclazz == null || !_isBloc(superclazz.lexeme)) return;
+
+    final eventType = _firstTypeArgument(superclazz);
+    if (eventType == null) return;
+
+    final bloc = _BlocInfo(
+      token: name,
+      eventType: eventType.lexeme,
+      isAbstract: abstractToken != null,
+    );
+    _blocs.add(bloc);
+    _currentBloc = bloc;
+  }
+
+  @override
+  void endClassDeclaration(Token beginToken, Token endToken) {
+    _currentBloc = null;
+  }
+
+  @override
+  void beginEnumDeclaration(
+    Token beginToken,
+    Token? augmentToken,
+    Token enumKeyword,
+    Token name,
+  ) {
+    _types[name.lexeme] = _DeclaredType(
+      name: name.lexeme,
+      parents: const [],
+      isAbstractOrSealed: false,
+      isEnum: true,
+    );
+  }
+
+  @override
+  void handleIdentifier(Token token, IdentifierContext _) {
+    final bloc = _currentBloc;
+    if (bloc == null) return;
+    if (token.lexeme != 'on') return;
+
+    final eventType = _firstTypeArgument(token);
+    if (eventType == null) return;
+    bloc.handled.add(eventType.lexeme);
+  }
+
+  @override
+  void endCompilationUnit(int count, Token token) {
+    for (final bloc in _blocs) {
+      if (bloc.isAbstract) continue;
+      if (bloc.handled.contains(bloc.eventType)) continue;
+
+      for (final event in _requiredEvents(bloc.eventType)) {
+        if (_isHandled(event.name, bloc)) continue;
+        context.reportToken(
+          token: bloc.token,
+          message: 'Missing event handler for ${event.name}.',
+          hint: 'Register a handler via on<${event.name}>.',
+        );
+      }
+    }
+  }
+
+  Iterable<_DeclaredType> _requiredEvents(String eventType) {
+    final descendants = _types.values.where(
+      (type) => type.name != eventType && _isDescendantOf(type.name, eventType),
+    );
+    final concreteDescendants = descendants.where(
+      (type) => !type.isAbstractOrSealed,
+    );
+
+    if (concreteDescendants.isNotEmpty) return concreteDescendants;
+
+    final declared = _types[eventType];
+    if (declared == null) return const [];
+    return [declared];
+  }
+
+  bool _isHandled(String eventName, _BlocInfo bloc) {
+    if (bloc.handled.contains(eventName)) return true;
+
+    final seen = <String>{};
+    final pending = <String>[eventName];
+    while (pending.isNotEmpty) {
+      final current = pending.removeLast();
+      if (!seen.add(current)) continue;
+      final type = _types[current];
+      if (type == null) continue;
+      for (final parent in type.parents) {
+        if (bloc.handled.contains(parent)) return true;
+        pending.add(parent);
+      }
+    }
+    return false;
+  }
+
+  bool _isDescendantOf(String name, String ancestor) {
+    final seen = <String>{};
+    final pending = <String>[name];
+    while (pending.isNotEmpty) {
+      final current = pending.removeLast();
+      if (!seen.add(current)) continue;
+      if (current == ancestor) return true;
+      final type = _types[current];
+      if (type == null) continue;
+      pending.addAll(type.parents);
+    }
+    return false;
+  }
+
+  bool _isBloc(String name) {
+    if (name.endsWith('MockBloc')) return false;
+    return name.endsWith('Bloc');
+  }
+
+  Token? _extendsName(Token name) {
+    var token = _afterTypeParameters(name);
+    while (token != null && !_isHeaderEnd(token)) {
+      if (token.kind == Keyword.EXTENDS.kind) {
+        return _typeName(token.next);
+      }
+      token = token.next;
+    }
+    return null;
+  }
+
+  List<String> _supertypes(Token name) {
+    final parents = <String>[];
+    var token = _afterTypeParameters(name);
+    var collecting = false;
+    while (token != null && !_isHeaderEnd(token)) {
+      if (token.kind == Keyword.EXTENDS.kind ||
+          token.kind == Keyword.IMPLEMENTS.kind) {
+        collecting = true;
+        token = token.next;
+        continue;
+      }
+      if (token.kind == Keyword.WITH.kind) {
+        collecting = false;
+        token = token.next;
+        continue;
+      }
+      if (!collecting) {
+        token = token.next;
+        continue;
+      }
+      if (token.type == TokenType.COMMA) {
+        token = token.next;
+        continue;
+      }
+      if (token.type == TokenType.LT) {
+        token = _skipTypeArguments(token);
+        continue;
+      }
+      final type = _typeName(token);
+      if (type != null) {
+        parents.add(type.lexeme);
+        token = type.next;
+        continue;
+      }
+      token = token.next;
+    }
+    return parents;
+  }
+
+  Token? _firstTypeArgument(Token typeName) {
+    final lt = typeName.next;
+    if (lt == null || lt.type != TokenType.LT) return null;
+    return _typeName(lt.next);
+  }
+
+  Token? _typeName(Token? token) {
+    if (token == null || !token.isIdentifier) return null;
+    if (token.next?.type == TokenType.PERIOD) {
+      final name = token.next?.next;
+      if (name != null && name.isIdentifier) return name;
+    }
+    return token;
+  }
+
+  Token? _afterTypeParameters(Token name) {
+    final next = name.next;
+    if (next != null && next.type == TokenType.LT) {
+      return _skipTypeArguments(next);
+    }
+    return next;
+  }
+
+  Token? _skipTypeArguments(Token lt) {
+    var depth = 0;
+    Token? token = lt;
+    while (token != null) {
+      final lexeme = token.lexeme;
+      if (lexeme == '<') {
+        depth++;
+      } else if (lexeme == '>') {
+        depth--;
+        if (depth <= 0) return token.next;
+      } else if (lexeme == '>>') {
+        depth -= 2;
+        if (depth <= 0) return token.next;
+      } else if (lexeme == '>>>') {
+        depth -= 3;
+        if (depth <= 0) return token.next;
+      }
+      token = token.next;
+    }
+    return token;
+  }
+
+  bool _isHeaderEnd(Token token) {
+    return token.lexeme == '{' || token.type == TokenType.SEMICOLON;
+  }
+}

--- a/packages/bloc_lint/lib/src/rules/rules.dart
+++ b/packages/bloc_lint/lib/src/rules/rules.dart
@@ -1,5 +1,6 @@
 export 'avoid_build_context_extensions.dart';
 export 'avoid_flutter_imports.dart';
+export 'avoid_missing_event_handlers.dart';
 export 'avoid_public_bloc_methods.dart';
 export 'avoid_public_fields.dart';
 export 'prefer_bloc.dart';

--- a/packages/bloc_lint/pubspec.yaml
+++ b/packages/bloc_lint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bloc_lint
 description: Official lint rules for development when using the bloc state management library.
-version: 0.4.2
+version: 0.4.3
 repository: https://github.com/felangel/bloc/tree/master/packages/bloc_lint
 issue_tracker: https://github.com/felangel/bloc/issues
 homepage: https://github.com/felangel/bloc

--- a/packages/bloc_lint/test/src/rules/avoid_missing_event_handlers_test.dart
+++ b/packages/bloc_lint/test/src/rules/avoid_missing_event_handlers_test.dart
@@ -1,0 +1,229 @@
+import 'package:bloc_lint/src/rules/rules.dart';
+import 'package:test/test.dart';
+
+import '../lint_test_helper.dart';
+
+void main() {
+  group(AvoidMissingEventHandlers, () {
+    lintTest(
+      'lints when a sealed event subclass has no handler',
+      rule: AvoidMissingEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+sealed class CounterEvent {}
+final class Increment extends CounterEvent {}
+final class Decrement extends CounterEvent {}
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+      ^^^^^^^^^^^
+  CounterBloc() : super(0) {
+    on<Increment>((event, emit) => emit(state + 1));
+  }
+}
+''',
+    );
+
+    lintTest(
+      'lints when an enum event has no handler',
+      rule: AvoidMissingEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+enum CounterEvent { increment, decrement }
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+      ^^^^^^^^^^^
+  CounterBloc() : super(0);
+}
+''',
+    );
+
+    lintTest(
+      'lints when a concrete event class has no handler',
+      rule: AvoidMissingEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+class CounterEvent {}
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+      ^^^^^^^^^^^
+  CounterBloc() : super(0);
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when every subclass has a handler',
+      rule: AvoidMissingEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+sealed class CounterEvent {}
+final class Increment extends CounterEvent {}
+final class Decrement extends CounterEvent {}
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0) {
+    on<Increment>((event, emit) => emit(state + 1));
+    on<Decrement>((event, emit) => emit(state - 1));
+  }
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when the event superclass is handled',
+      rule: AvoidMissingEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+sealed class CounterEvent {}
+final class Increment extends CounterEvent {}
+final class Decrement extends CounterEvent {}
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0) {
+    on<CounterEvent>((event, emit) {});
+  }
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when an enum event is handled',
+      rule: AvoidMissingEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+enum CounterEvent { increment, decrement }
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0) {
+    on<CounterEvent>((event, emit) {});
+  }
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when an ancestor handler covers a subclass',
+      rule: AvoidMissingEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+sealed class CounterEvent {}
+sealed class CounterWriteEvent extends CounterEvent {}
+final class Increment extends CounterWriteEvent {}
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0) {
+    on<CounterWriteEvent>((event, emit) {});
+  }
+}
+''',
+    );
+
+    lintTest(
+      'does not lint cubits',
+      rule: AvoidMissingEventHandlers.new,
+      path: 'counter_cubit.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+class CounterCubit extends Cubit<int> {
+  CounterCubit() : super(0);
+}
+''',
+    );
+
+    lintTest(
+      'does not lint mock blocs',
+      rule: AvoidMissingEventHandlers.new,
+      path: 'app_test.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+import 'package:bloc_test/bloc_test.dart';
+
+enum CounterEvent { increment }
+
+class _MockCounterBloc extends MockBloc<CounterEvent, int> {}
+''',
+    );
+
+    lintTest(
+      'does not lint abstract blocs',
+      rule: AvoidMissingEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+enum CounterEvent { increment }
+
+abstract class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0);
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when the event type is not declared in the same file',
+      rule: AvoidMissingEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0) {
+    on<Increment>((event, emit) => emit(state + 1));
+  }
+}
+''',
+    );
+
+    lintTest(
+      'lints hydrated blocs with missing handlers',
+      rule: AvoidMissingEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+
+enum CounterEvent { increment }
+
+class CounterBloc extends HydratedBloc<CounterEvent, int> {
+      ^^^^^^^^^^^
+  CounterBloc() : super(0);
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when handlers are registered outside the constructor',
+      rule: AvoidMissingEventHandlers.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+enum CounterEvent { increment }
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0) {
+    _registerHandlers();
+  }
+
+  void _registerHandlers() {
+    on<CounterEvent>((event, emit) {});
+  }
+}
+''',
+    );
+  });
+}


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

Adds `avoid_missing_event_handlers`. It warns when a Bloc's event type, or a concrete subclass declared in the same file, has no `on<Event>` handler.

`bloc_lint` doesn't have type resolution, so this stays same-file and uses the same name heuristic as the other rules. `on<EventSuperclass>` still covers every subclass.

Closes #4461

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
