### PR TITLE
feat(bloc_lint): add avoid_returning_existing_instance_from_bloc_provider_create

### DIFF
--- a/docs/src/components/lint-rules/avoid_returning_existing_instance_from_bloc_provider_create/BadSnippet.mdx
+++ b/docs/src/components/lint-rules/avoid_returning_existing_instance_from_bloc_provider_create/BadSnippet.mdx
@@ -1,0 +1,27 @@
+import { Code } from '@astrojs/starlight/components';
+import { transformerMetaHighlight } from '@shikijs/transformers';
+
+<Code
+	code={`
+  import 'package:flutter/material.dart';
+  import 'package:flutter_bloc/flutter_bloc.dart';
+
+  class CounterPage extends StatelessWidget {
+    const CounterPage({required this.bloc, super.key});
+
+    final CounterBloc bloc;
+
+    @override
+    Widget build(BuildContext context) {
+      return BlocProvider(
+        // Avoid returning an existing instance!
+        // The instance will be closed when the provider is removed.
+        create: (_) => bloc,
+        child: const CounterView(),
+      );
+    }
+  }
+`}
+lang="dart" title="counter_page.dart"
+transformers={[transformerMetaHighlight()]} class='warning' meta="{14}"
+/>

--- a/docs/src/components/lint-rules/avoid_returning_existing_instance_from_bloc_provider_create/GoodSnippet.astro
+++ b/docs/src/components/lint-rules/avoid_returning_existing_instance_from_bloc_provider_create/GoodSnippet.astro
@@ -1,0 +1,24 @@
+---
+import { Code } from '@astrojs/starlight/components';
+
+const code = `
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class CounterPage extends StatelessWidget {
+  const CounterPage({required this.bloc, super.key});
+
+  final CounterBloc bloc;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider.value(
+      value: bloc,
+      child: const CounterView(),
+    );
+  }
+}
+`;
+---
+
+<Code code={code} lang="dart" title="counter_page.dart" />

--- a/docs/src/content/docs/lint-rules/avoid_returning_existing_instance_from_bloc_provider_create.mdx
+++ b/docs/src/content/docs/lint-rules/avoid_returning_existing_instance_from_bloc_provider_create.mdx
@@ -1,0 +1,55 @@
+---
+title: Avoid Returning Existing Instance From BlocProvider Create
+description:
+  The avoid_returning_existing_instance_from_bloc_provider_create rule.
+---
+
+import { Badge } from '@astrojs/starlight/components';
+import EnableRuleSnippet from '~/components/lint-rules/EnableRuleSnippet.astro';
+import BadSnippet from '~/components/lint-rules/avoid_returning_existing_instance_from_bloc_provider_create/BadSnippet.mdx';
+import GoodSnippet from '~/components/lint-rules/avoid_returning_existing_instance_from_bloc_provider_create/GoodSnippet.astro';
+
+<div class="badges">
+	<Badge text="new" />
+	<Badge text="dart" variant="note" />
+</div>
+
+Avoid returning an existing `Bloc` or `Cubit` instance from the `create`
+callback of a `BlocProvider`.
+
+:::note
+
+This lint rule was introduced in version `0.4.3` of
+[`package:bloc_lint`](https://pub.dev/packages/bloc_lint)
+
+:::
+
+## Rationale
+
+`BlocProvider` owns whatever the `create` callback returns and closes it when
+the provider is removed from the widget tree. Returning an instance that was
+created somewhere else hands ownership to the provider, so the instance can be
+closed while another part of the app is still using it.
+
+Use the default `BlocProvider` constructor to create a new instance and use
+`BlocProvider.value` to provide an instance that already exists. An instance
+provided via `BlocProvider.value` is never closed by the provider.
+
+## Examples
+
+**Avoid** returning an instance that already exists from `create`.
+
+**BAD**:
+
+<BadSnippet />
+
+**GOOD**:
+
+<GoodSnippet />
+
+## Enable
+
+To enable the `avoid_returning_existing_instance_from_bloc_provider_create`
+rule, add it to your `analysis_options.yaml` under `bloc` > `rules`:
+
+<EnableRuleSnippet name="avoid_returning_existing_instance_from_bloc_provider_create" />

--- a/packages/bloc_lint/README.md
+++ b/packages/bloc_lint/README.md
@@ -100,6 +100,7 @@ For more information, check out the [official documentation](https://bloclibrary
 - [avoid_flutter_imports](https://bloclibrary.dev/lint-rules/avoid_flutter_imports)
 - [avoid_public_bloc_methods](https://bloclibrary.dev/lint-rules/avoid_public_bloc_methods)
 - [avoid_public_fields](https://bloclibrary.dev/lint-rules/avoid_public_fields)
+- [avoid_returning_existing_instance_from_bloc_provider_create](https://bloclibrary.dev/lint-rules/avoid_returning_existing_instance_from_bloc_provider_create)
 - [prefer_bloc](https://bloclibrary.dev/lint-rules/prefer_bloc)
 - [prefer_build_context_extensions](https://bloclibrary.dev/lint-rules/prefer_build_context_extensions)
 - [prefer_cubit](https://bloclibrary.dev/lint-rules/prefer_cubit)

--- a/packages/bloc_lint/lib/all.yaml
+++ b/packages/bloc_lint/lib/all.yaml
@@ -4,6 +4,7 @@ bloc:
     - avoid_flutter_imports
     - avoid_public_bloc_methods
     - avoid_public_fields
+    - avoid_returning_existing_instance_from_bloc_provider_create
     - prefer_bloc
     - prefer_build_context_extensions
     - prefer_cubit

--- a/packages/bloc_lint/lib/bloc_lint.dart
+++ b/packages/bloc_lint/lib/bloc_lint.dart
@@ -12,6 +12,7 @@ export 'src/rules/rules.dart'
         AvoidFlutterImports,
         AvoidPublicBlocMethods,
         AvoidPublicFields,
+        AvoidReturningExistingInstanceFromBlocProviderCreate,
         PreferBloc,
         PreferBuildContextExtensions,
         PreferCubit,

--- a/packages/bloc_lint/lib/src/linter.dart
+++ b/packages/bloc_lint/lib/src/linter.dart
@@ -25,6 +25,8 @@ final allRules = <String, LintRuleBuilder>{
   AvoidFlutterImports.rule: AvoidFlutterImports.new,
   AvoidPublicBlocMethods.rule: AvoidPublicBlocMethods.new,
   AvoidPublicFields.rule: AvoidPublicFields.new,
+  AvoidReturningExistingInstanceFromBlocProviderCreate.rule:
+      AvoidReturningExistingInstanceFromBlocProviderCreate.new,
   PreferBloc.rule: PreferBloc.new,
   PreferBuildContextExtensions.rule: PreferBuildContextExtensions.new,
   PreferCubit.rule: PreferCubit.new,

--- a/packages/bloc_lint/lib/src/rules/avoid_returning_existing_instance_from_bloc_provider_create.dart
+++ b/packages/bloc_lint/lib/src/rules/avoid_returning_existing_instance_from_bloc_provider_create.dart
@@ -1,0 +1,177 @@
+import 'package:bloc_lint/bloc_lint.dart';
+
+/// {@template avoid_returning_existing_instance_from_bloc_provider_create}
+/// The avoid_returning_existing_instance_from_bloc_provider_create lint rule.
+/// {@endtemplate}
+class AvoidReturningExistingInstanceFromBlocProviderCreate extends LintRule {
+  /// {@macro avoid_returning_existing_instance_from_bloc_provider_create}
+  AvoidReturningExistingInstanceFromBlocProviderCreate([Severity? severity])
+    : super(name: rule, severity: severity ?? Severity.warning);
+
+  /// The name of the lint rule.
+  static const rule =
+      'avoid_returning_existing_instance_from_bloc_provider_create';
+
+  @override
+  Listener create(LintContext context) => _Listener(context);
+}
+
+class _Listener extends Listener {
+  _Listener(this.context);
+
+  final LintContext context;
+
+  static const _message =
+      'Avoid returning an existing instance from BlocProvider create.';
+
+  static const _hint = '''
+Prefer creating a new instance within create.
+Use BlocProvider.value to provide an existing instance.''';
+
+  // Tokens which can make up a reference to an existing instance such as
+  // `bloc`, `_bloc`, `this.bloc`, `widget.bloc` and `widget.bloc!`.
+  static const _referenceTokenTypes = <TokenType>{
+    TokenType.IDENTIFIER,
+    TokenType.PERIOD,
+    TokenType.QUESTION_PERIOD,
+    TokenType.BANG,
+    Keyword.THIS,
+  };
+
+  // Methods which look up an existing instance from the widget tree.
+  static const _lookupMethods = <String>{'read', 'watch'};
+
+  @override
+  void handleIdentifier(Token token, IdentifierContext _) {
+    if (token.lexeme != 'BlocProvider') return;
+
+    final openParen = _argumentList(token);
+    if (openParen == null) return;
+
+    // Look for a top level `create` argument within the argument list.
+    final closeParen = openParen.endGroup;
+    var current = openParen.next;
+    while (current != null && current != closeParen) {
+      final group = current.endGroup;
+      if (group != null) {
+        current = group.next;
+        continue;
+      }
+      final next = current.next;
+      if (current.lexeme == 'create' && next?.type == TokenType.COLON) {
+        return _visitCreate(next?.next);
+      }
+      current = next;
+    }
+  }
+
+  /// Returns the `(` of the argument list when [token] is the beginning of a
+  /// `BlocProvider(...)` or `BlocProvider<T>(...)` invocation.
+  Token? _argumentList(Token token) {
+    var next = token.next;
+    if (next?.type == TokenType.LT) next = next?.endGroup?.next ?? next;
+    if (next?.type != TokenType.OPEN_PAREN) return null;
+    return next;
+  }
+
+  /// Visits the value of the `create` argument which begins at [token].
+  /// Only function literals are visited since a tear-off does not reveal
+  /// what will be returned.
+  void _visitCreate(Token? token) {
+    if (token?.type != TokenType.OPEN_PAREN) return;
+    final parameters = token?.endGroup;
+    final body = parameters?.next;
+    // The name of the `BuildContext` parameter, if there is one.
+    final parameter = parameters?.previous?.lexeme;
+    if (body?.type == TokenType.FUNCTION) {
+      return _visitReturnValue(body?.next, parameter);
+    }
+    if (body?.type == TokenType.OPEN_CURLY_BRACKET) {
+      return _visitBlock(body!, parameter);
+    }
+  }
+
+  /// Visits every top level `return` within the block beginning at [token].
+  void _visitBlock(Token token, String? parameter) {
+    final closeCurly = token.endGroup;
+    var current = token.next;
+    while (current != null && current != closeCurly) {
+      final group = current.endGroup;
+      if (group != null) {
+        current = group.next;
+        continue;
+      }
+      if (current.type == Keyword.RETURN) {
+        _visitReturnValue(current.next, parameter);
+      }
+      current = current.next;
+    }
+  }
+
+  /// Reports the expression beginning at [token] when it resolves to an
+  /// instance which already exists.
+  void _visitReturnValue(Token? token, String? parameter) {
+    if (token == null) return;
+    final end = _expressionEnd(token);
+    final isExisting =
+        _isReference(token, end) || _isLookup(token, end, parameter);
+    if (!isExisting) return;
+    context.reportTokenRange(
+      beginToken: token,
+      endToken: end,
+      message: _message,
+      hint: _hint,
+    );
+  }
+
+  /// Returns the last token of the expression beginning at [token].
+  Token _expressionEnd(Token token) {
+    var current = token;
+    while (true) {
+      current = current.endGroup ?? current;
+      final next = current.next;
+      if (next == null ||
+          next.type == TokenType.COMMA ||
+          next.type == TokenType.CLOSE_PAREN ||
+          next.type == TokenType.SEMICOLON) {
+        return current;
+      }
+      current = next;
+    }
+  }
+
+  /// Whether the expression from [begin] to [end] is only a reference to an
+  /// instance which already exists (e.g. `bloc` or `widget.bloc`).
+  bool _isReference(Token begin, Token end) {
+    var current = begin;
+    while (_referenceTokenTypes.contains(current.type)) {
+      if (current == end) return true;
+      current = current.next!;
+    }
+    return false;
+  }
+
+  /// Whether the expression from [begin] to [end] looks up an instance which
+  /// already exists such as `context.read<T>()` or
+  /// `BlocProvider.of<T>(context)`.
+  bool _isLookup(Token begin, Token end, String? parameter) {
+    if (begin.type != TokenType.IDENTIFIER) return false;
+    final period = begin.next;
+    if (period?.type != TokenType.PERIOD) return false;
+
+    final method = period?.next;
+    if (method == null) return false;
+
+    final target = begin.lexeme;
+    final isExtension =
+        (target == 'context' || target == parameter) &&
+        _lookupMethods.contains(method.lexeme);
+    final isProviderOf = target == 'BlocProvider' && method.lexeme == 'of';
+    if (!isExtension && !isProviderOf) return false;
+
+    var next = method.next;
+    if (next?.type == TokenType.LT) next = next?.endGroup?.next ?? next;
+    if (next?.type != TokenType.OPEN_PAREN) return false;
+    return next?.endGroup == end;
+  }
+}

--- a/packages/bloc_lint/lib/src/rules/rules.dart
+++ b/packages/bloc_lint/lib/src/rules/rules.dart
@@ -2,6 +2,7 @@ export 'avoid_build_context_extensions.dart';
 export 'avoid_flutter_imports.dart';
 export 'avoid_public_bloc_methods.dart';
 export 'avoid_public_fields.dart';
+export 'avoid_returning_existing_instance_from_bloc_provider_create.dart';
 export 'prefer_bloc.dart';
 export 'prefer_build_context_extensions.dart';
 export 'prefer_cubit.dart';

--- a/packages/bloc_lint/test/src/rules/avoid_returning_existing_instance_from_bloc_provider_create_test.dart
+++ b/packages/bloc_lint/test/src/rules/avoid_returning_existing_instance_from_bloc_provider_create_test.dart
@@ -1,0 +1,445 @@
+import 'package:bloc_lint/src/rules/rules.dart';
+import 'package:test/test.dart';
+
+import '../lint_test_helper.dart';
+
+void main() {
+  group(AvoidReturningExistingInstanceFromBlocProviderCreate, () {
+    lintTest(
+      'lints when returning an existing instance',
+      rule: AvoidReturningExistingInstanceFromBlocProviderCreate.new,
+      path: 'counter_page.dart',
+      content: '''
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class CounterPage extends StatefulWidget {
+  const CounterPage({super.key});
+
+  @override
+  State<CounterPage> createState() => _CounterPageState();
+}
+
+class _CounterPageState extends State<CounterPage> {
+  final bloc = CounterBloc();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => bloc,
+                     ^^^^
+      child: const CounterView(),
+    );
+  }
+}
+''',
+    );
+
+    lintTest(
+      'lints when returning an existing instance from the widget',
+      rule: AvoidReturningExistingInstanceFromBlocProviderCreate.new,
+      path: 'counter_page.dart',
+      content: '''
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class CounterPage extends StatefulWidget {
+  const CounterPage({required this.bloc, super.key});
+
+  final CounterBloc bloc;
+
+  @override
+  State<CounterPage> createState() => _CounterPageState();
+}
+
+class _CounterPageState extends State<CounterPage> {
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => widget.bloc,
+                     ^^^^^^^^^^^
+      child: const CounterView(),
+    );
+  }
+}
+''',
+    );
+
+    lintTest(
+      'lints when returning an existing instance without a trailing comma',
+      rule: AvoidReturningExistingInstanceFromBlocProviderCreate.new,
+      path: 'counter_page.dart',
+      content: '''
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class CounterPage extends StatelessWidget {
+  const CounterPage({required this.bloc, super.key});
+
+  final CounterBloc bloc;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(create: (_) => bloc);
+                                       ^^^^
+  }
+}
+''',
+    );
+
+    lintTest(
+      'lints when returning an existing instance from a generic BlocProvider',
+      rule: AvoidReturningExistingInstanceFromBlocProviderCreate.new,
+      path: 'counter_page.dart',
+      content: '''
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class CounterPage extends StatelessWidget {
+  const CounterPage({required this.bloc, super.key});
+
+  final CounterBloc bloc;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider<CounterBloc>(
+      create: (_) => bloc,
+                     ^^^^
+      child: const CounterView(),
+    );
+  }
+}
+''',
+    );
+
+    lintTest(
+      'lints when create is preceded by other arguments',
+      rule: AvoidReturningExistingInstanceFromBlocProviderCreate.new,
+      path: 'counter_page.dart',
+      content: '''
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class CounterPage extends StatelessWidget {
+  const CounterPage({required this.bloc, super.key});
+
+  final CounterBloc bloc;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      key: const Key('counter'),
+      create: (_) => bloc,
+                     ^^^^
+      child: const CounterView(),
+    );
+  }
+}
+''',
+    );
+
+    lintTest(
+      'lints when returning the result of context.read',
+      rule: AvoidReturningExistingInstanceFromBlocProviderCreate.new,
+      path: 'counter_page.dart',
+      content: '''
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class CounterPage extends StatelessWidget {
+  const CounterPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => context.read<CounterBloc>(),
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      child: const CounterView(),
+    );
+  }
+}
+''',
+    );
+
+    lintTest(
+      'lints when returning the result of watch on the create parameter',
+      rule: AvoidReturningExistingInstanceFromBlocProviderCreate.new,
+      path: 'counter_page.dart',
+      content: '''
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class CounterPage extends StatelessWidget {
+  const CounterPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (ctx) => ctx.watch<CounterBloc>(),
+                       ^^^^^^^^^^^^^^^^^^^^^^^^
+      child: const CounterView(),
+    );
+  }
+}
+''',
+    );
+
+    lintTest(
+      'lints when returning the result of BlocProvider.of',
+      rule: AvoidReturningExistingInstanceFromBlocProviderCreate.new,
+      path: 'counter_page.dart',
+      content: '''
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class CounterPage extends StatelessWidget {
+  const CounterPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => BlocProvider.of<CounterBloc>(context),
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      child: const CounterView(),
+    );
+  }
+}
+''',
+    );
+
+    lintTest(
+      'lints when returning an existing instance from a block body',
+      rule: AvoidReturningExistingInstanceFromBlocProviderCreate.new,
+      path: 'counter_page.dart',
+      content: '''
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class CounterPage extends StatelessWidget {
+  const CounterPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) {
+        final bloc = context.read<CounterBloc>();
+        return bloc;
+               ^^^^
+      },
+      child: const CounterView(),
+    );
+  }
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when creating a new instance',
+      rule: AvoidReturningExistingInstanceFromBlocProviderCreate.new,
+      path: 'counter_page.dart',
+      content: '''
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class CounterPage extends StatelessWidget {
+  const CounterPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => CounterBloc(),
+      child: const CounterView(),
+    );
+  }
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when creating a new const instance',
+      rule: AvoidReturningExistingInstanceFromBlocProviderCreate.new,
+      path: 'counter_page.dart',
+      content: '''
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class CounterPage extends StatelessWidget {
+  const CounterPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => const CounterBloc(),
+      child: const CounterView(),
+    );
+  }
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when using a named constructor',
+      rule: AvoidReturningExistingInstanceFromBlocProviderCreate.new,
+      path: 'counter_page.dart',
+      content: '''
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class CounterPage extends StatelessWidget {
+  const CounterPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => CounterBloc.initial(),
+      child: const CounterView(),
+    );
+  }
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when calling a factory function',
+      rule: AvoidReturningExistingInstanceFromBlocProviderCreate.new,
+      path: 'counter_page.dart',
+      content: '''
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+CounterBloc createCounterBloc() => CounterBloc();
+
+class CounterPage extends StatelessWidget {
+  const CounterPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => createCounterBloc(),
+      child: const CounterView(),
+    );
+  }
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when resolving via a service locator',
+      rule: AvoidReturningExistingInstanceFromBlocProviderCreate.new,
+      path: 'counter_page.dart',
+      content: '''
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class CounterPage extends StatelessWidget {
+  const CounterPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => getIt<CounterBloc>(),
+      child: const CounterView(),
+    );
+  }
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when creating a new instance in a block body',
+      rule: AvoidReturningExistingInstanceFromBlocProviderCreate.new,
+      path: 'counter_page.dart',
+      content: '''
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class CounterPage extends StatelessWidget {
+  const CounterPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) {
+        final repository = context.read<CounterRepository>();
+        return CounterBloc(repository: repository);
+      },
+      child: const CounterView(),
+    );
+  }
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when create is a tear-off',
+      rule: AvoidReturningExistingInstanceFromBlocProviderCreate.new,
+      path: 'counter_page.dart',
+      content: '''
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+CounterBloc createCounterBloc(BuildContext context) => CounterBloc();
+
+class CounterPage extends StatelessWidget {
+  const CounterPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: createCounterBloc,
+      child: const CounterView(),
+    );
+  }
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when using BlocProvider.value',
+      rule: AvoidReturningExistingInstanceFromBlocProviderCreate.new,
+      path: 'counter_page.dart',
+      content: '''
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class CounterPage extends StatelessWidget {
+  const CounterPage({required this.bloc, super.key});
+
+  final CounterBloc bloc;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider.value(
+      value: bloc,
+      child: const CounterView(),
+    );
+  }
+}
+''',
+    );
+
+    lintTest(
+      'does not lint when the provider is not a BlocProvider',
+      rule: AvoidReturningExistingInstanceFromBlocProviderCreate.new,
+      path: 'counter_page.dart',
+      content: '''
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class CounterPage extends StatelessWidget {
+  const CounterPage({required this.repository, super.key});
+
+  final CounterRepository repository;
+
+  @override
+  Widget build(BuildContext context) {
+    return RepositoryProvider(
+      create: (_) => repository,
+      child: const CounterView(),
+    );
+  }
+}
+''',
+    );
+  });
+}


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

NO

## Description

Adds the `avoid_returning_existing_instance_from_bloc_provider_create` lint rule requested in #4462. It warns when a `BlocProvider`'s `create` callback returns an instance that already exists, which matters because the default constructor makes the provider the owner and closes what `create` returned when it leaves the tree.

Fixes #4462

It looks at `BlocProvider(...)` and `BlocProvider<T>(...)`, at a top-level `create` argument whose value is a function literal, checking the arrow body and every top-level `return` in a block body. An expression counts as existing when it is a plain reference with no invocation (`bloc`, `_bloc`, `this.bloc`, `widget.bloc`, `widget.bloc!`), or a lookup that can only hand back something already built: `context.read<T>()` / `context.watch<T>()` where the receiver is `context` or the `create` parameter's name, and `BlocProvider.of<T>(context)`.

The obvious alternative, reporting anything that is not a constructor invocation, misfires because `bloc_lint` runs on the parser without type information. `create: (_) => createCounterBloc()`, `create: (_) => getIt<CounterBloc>()` from a locator registered as a factory, and `create: (_) => CounterBloc.initial()` all return fresh instances and cannot be told apart from a cached one by tokens alone. So the rule reports only shapes that cannot construct anything, and stays quiet on shapes that might.

Two consequences. A getter that constructs on every read is still reported, which seems acceptable since a reader cannot tell what that line does at the call site either. And a cascade such as `create: (_) => bloc..add(Increment())` is not reported today, a miss I would rather add later than guess at now.

Registered in `allRules`, exported from `bloc_lint.dart` and `rules.dart`, added to `all.yaml`, listed in the README, and documented under `docs/src/content/docs/lint-rules`. I left it out of `recommended.yaml` since that set is your call.

18 `lintTest` cases, 9 linting and 9 not. Linted: field reference, `widget.bloc`, no trailing comma, generic `BlocProvider<T>`, `create` preceded by other arguments, `context.read`, `watch` on a renamed callback parameter, `BlocProvider.of`, and a block body with a `return`. Not linted: inline construction, `const` constructor, named constructor, factory function, service locator, block body returning a new instance, `create` tear-off, `BlocProvider.value`, and a `RepositoryProvider`.

`dart test` passes at 169 tests in `packages/bloc_lint`. `format_coverage` reports 100.0% line coverage, 639/639, including 65/65 in the new rule file. `dart format .` reports nothing; `dart analyze --fatal-infos --fatal-warnings .` is clean apart from two unrecognized-lint-name warnings in the shared `analysis_options.yaml` that also appear on master with my local SDK. The docs site builds and `npm run format:check` passes.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
