### PR TITLE
fix(bloc_lint): reset the `@override` flag between class members

### DIFF
--- a/packages/bloc_lint/lib/src/rules/avoid_public_bloc_methods.dart
+++ b/packages/bloc_lint/lib/src/rules/avoid_public_bloc_methods.dart
@@ -38,8 +38,13 @@ class _Listener extends Listener {
   var _isOverride = false;
 
   @override
+  void beginMetadataStar(Token token) {
+    _isOverride = false;
+  }
+
+  @override
   void beginMetadata(Token token) {
-    _isOverride = token.next?.lexeme == 'override';
+    if (token.next?.lexeme == 'override') _isOverride = true;
   }
 
   @override

--- a/packages/bloc_lint/lib/src/rules/prefer_void_public_cubit_methods.dart
+++ b/packages/bloc_lint/lib/src/rules/prefer_void_public_cubit_methods.dart
@@ -25,8 +25,13 @@ class _Listener extends Listener {
   static const allowedReturnTypes = ['void', 'Future<void>', 'FutureOr<void>'];
 
   @override
+  void beginMetadataStar(Token token) {
+    _isOverride = false;
+  }
+
+  @override
   void beginMetadata(Token token) {
-    _isOverride = token.next?.lexeme == 'override';
+    if (token.next?.lexeme == 'override') _isOverride = true;
   }
 
   @override

--- a/packages/bloc_lint/test/src/rules/avoid_public_bloc_methods_test.dart
+++ b/packages/bloc_lint/test/src/rules/avoid_public_bloc_methods_test.dart
@@ -118,5 +118,24 @@ class CounterBloc extends Bloc<CounterEvent, int> {
 }
 ''',
     );
+
+    lintTest(
+      'lints when a public method follows an @override method',
+      rule: AvoidPublicBlocMethods.new,
+      path: 'counter_bloc.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+class CounterBloc extends Bloc<CounterEvent, int> {
+  CounterBloc() : super(0);
+
+  @override
+  Future<void> close() => super.close();
+
+  void increment() {}
+       ^^^^^^^^^
+}
+''',
+    );
   });
 }

--- a/packages/bloc_lint/test/src/rules/prefer_void_public_cubit_methods_test.dart
+++ b/packages/bloc_lint/test/src/rules/prefer_void_public_cubit_methods_test.dart
@@ -297,5 +297,42 @@ class ToggleCubit extends Cubit<bool> {
 }
 ''',
     );
+
+    lintTest(
+      'lints when a non-void public method follows an @override method',
+      rule: PreferVoidPublicCubitMethods.new,
+      path: 'counter_cubit.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+
+class CounterCubit extends Cubit<int> {
+  CounterCubit() : super(0);
+
+  @override
+  void emit(int state) => super.emit(state);
+
+  Future<bool> increment() async => true;
+               ^^^^^^^^^
+}
+''',
+    );
+
+    lintTest(
+      'does not lint an @override method annotated more than once',
+      rule: PreferVoidPublicCubitMethods.new,
+      path: 'counter_cubit.dart',
+      content: '''
+import 'package:bloc/bloc.dart';
+import 'package:meta/meta.dart';
+
+class CounterCubit extends Cubit<int> {
+  CounterCubit() : super(0);
+
+  @override
+  @visibleForTesting
+  Future<bool> isReady() async => true;
+}
+''',
+    );
   });
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

<!--- Describe your changes in detail -->
- fix(bloc_lint): reset the `@override` flag between class members (closes #4863)

`avoid_public_bloc_methods` and `prefer_void_public_cubit_methods` each keep an `_isOverride` flag that was only ever written from `beginMetadata`, which fires only for declarations that have an annotation. The flag was therefore never cleared, so an `@override` on one member exempted every member after it, and a member annotated with `@override` plus anything else was reported despite the exemption.

`beginMetadataStar` fires for every member before its metadata is read, so it is the point at which the flag can be cleared. `beginMember` is not usable for this, since it runs after the metadata and clearing there would drop a legitimate `@override`.

Both rules now clear the flag on `beginMetadataStar` and accumulate in `beginMetadata` instead of assigning, which fixes the false negative and the false positive respectively.

Three regression tests are included, one per defect plus the `avoid_public_bloc_methods` case. Each fails without the change and passes with it. The suite goes from 151 to 154 tests, and `bloc_lint` stays at 100% coverage.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
